### PR TITLE
[frei0r) update to 2.5.6

### DIFF
--- a/ports/frei0r/portfile.cmake
+++ b/ports/frei0r/portfile.cmake
@@ -2,20 +2,13 @@
 # hence they don't have import libs
 set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
 
-vcpkg_download_distfile(FIX_UPSTREAM_PR_252
-    URLS https://github.com/dyne/frei0r/pull/252.patch?full_index=1
-    SHA512 bdf8c6e64d73495a843c76d08204217002f1108363674633a70574ba05f0f33efafc567b73f604c7c76fd9a9614a64ccadd62c3709454b52efbb8b8d61055532
-    FILENAME fix-sleid0r-symbol-export.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dyne/frei0r
     REF "v${VERSION}"
-    SHA512 81831ede1d76d0ad8811f6b8116eb71a74e5af47a3249954f2c6f327e71e618d92c31f19566963bd9952363b22c5a6606df3ef8592f97c3bb1cd8ed9abe94c14
+    SHA512 323028431039a14947234ec2ce969d2fd3121fda47d3ac57e7cfb9ddc12c4c6545824e8fed0efb6860beb14983fd3a1879a85879aed4a6655d9608ea6a85f971
     HEAD_REF master
     PATCHES
-        "${FIX_UPSTREAM_PR_252}"
         install-dlls-to-bin.diff
 )
 

--- a/ports/frei0r/vcpkg.json
+++ b/ports/frei0r/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "frei0r",
-  "version": "2.5.4",
+  "version": "2.5.6",
   "description": "A large collection of free and portable video plugins",
   "homepage": "https://frei0r.dyne.org/",
   "license": "GPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3201,7 +3201,7 @@
       "port-version": 2
     },
     "frei0r": {
-      "baseline": "2.5.4",
+      "baseline": "2.5.6",
       "port-version": 0
     },
     "fribidi": {

--- a/versions/f-/frei0r.json
+++ b/versions/f-/frei0r.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a347546fdca10c8dfe8d3dbf0100499ddb529015",
+      "version": "2.5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "ddfa0c31ead64f21a195cc53c5b5c437f73f9142",
       "version": "2.5.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or~ no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.