### PR TITLE
[libwmf] Add new port

### DIFF
--- a/ports/libwmf/portfile.cmake
+++ b/ports/libwmf/portfile.cmake
@@ -1,0 +1,46 @@
+vcpkg_download_distfile(ZLIB_LIBPNG_PATCH
+    URLS https://github.com/caolanm/libwmf/commit/65f830d3a8269353012e6880bd70e3f392bb3727.patch?full_index=1
+    SHA512 c45cc74e2861e272744bf38a31b1359c2235f91d25b8e7f62b61a9a712083080661d6040aaffb34274606a1d8964757abbcec23dbaa39890ba1be73614ce8be9
+    FILENAME zlib_libpng.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO caolanm/libwmf
+    REF "v${VERSION}"
+    SHA512 e95ab312ac06add60f278b9fa8cebb20bd8bd53b98f7159fe1ebc206cbcad1a186ef2ce4dd6c3c271dcad037e9b685493cda1267d4ebf9638906584eedb4f960
+    HEAD_REF master
+    PATCHES
+        "${ZLIB_LIBPNG_PATCH}"
+)
+
+set(FONTMAP "${CURRENT_INSTALLED_DIR}/share/libwmf/fonts/fontmap")
+set(FONTDIR "${CURRENT_INSTALLED_DIR}/share/libwmf/fonts")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    OPTIONS
+        --without-x
+        --with-xtrafontmap="${FONTMAP}"
+        --with-fontdir="${FONTDIR}"
+)
+
+vcpkg_make_install()
+
+set(LIBWMF_FONTMAP "${CURRENT_PACKAGES_DIR}/tools/libwmf/bin/libwmf-fontmap")
+vcpkg_replace_string("${LIBWMF_FONTMAP}" "\"${FONTMAP}\"" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../share/libwmf/fonts/fontmap]=])
+vcpkg_replace_string("${LIBWMF_FONTMAP}" "\"${FONTDIR}\"" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../share/libwmf/fonts]=])
+
+set(LIBWMF_FONTMAP "${CURRENT_PACKAGES_DIR}/tools/libwmf/debug/bin/libwmf-fontmap")
+if(EXISTS "${LIBWMF_FONTMAP}")
+    vcpkg_replace_string("${LIBWMF_FONTMAP}" "\"${FONTMAP}\"" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../../share/libwmf/fonts/fontmap]=])
+    vcpkg_replace_string("${LIBWMF_FONTMAP}" "\"${FONTDIR}\"" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../../share/libwmf/fonts]=])
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libwmf/portfile.cmake
+++ b/ports/libwmf/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_download_distfile(ZLIB_LIBPNG_PATCH
+    URLS https://github.com/caolanm/libwmf/commit/65f830d3a8269353012e6880bd70e3f392bb3727.patch?full_index=1
+    SHA512 c45cc74e2861e272744bf38a31b1359c2235f91d25b8e7f62b61a9a712083080661d6040aaffb34274606a1d8964757abbcec23dbaa39890ba1be73614ce8be9
+    FILENAME zlib_libpng.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO caolanm/libwmf
+    REF "v${VERSION}"
+    SHA512 e95ab312ac06add60f278b9fa8cebb20bd8bd53b98f7159fe1ebc206cbcad1a186ef2ce4dd6c3c271dcad037e9b685493cda1267d4ebf9638906584eedb4f960
+    HEAD_REF master
+    PATCHES
+        "${ZLIB_LIBPNG_PATCH}"
+)
+
+
+if("jpeg" IN_LIST FEATURES)
+    list(APPEND OPTIONS --with-jpeg=yes)
+else()
+    list(APPEND OPTIONS --with-jpeg=no)
+endif()
+
+
+set(FONTMAP "${CURRENT_PACKAGES_DIR}/share/libwmf/fonts/fontmap")
+set(FONTDIR "${CURRENT_PACKAGES_DIR}/share/libwmf/fonts")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    OPTIONS
+        --with-libxml2=yes
+        --with-expat=no
+        --without-x
+        "--with-xtrafontmap=${FONTMAP}"
+        "--with-fontdir=${FONTDIR}"
+)
+
+vcpkg_make_install()
+
+set(LIBWMF_FONTMAP "${CURRENT_PACKAGES_DIR}/tools/libwmf/bin/libwmf-fontmap")
+vcpkg_replace_string("${LIBWMF_FONTMAP}" "${FONTMAP}" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../share/libwmf/fonts/fontmap]=])
+vcpkg_replace_string("${LIBWMF_FONTMAP}" "${FONTDIR}" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../share/libwmf/fonts]=])
+
+set(LIBWMF_FONTMAP "${CURRENT_PACKAGES_DIR}/tools/libwmf/debug/bin/libwmf-fontmap")
+if(EXISTS "${LIBWMF_FONTMAP}")
+    vcpkg_replace_string("${LIBWMF_FONTMAP}" "${FONTMAP}" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../../share/libwmf/fonts/fontmap]=])
+    vcpkg_replace_string("${LIBWMF_FONTMAP}" "${FONTDIR}" [=["$(cd "$(dirname "${0}")" && pwd)"/../../../../share/libwmf/fonts]=])
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libwmf/portfile.cmake
+++ b/ports/libwmf/portfile.cmake
@@ -1,0 +1,48 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO caolanm/libwmf
+    REF "v${VERSION}"
+    SHA512 f6c48e557b9cb69910fc106db2fa497c44c0e5fc5088f353abdc981746db5a5015a4ee0749f0ec713da3d0275a1f5f9e27e93430d26b9cacb574cd28928e1714
+    HEAD_REF master
+    PATCHES
+)
+
+
+if("jpeg" IN_LIST FEATURES)
+    list(APPEND OPTIONS --with-jpeg=yes)
+else()
+    list(APPEND OPTIONS --with-jpeg=no)
+endif()
+
+if(NOT "pixbuf" IN_LIST FEATURES)
+    list(APPEND OPTIONS --disable-pixbuf)
+endif()
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    OPTIONS
+        --with-sys-gd=yes
+        --with-libxml2=yes
+        --with-expat=no
+        --without-x
+        ${OPTIONS}
+)
+
+vcpkg_make_install()
+
+set(FONTMAP_BIN "${CURRENT_PACKAGES_DIR}/tools/libwmf/bin/libwmf-fontmap")
+if(EXISTS "${FONTMAP_BIN}")
+    file(REMOVE_RECURSE "${FONTMAP_BIN}")
+endif()
+set(FONTMAP_BIN "${CURRENT_PACKAGES_DIR}/tools/libwmf/debug/bin/libwmf-fontmap")
+if(EXISTS "${FONTMAP_BIN}")
+    file(REMOVE_RECURSE "${FONTMAP_BIN}")
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libwmf/vcpkg.json
+++ b/ports/libwmf/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "libwmf",
+  "version": "0.2.15",
+  "description": "Library for Converting Metafile Images",
+  "homepage": "https://wvWare.sourceforge.io/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "freetype",
+      "default-features": false
+    },
+    "libjpeg-turbo",
+    "libpng",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/ports/libwmf/vcpkg.json
+++ b/ports/libwmf/vcpkg.json
@@ -1,0 +1,34 @@
+{
+  "name": "libwmf",
+  "version": "0.2.15",
+  "description": "Library for Converting Metafile Images",
+  "homepage": "https://wvWare.sourceforge.io/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "freetype",
+      "default-features": false
+    },
+    "libpng",
+    {
+      "name": "libxml2",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "jpeg"
+  ],
+  "features": {
+    "jpeg": {
+      "description": "Support JPEG compression in WMF image files",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    }
+  }
+}

