### PR TITLE
[meshoptimizer] update to 1.1

### DIFF
--- a/ports/meshoptimizer/portfile.cmake
+++ b/ports/meshoptimizer/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeux/meshoptimizer
     REF "v${VERSION}"
-    SHA512 8083df3cf41b90a472aaede06bcc316ec4c1c2f34775fd1f436dcea11d241087ae9e18aad115d46e7b2aaca2d754dd672872cddb6910db22770c064097b31254
+    SHA512 5e185b580050831a7f63cabcc5be4dd3f5205a5ae903b1b3057486909b85bc01eb2c9b89435ccbfce0cbaa9ca8e5fa516430bf6cd67b1303a91755909b782dcc
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/meshoptimizer/vcpkg.json
+++ b/ports/meshoptimizer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "meshoptimizer",
-  "version": "1.0.1",
+  "version": "1.1",
   "description": "Mesh optimization library that makes meshes smaller and faster to render",
   "homepage": "https://github.com/zeux/meshoptimizer",
   "license": "MIT",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -780,7 +780,6 @@ mesa:x64-linux=fail # Missing dependent libraries.
 mesa:x64-windows-static=fail # Due to static crt.
 mesa[egl](!windows)=feature-fails # ERROR: Problem encountered: EGL requires dri, haiku, or windows
 mesa[llvm]=feature-fails # ERROR: Neither a subproject directory nor a llvm.wrap file was found. (llvm-config found: NO)
-meshoptimizer[gltfpack]:arm64-linux=feature-fails
 metrohash:arm64-linux=fail
 minc:arm64-linux=cascade
 minc[minc1](android)=feature-fails

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6409,7 +6409,7 @@
       "port-version": 6
     },
     "meshoptimizer": {
-      "baseline": "1.0.1",
+      "baseline": "1.1",
       "port-version": 0
     },
     "metis": {

--- a/versions/m-/meshoptimizer.json
+++ b/versions/m-/meshoptimizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dbee1143e3830b52872fa9ee8ae65e86ee5493e4",
+      "version": "1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "09553a6c5e0d1f6bb978ba44bbd32280edd67999",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #50925 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.
