### PR TITLE
[maxflow] Add new port

### DIFF
--- a/ports/maxflow/portfile.cmake
+++ b/ports/maxflow/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gerddie/maxflow
+    REF 6ac148f164b9567ac81fbb4ebb36112f850c902b
+    SHA512 78ef91bde07a581747687c46f633ff7b89780f853582e2812c655dac79b308e2b5e8f4cc1d0d5bd08780393c5b5187acd93d606fe5e116e1595b34045341ca0d
+    HEAD_REF master
+)
+
+set(opts "")
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(opts
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS:BOOL=ON
+  )
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" "SHARED" "STATIC")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        ${opts}
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_POLICY_VERSION_MINIMUM
+        CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/GPL.TXT")

--- a/ports/maxflow/vcpkg.json
+++ b/ports/maxflow/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "maxflow",
+  "version": "2020-11-09",
+  "description": "An implementation of the maxflow algorithm.",
+  "homepage": "https://github.com/gerddie/maxflow",
+  "license": "GPL-3.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6352,6 +6352,10 @@
       "baseline": "1.7.1",
       "port-version": 3
     },
+    "maxflow": {
+      "baseline": "2020-11-09",
+      "port-version": 0
+    },
     "mbedtls": {
       "baseline": "3.6.5",
       "port-version": 0

--- a/versions/m-/maxflow.json
+++ b/versions/m-/maxflow.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0632550ff5321ab1f33d46972552f477b2a9a93f",
+      "version": "2020-11-09",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
maxflow can be used by gegl to build paint-select operation.

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md). (I see the maintainer guide have a strong statement regarding CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS, could a exception be made?)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/maxflow/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says (as on MSYS2 and macports, I choose to not use the tags since they are too old).
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
