### PR TITLE
[gumbo] update to 0.13.2

### DIFF
--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://codeberg.org/gumbo-parser/gumbo-parser/archive/${VERSION}.tar.gz"
     FILENAME "gumbo-${VERSION}.tar.gz"
-    SHA512  15da29bc1b7d70a827870562462ca90fd57469d72d7a4804c59da96c5c46b3a0c50e99a08a80d6e08d2be87f55388c8848918bfbab58ac0c22df85fdc2bd35e7
+    SHA512  1513e88acfc3240081039b30ab63ca6fc23a85b7d1415cb8e90e9c43f9c3d99d37634a7a50d81ef7f6d43a4facac3802feea6959256a2330b26b16523a288568
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gumbo",
-  "version": "0.12.3",
+  "version": "0.13.2",
   "description": "An HTML5 parsing library in pure C99",
   "homepage": "https://codeberg.org/gumbo-parser/gumbo-parser",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3641,7 +3641,7 @@
       "port-version": 0
     },
     "gumbo": {
-      "baseline": "0.12.3",
+      "baseline": "0.13.2",
       "port-version": 0
     },
     "gz-cmake": {

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf622a1d3b7ad98e86a99b371f3b693a5cce272c",
+      "version": "0.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "34c97da27c275c1657e50d6598c72b8aca5cb8cd",
       "version": "0.12.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://codeberg.org/gumbo-parser/gumbo-parser/releases/tag/0.13.2
