### PR TITLE
[trieste] Add new port (1.0.0)

### DIFF
--- a/ports/trieste/portfile.cmake
+++ b/ports/trieste/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/Trieste
+    REF "v${VERSION}"
+    SHA512 cd92ef15181c7adc4e777342b9e5ae60ec1b12356d3742044d98e54d3f9a44012c377eafbc02f92afc7f80e963b32a22e5230f765a2f63345139050512bc3af0
+    HEAD_REF main
+)
+
+# NOTE: The CI overlay port (see .github/workflows/buildtest.yml,
+# vcpkg-integration) uses sed to extract from the "if" line below onwards to
+# build a portfile that points at the local checkout. If you reorder code above
+# this line, update the sed pattern there.
+if("parsers" IN_LIST FEATURES)
+  set(BUILD_PARSERS ON)
+  # The parser libraries lack __declspec(dllexport) annotations,
+  # so they must be built as static libraries on Windows.
+  if(VCPKG_TARGET_IS_WINDOWS)
+    set(VCPKG_LIBRARY_LINKAGE static)
+  endif()
+else()
+  set(BUILD_PARSERS OFF)
+  # Without parsers, this is a header-only library.
+  set(VCPKG_BUILD_TYPE release)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTRIESTE_USE_FETCH_CONTENT=OFF
+        -DTRIESTE_BUILD_SAMPLES=OFF
+        -DTRIESTE_BUILD_PARSERS=${BUILD_PARSERS}
+        -DTRIESTE_ENABLE_TESTING=OFF
+        -DTRIESTE_USE_SNMALLOC=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME trieste CONFIG_PATH share/trieste/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if(NOT "parsers" IN_LIST FEATURES)
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/trieste/usage
+++ b/ports/trieste/usage
@@ -1,0 +1,9 @@
+trieste provides CMake targets:
+
+    find_package(trieste CONFIG REQUIRED)
+    target_link_libraries(<your-target> PRIVATE trieste::trieste)
+
+When installed with the "parsers" feature (vcpkg install trieste[parsers]):
+
+    target_link_libraries(<your-target> PRIVATE trieste::json)
+    target_link_libraries(<your-target> PRIVATE trieste::yaml)

--- a/ports/trieste/vcpkg.json
+++ b/ports/trieste/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "trieste",
+  "version": "1.0.0",
+  "description": "A header-only C++20 term rewriting system for rapidly prototyping programming languages",
+  "homepage": "https://github.com/microsoft/Trieste",
+  "license": "MIT",
+  "supports": "!x86",
+  "dependencies": [
+    "cli11",
+    "snmalloc",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "parsers": {
+      "description": "Build the JSON and YAML parser libraries (trieste::json, trieste::yaml)"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10168,6 +10168,10 @@
       "baseline": "1.1.0",
       "port-version": 0
     },
+    "trieste": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "triton": {
       "baseline": "2025-02-15",
       "port-version": 0

--- a/versions/t-/trieste.json
+++ b/versions/t-/trieste.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0adfdb1fb82a3c09110728d531d3abdc0cd81222",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="866" height="1297" alt="image" src="https://github.com/user-attachments/assets/d39e307b-d76e-447d-87bf-44b98f0ebdc2" />