--- a/ports/libwmf/vcpkg.json
+++ b/ports/libwmf/vcpkg.json
@@ -1,0 +1,44 @@
+{
+  "name": "libwmf",
+  "version": "0.2.16",
+  "description": "Library for Converting Metafile Images",
+  "homepage": "https://wvWare.sourceforge.io/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "freetype",
+      "default-features": false
+    },
+    {
+      "name": "libgd",
+      "default-features": false
+    },
+    "libpng",
+    {
+      "name": "libxml2",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "jpeg"
+  ],
+  "features": {
+    "jpeg": {
+      "description": "Support JPEG compression in WMF image files",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    },
+    "pixbuf": {
+      "description": "Build pixbuf plugin",
+      "dependencies": [
+        "gdk-pixbuf"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5832,6 +5832,10 @@
       "baseline": "4.5.8",
       "port-version": 0
     },
+    "libwmf": {
+      "baseline": "0.2.15",
+      "port-version": 0
+    },
     "libx11": {
       "baseline": "1.8.1",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5844,6 +5844,10 @@
       "baseline": "4.5.8",
       "port-version": 0
     },
+    "libwmf": {
+      "baseline": "0.2.15",
+      "port-version": 0
+    },
     "libx11": {
       "baseline": "1.8.1",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5980,6 +5980,10 @@
       "baseline": "4.5.8",
       "port-version": 0
     },
+    "libwmf": {
+      "baseline": "0.2.16",
+      "port-version": 0
+    },
     "libx11": {
       "baseline": "1.8.1",
       "port-version": 6

--- a/versions/l-/libwmf.json
+++ b/versions/l-/libwmf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9e0253d7f7c5651f15ea8afd947e19b5439ecab5",
+      "version": "0.2.15",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libwmf.json
+++ b/versions/l-/libwmf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9871c0e48acfdc02a2e022b6bd63c46d60bfeb11",
+      "version": "0.2.15",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libwmf.json
+++ b/versions/l-/libwmf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "975c1d3e659de5a127823161defcaa5d2681f2d9",
+      "version": "0.2.16",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Needed by GIMP to build file-wmf plugin.

~The first 3 patches should be removed once the upstream fixes are released: https://github.com/caolanm/libwmf/pull/22~

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/libwmf/versions
    - [x] The project is amongst the first web search results for "libwmf" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR. <img width="1512" height="798" alt="Captura de Tela 2026-04-04 às 14 40 02" src="https://github.com/user-attachments/assets/ac4f9618-29fe-439c-9cf3-ccd4087bfd69" />
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


Needed by GIMP to build file-wmf plugin.

~The first 3 patches should be removed once the upstream fixes are released: https://github.com/caolanm/libwmf/pull/22~