### PR TITLE
[unrar] Update to version 7.2.5

### DIFF
--- a/ports/unrar/portfile.cmake
+++ b/ports/unrar/portfile.cmake
@@ -1,20 +1,14 @@
-set(UNRAR_VERSION "7.0.7")
-set(UNRAR_SHA512 7151a42742d4c34a8f03c58dae471f80788b76adbb52188759b7fc7357757f88fa9d980de006ce48732c40f326b92b79fb069e807c2b66d4387ee60433a8accb)
-set(UNRAR_FILENAME unrarsrc-${UNRAR_VERSION}.tar.gz)
-set(UNRAR_URL https://www.rarlab.com/rar/${UNRAR_FILENAME})
-
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-#SRC
 vcpkg_download_distfile(ARCHIVE
-    URLS ${UNRAR_URL}
-    FILENAME ${UNRAR_FILENAME}
-    SHA512 ${UNRAR_SHA512}
+    URLS "https://www.rarlab.com/rar/unrarsrc-${VERSION}.tar.gz"
+    FILENAME "unrarsrc-${VERSION}.tar.gz"
+    SHA512 8e2b7e801e1e1f8861657e7e613b4540c46938af377e43383ec2b509db1a59073d1e970fa20ee923db73a6c93777d677e7488ca6696177625cc1020922504346
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    SOURCE_BASE ${UNRAR_VERSION}
+    SOURCE_BASE ${VERSION}
 )
 
 vcpkg_msbuild_install(

--- a/ports/unrar/vcpkg.json
+++ b/ports/unrar/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "unrar",
-  "version": "7.0.7",
+  "version": "7.2.5",
   "description": "rarlab's unrar library",
   "homepage": "https://www.rarlab.com",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10289,7 +10289,7 @@
       "port-version": 0
     },
     "unrar": {
-      "baseline": "7.0.7",
+      "baseline": "7.2.5",
       "port-version": 0
     },
     "upa-url": {

--- a/versions/u-/unrar.json
+++ b/versions/u-/unrar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54894143dc5cf8e6d12b7a25c32a72a13155676d",
+      "version": "7.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "efd77010f783812337dbbda1c0f54af588506d02",
       "version": "7.0.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.