### PR TITLE
Fix osgEarth license

### DIFF
--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.8",
   "description": "osgEarth - 3D Maps for OpenSceneGraph",
   "homepage": "https://github.com/pelicanmapping/osgearth",
-  "license": "MIT",
+  "license": "LGPL-3.0-or-later",
   "supports": "!(arm | x86 | wasm32 | android)",
   "dependencies": [
     {


### PR DESCRIPTION

- [X] The license declaration in `vcpkg.json` matches what upstream says.

I am not affiliated with the project, but MIT seems clearly wrong per https://github.com/pelicanmapping/osgearth?tab=License-1-ov-file

Was changed in https://github.com/microsoft/vcpkg/pull/50297, this changes it back.

cc @gwaldron 