### PR TITLE
[stillwater-universal] update to 4.6.8

### DIFF
--- a/ports/stillwater-universal/fix-install-path.patch
+++ b/ports/stillwater-universal/fix-install-path.patch
@@ -1,6 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de28c31..599ddc5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -559,19 +559,10 @@
+@@ -697,19 +697,10 @@ set(namespace "${PACKAGE_NAME}::")
  
  # Set up install directories. INCLUDE_INSTALL_DIR and
  # CMAKECONFIG_INSTALL_DIR must not be absolute paths.
@@ -10,8 +12,8 @@
 -    set(config_install_dir CMake)
 -elseif(UNIX)
 -    set(include_install_dir include)
--    set(include_install_dir_postfix "${project_library_target_name}")
--    set(include_install_dir_full    "${include_install_dir}/${include_install_dir_postfix}")
+-    set(include_install_dir_postfix "")
+-    set(include_install_dir_full    "${include_install_dir}")
 -
 -    set(config_install_dir share/${PACKAGE_NAME})
 -else()
@@ -24,14 +26,3 @@
  
  #####  Gather git repo related information
  # Get the current working branch
-@@ -658,7 +649,8 @@
-     DESTINATION ${config_install_dir} COMPONENT cmake)
- 
- # Install headers
--install(DIRECTORY   ${PROJECT_SOURCE_DIR}/include/${project_library_target_name}
--        DESTINATION ${include_install_dir})
-+install(DIRECTORY   ${PROJECT_SOURCE_DIR}/include/sw/universal
-+        DESTINATION ${include_install_dir}
-+        FILES_MATCHING PATTERN "*.hpp")
- 
- if(UNIVERSAL_BUILD_ALL)

--- a/ports/stillwater-universal/portfile.cmake
+++ b/ports/stillwater-universal/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stillwater-sc/universal
     REF "v${VERSION}"
-    SHA512 b4015a3c68aa17417f39867de0f036e7706442f9d7cdc470b6f237b98e341d6875a73fd22579713cf28976b7dd6bbfbad700023dda44a977ed0722efa5880284
+    SHA512 7370e60cb54bcccc40eb612c0c57a4de060670c39a9379285a21044f6c5dd38f75e8588351f978a807cafea1aedcd3b367560f642faa5eda754701751ca0f379
     HEAD_REF master
     PATCHES
         fix-install-path.patch

--- a/ports/stillwater-universal/vcpkg.json
+++ b/ports/stillwater-universal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stillwater-universal",
-  "version": "3.96",
+  "version": "4.6.8",
   "description": "A header-only C++ library for plug-in replacement number systems for native types",
   "homepage": "https://github.com/stillwater-sc/universal",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9617,7 +9617,7 @@
       "port-version": 0
     },
     "stillwater-universal": {
-      "baseline": "3.96",
+      "baseline": "4.6.8",
       "port-version": 0
     },
     "stlab": {

--- a/versions/s-/stillwater-universal.json
+++ b/versions/s-/stillwater-universal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4507cdf2ade369cfa5759a1a07a90d07a488f390",
+      "version": "4.6.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "2381846a48db7cc424095bc60a21c8432d702a0f",
       "version": "3.96",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stillwater-sc/universal/releases/tag/v4.6.8
