### PR TITLE
[dacap-clip] Install missing headers

### DIFF
--- a/ports/dacap-clip/fix-install-header-and-force-static-compilation.patch
+++ b/ports/dacap-clip/fix-install-header-and-force-static-compilation.patch
@@ -9,5 +9,6 @@ index d9aa76e..cee1d90 100644
 +  target_include_directories(clip PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 +
    install(
-     FILES clip.h
+-    FILES clip.h
++    FILES clip_base.h clip.h clip_common.h
      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dacap-clip",
   "version": "1.14",
+  "port-version": 1,
   "description": "Cross-platform C++ library to copy/paste clipboard content.",
   "homepage": "https://github.com/dacap/clip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2346,7 +2346,7 @@
     },
     "dacap-clip": {
       "baseline": "1.14",
-      "port-version": 0
+      "port-version": 1
     },
     "dagir": {
       "baseline": "0.1.0",

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f80542dcfe286dcff48a65d545afa634cb0bea0",
+      "version": "1.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "caecb666d499ee31770e68de773323a0d872e779",
       "version": "1.14",
       "port-version": 0


### PR DESCRIPTION
The port `dacap-clip` only installed the `clip.h` file which references the `clip_base.h` file, hence causing a compilation error. This pull request updates the git patch to also install the necessary additional header(s) from the `dacap-clip` project repository.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.