### PR TITLE
[lexbor] update to 3.0.0

### DIFF
--- a/ports/lexbor/portfile.cmake
+++ b/ports/lexbor/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/lexbor)
+vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/lexbor/portfile.cmake
+++ b/ports/lexbor/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lexbor/lexbor
     REF v${VERSION}
-    SHA512 ad2b333e2802b9e05fea461c017fecaec1619c67d4e165da7fb9c6d24a77584b8e1ff0348330a61a169e19025d215e7a0a6356ce1424daf14cf3caf2b2c2dbef
+    SHA512 076ff831e89717f07ad0f846cf2ea46fe4dfd0c7fbf37b5705f0eacaa4baa418116ce1e020fde44bd7ed75ddf5931cac74947e37fcf1330d68389b39cc392f6a
 )
 
 vcpkg_check_features(

--- a/ports/lexbor/vcpkg.json
+++ b/ports/lexbor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lexbor",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "description": "Lexbor is development of an open source HTML Renderer library.",
   "homepage": "https://github.com/lexbor/lexbor",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4617,7 +4617,7 @@
       "port-version": 3
     },
     "lexbor": {
-      "baseline": "2.7.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "lexilla": {

--- a/versions/l-/lexbor.json
+++ b/versions/l-/lexbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddb11334606782f2a1b586afcd06a7f7c7a403bf",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8230e889037d74c8c1fbaf9e48961768eff81ac6",
       "version": "2.7.0",
       "port-version": 0

--- a/versions/l-/lexbor.json
+++ b/versions/l-/lexbor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ddb11334606782f2a1b586afcd06a7f7c7a403bf",
+      "git-tree": "77a057664d8592ab2c3786aea23331ed38fbb521",
       "version": "3.0.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/lexbor/lexbor/releases/tag/v3.0.0
