### PR TITLE
[restinio] Update to 0.7.9.1

### DIFF
--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v${VERSION}"
-    SHA512 a1bc51d4c29afbb7a3f04e731f0f06674ad581b021462d6b96b424b2203e4e3b6bd2176810d8e3dc344c4a852ef1651d90f1a96717c71da4cddaf19aeabf06c0
+    SHA512 cf5f088126947182556c2e21c94df60e36bdf15bca1a3e4022570b8e9804c133cacf80ab79e60d334d7c56d6a80880168adbf30944db9bf746af4deb96924dd7
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "restinio",
-  "version": "0.7.9",
+  "version": "0.7.9.1",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8689,7 +8689,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.7.9",
+      "baseline": "0.7.9.1",
       "port-version": 0
     },
     "resultlib": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20e8ae9ccf51f5c2337ba4f965729181a6534c5a",
+      "version": "0.7.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e647a994a3ed2894bec673fe668fe04eb80e597",
       "version": "0.7.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- ~~[ ] All patch files in the port are applied and succeed.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
