### PR TITLE
[babl] Update to 0.1.126, add native msvc support

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,13 +3,14 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 8e0199444e375c54e6723a5414a0e75874d11ba778d2c9c833f16b79f0634e900f82c2cf8d01b7e33ca609b6273873acf138d84778ba181b88ca50e1368c5ace
+    SHA512 953037386e1763b28385f0f1802a657e2b918b5db3932cc62e75aa32c36b36b0513258f1b5548dfebedb51fb6de47412503ea8f8aff4ce79c314e33a28d27166
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
+        support-plugins.patch
         remove-consistency-check.patch
 )
 
@@ -39,6 +40,8 @@ vcpkg_configure_meson(
 vcpkg_install_meson()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_tools(TOOL_NAMES babl AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/babl/remove-consistency-check.patch
+++ b/ports/babl/remove-consistency-check.patch
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index e5f9523..f974871 100644
+index 08332a0571..bd4e31c55f 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -574,7 +574,7 @@ if build_docs
+@@ -580,7 +580,7 @@ if build_docs
  endif
  subdir('bin')
  
 -if not platform_osx and host_cpu_family != 'x86'
 +if false
+   nm = find_program('nm', required: false)
+ 
    # Verify .def files for Windows linking.
-   # We check this on non-Windows platform  on CI, and on Windows itself.
-   custom_target('check-def-files',

--- a/ports/babl/support-plugins.patch
+++ b/ports/babl/support-plugins.patch
@@ -1,0 +1,89 @@
+diff --git a/babl/babl.c b/babl/babl.c
+--- a/babl/babl.c
++++ b/babl/babl.c
+@@ -101,7 +101,7 @@ babl_dir_list (void)
+         babl_fatal ("Converting module filename to UTF-8 failed");
+ 
+       /* If the DLL file name is of the format
+-       * <foobar>\bin\*.dll, use <foobar>\lib\{BABL_LIBRARY}.
++       * <foobar>\bin\*.dll, use <foobar>\plugins\{BABL_LIBRARY}.
+        * Otherwise, use the directory where the DLL is.
+        */
+ 
+@@ -121,7 +121,7 @@ babl_dir_list (void)
+               filename_tmp = babl_malloc (sizeof (char) * tmp_size);
+               strcpy_s (filename_tmp, tmp_size, filename);
+               babl_free (filename);
+-              strcat_s (filename_tmp, tmp_size, "lib" BABL_DIR_SEPARATOR BABL_LIBRARY);
++              strcat_s (filename_tmp, tmp_size, "plugins" BABL_DIR_SEPARATOR BABL_LIBRARY);
+               filename = filename_tmp;
+             }
+         }
+diff --git a/extensions/meson.build b/extensions/meson.build
+--- a/extensions/meson.build
++++ b/extensions/meson.build
+@@ -85,7 +85,7 @@ foreach ext : extensions
+     dependencies: babl_ext_dep,
+     name_prefix: '',
+     install: true,
+-    install_dir: babl_libdir / lib_name,
++    install_dir: babl_pluginsdir / lib_name,
+   )
+ endforeach
+ 
+@@ -102,7 +102,7 @@ if host_cpu_family == 'x86_64'
+       dependencies: babl_ext_dep,
+       name_prefix: '',
+       install: true,
+-      install_dir: babl_libdir / lib_name,
++      install_dir: babl_pluginsdir / lib_name,
+    )
+   endforeach
+ 
+@@ -117,7 +117,7 @@ if host_cpu_family == 'x86_64'
+       dependencies: babl_ext_dep,
+       name_prefix: '',
+       install: true,
+-      install_dir: babl_libdir / lib_name,
++      install_dir: babl_pluginsdir / lib_name,
+    )
+   endforeach
+ 
+@@ -132,7 +132,7 @@ if host_cpu_family == 'x86_64'
+       dependencies: babl_ext_dep,
+       name_prefix: '',
+       install: true,
+-      install_dir: babl_libdir / lib_name,
++      install_dir: babl_pluginsdir / lib_name,
+    )
+   endforeach
+ 
+@@ -150,7 +150,7 @@ elif host_cpu_family == 'arm'
+       dependencies: babl_ext_dep,
+       name_prefix: '',
+       install: true,
+-      install_dir: babl_libdir / lib_name,
++      install_dir: babl_pluginsdir / lib_name,
+    )
+   endforeach
+ 
+diff --git a/meson.build b/meson.build
+--- a/meson.build
++++ b/meson.build
+@@ -29,6 +29,7 @@ buildtype = get_option('buildtype')
+ 
+ babl_prefix = get_option('prefix')
+ babl_libdir = babl_prefix / get_option('libdir')
++babl_pluginsdir = babl_prefix / 'plugins'
+ 
+ project_build_root = meson.current_build_dir()
+ project_source_root = meson.current_source_dir()
+@@ -628,7 +629,7 @@ pkgconfig.generate(
+   subdirs: lib_name,
+   variables: [
+     'datadir=${prefix}/share',
+-    'pluginsdir=${libdir}/@0@'.format(lib_name),
++    'pluginsdir=${prefix}/plugins/@0@'.format(lib_name),
+     'girdir=${datadir}/gir-1.0',
+     'typelibdir=${libdir}/girepository-1.0',
+   ],

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "babl",
-  "version": "0.1.124",
+  "version": "0.1.126",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",
-  "supports": "!windows | mingw",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",
@@ -20,6 +19,7 @@
     },
     "introspection": {
       "description": "Enable introspection",
+      "supports": "!windows | mingw",
       "dependencies": [
         "gobject-introspection"
       ]

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16be1f5ab43c471b63e6fd5c01b58bd18f8401ee",
+      "version": "0.1.126",
+      "port-version": 0
+    },
+    {
       "git-tree": "712240fb456214b23808542557986b3787dcc174",
       "version": "0.1.124",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -621,7 +621,7 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.124",
+      "baseline": "0.1.126",
       "port-version": 0
     },
     "backward-cpp": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
