### PR TITLE
[iso-codes] Add new port

### DIFF
--- a/ports/iso-codes/portfile.cmake
+++ b/ports/iso-codes/portfile.cmake
@@ -1,0 +1,23 @@
+# data-only port
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://salsa.debian.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO iso-codes-team/iso-codes
+    REF "v${VERSION}"
+    SHA512 2b5690b109da3d4f969c62f1a9653f6a12f6529794b97d0c834d708ff9a407bc0193047992b2acea7525f4638a68dbd9a6dceec8b0b0d08f23a2fd2e3124b1d2
+)
+
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin")
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_install_meson()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/LGPL-2.1-or-later.txt")

--- a/ports/iso-codes/vcpkg.json
+++ b/ports/iso-codes/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "iso-codes",
+  "version": "4.20.1",
+  "description": "Lists of the country, language, and currency names",
+  "homepage": "https://salsa.debian.org/iso-codes-team/iso-codes",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "gettext",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4048,6 +4048,10 @@
       "baseline": "1.15.0",
       "port-version": 0
     },
+    "iso-codes": {
+      "baseline": "4.20.1",
+      "port-version": 0
+    },
     "itay-grudev-singleapplication": {
       "baseline": "3.5.4",
       "port-version": 0

--- a/versions/i-/iso-codes.json
+++ b/versions/i-/iso-codes.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6abba4c49f45325fda174b29b8d972e9e9bd8195",
+      "version": "4.20.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This is needed for localization support on GIMP

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/iso-codes/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
