### PR TITLE
[numkong] update to 7.3.0

### DIFF
--- a/ports/numkong/portfile.cmake
+++ b/ports/numkong/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/NumKong
     REF "v${VERSION}"
-    SHA512 1585f055a4f0bc1f86b07a5f3af21970cceb4f7b2b41d50f3e1d0474fc52b198b7dda6168d289e51c2ab419d5407a99673e6b900db45f30776150752ff2f24f9
+    SHA512 e3514bd8520babdb47058c5693eb329d57053d45640f300db38a9704ecf427b40ac2f0c1f8f5c28a8feb5a8bdd38b5fb2a52577ca0ace56d47bdbbe4178b6fcf
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/numkong/vcpkg.json
+++ b/ports/numkong/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "numkong",
-  "version": "7.2.4",
+  "version": "7.3.0",
   "description": "NumKong (previously SimSIMD) delivers mixed-precision numerics that are often faster and more accurate than standard BLAS libraries",
   "homepage": "https://github.com/ashvardanian/NumKong",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7069,7 +7069,7 @@
       "port-version": 0
     },
     "numkong": {
-      "baseline": "7.2.4",
+      "baseline": "7.3.0",
       "port-version": 0
     },
     "nuraft": {

--- a/versions/n-/numkong.json
+++ b/versions/n-/numkong.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8a97a83c6a684230df214d40f82386fe3a797ac",
+      "version": "7.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "724c1ce41849baffebd0d1ad703f8dca4c862711",
       "version": "7.2.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ashvardanian/NumKong/releases/tag/v7.3.0
