### PR TITLE
[ruckig] Update to 0.17.3

### DIFF
--- a/ports/ruckig/portfile.cmake
+++ b/ports/ruckig/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pantor/ruckig
     REF "v${VERSION}"
-    SHA512 5399e1f0c61c1c4d96a8a910e4b934b629c6302fd18fd609c7a8bc76156bf0f3f5197ff9e83ac0fc443083e40cc7208d9a2f09070f4f8ab4511f4a6566981b5d
+    SHA512 357b78a39b0ed0dde959aa7629af036d66e77ba3c0c4d0edb1f8fe3a6de4afca91bd4aecd316edd26d8b35a00e739f395850671374cd0f46743d4fe9a088f14b
     HEAD_REF main
     PATCHES
         third_party.patch

--- a/ports/ruckig/vcpkg.json
+++ b/ports/ruckig/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ruckig",
-  "version": "0.15.3",
+  "version": "0.17.3",
   "description": "Ruckig generates trajectories on-the-fly, allowing robots and machines to react instantaneously to sensor input.",
   "homepage": "https://ruckig.com/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8865,7 +8865,7 @@
       "port-version": 1
     },
     "ruckig": {
-      "baseline": "0.15.3",
+      "baseline": "0.17.3",
       "port-version": 0
     },
     "rxcpp": {

--- a/versions/r-/ruckig.json
+++ b/versions/r-/ruckig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b057b43abeb8d1ab3e5dbb1cad4312bc94c09fb5",
+      "version": "0.17.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "634f7ae551de76541aa80a69eb408245c8a86ca3",
       "version": "0.15.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.