### PR TITLE
[vincentlaucsb-csv-parser] Update to 2.5.2

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,18 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f0b137a..3ff9de7 100644
+index a14387c..3db06b2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,5 +1,9 @@
+@@ -1,5 +1,8 @@
  cmake_minimum_required(VERSION 3.10)
  project(csv)
 +include(GNUInstallDirs)
 +
 +find_package(mio CONFIG REQUIRED)
-+find_package(string-view-lite CONFIG REQUIRED)
  
  if(CSV_CXX_STANDARD)
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
-@@ -46,10 +50,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
+@@ -49,10 +52,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  
  include_directories(${CSV_INCLUDE_DIR})
  
@@ -24,7 +23,7 @@ index f0b137a..3ff9de7 100644
  
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
-@@ -66,6 +67,23 @@ if (CSV_BUILD_PROGRAMS)
+@@ -69,6 +69,23 @@ if (CSV_BUILD_PROGRAMS)
      add_subdirectory("programs")
  endif()
  
@@ -49,7 +48,7 @@ index f0b137a..3ff9de7 100644
  if (CSV_DEVELOPER)
      # Allow for performance profiling
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index 7da751c..9c80176 100644
+index 7da751c..855804f 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
 @@ -26,6 +26,8 @@ target_sources(csv
@@ -63,4 +62,4 @@ index 7da751c..9c80176 100644
 +target_include_directories(csv
 +	INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vincentlaucsb-csv-parser>
 +)
-+target_link_libraries(csv PRIVATE Threads::Threads PUBLIC mio::mio mio::mio-headers nonstd::string-view-lite)
++target_link_libraries(csv PRIVATE Threads::Threads PUBLIC mio::mio mio::mio-headers)

--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -1,5 +1,5 @@
 diff --git a/include/internal/basic_csv_parser.hpp b/include/internal/basic_csv_parser.hpp
-index 16c8666..7b4221e 100644
+index 6e1efb0..fac6ebf 100644
 --- a/include/internal/basic_csv_parser.hpp
 +++ b/include/internal/basic_csv_parser.hpp
 @@ -12,7 +12,7 @@
@@ -12,20 +12,32 @@ index 16c8666..7b4221e 100644
  #include "common.hpp"
  #include "csv_format.hpp"
 diff --git a/include/internal/common.hpp b/include/internal/common.hpp
-index 7f8d737..f0ead1a 100644
+index f7668d8..dc42f63 100644
 --- a/include/internal/common.hpp
 +++ b/include/internal/common.hpp
-@@ -92,7 +92,7 @@ namespace csv {
-       */
-     using string_view = std::string_view;
- #else
+@@ -86,10 +86,8 @@
+ #endif
+ 
+ // Include string_view BEFORE csv namespace to avoid namespace pollution issues
+-#ifdef CSV_HAS_CXX17
++#if 1
+ #include <string_view>
+-#else
 -#include "../external/string_view.hpp"
-+#include "nonstd/string_view.hpp"
+ #endif
+ 
+ namespace csv {
+@@ -111,7 +109,7 @@ namespace csv {
+ 
+ #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
+ 
+-#ifdef CSV_HAS_CXX17
++#if 1
       /** @typedef string_view
        *  The string_view class used by this library.
        */
 diff --git a/include/internal/csv_reader.hpp b/include/internal/csv_reader.hpp
-index 02e9164..2e93f12 100644
+index 7e66666..1382cfb 100644
 --- a/include/internal/csv_reader.hpp
 +++ b/include/internal/csv_reader.hpp
 @@ -16,7 +16,7 @@

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,12 +4,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 908dd610ae3362aac1b3947892583f5aeea55a71b9d66798e4353a17fcb74ccd79de7513d94508a07876685318e2b6ba974af2aed39ea6fda09b306a353fb5a9
+    SHA512 2422a91685d68b8fe958c28b506856af0648725ea6de8b6c145346ef3fcbdfb1f9b42379c7fd0822bdca7f7382d1b1babf36bd6206efcf006b2b50ad4518ed9e
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch
         002-fix-include.patch
 )
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/include/external")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -30,8 +32,7 @@ file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-vincentlaucsb-csv-parser/uno
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-vincentlaucsb-csv-parser/unofficial-vincentlaucsb-csv-parser-config.cmake"
 "include(CMakeFindDependencyMacro)
 find_dependency(Threads)
-find_dependency(mio CONFIG)
-find_dependency(string-view-lite CONFIG)
+find_dependency(mio)
 ${cmake_config}
 ")
 

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,13 +1,12 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     "mio",
-    "string-view-lite",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10525,7 +10525,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "2.5.1",
+      "baseline": "2.5.2",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77aa8434a9508c5ac172056bc5969fa7786b998e",
+      "version": "2.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b95b2445edc9396ef461f3612b2b956aed988ef5",
       "version": "2.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
