### PR TITLE
[dlib] fix LAPACK::LAPACK target not found in dlibConfig.cmake

### DIFF
--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -62,6 +62,33 @@ endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/dlib)
 
+# Workaround: The fix-dependencies and fix-lapack patches insert find_dependency
+# calls for BLAS/LAPACK AFTER the include of the targets file (dlib.cmake) in
+# dlibConfig.cmake. CMake fails because LAPACK::LAPACK and BLAS::BLAS are
+# referenced in dlib.cmake before they are defined.
+# Fix: remove the misplaced calls and inject explicit find_package calls (which
+# go through the vcpkg cmake wrappers) before the targets include block.
+set(_dlib_config_file "${CURRENT_PACKAGES_DIR}/share/${PORT}/dlibConfig.cmake")
+file(READ "${_dlib_config_file}" _dlib_config_contents)
+# Remove original misplaced find_dependency calls
+string(REPLACE "find_dependency(BLAS)
+find_dependency(LAPACK)" "# BLAS/LAPACK: moved before targets include" _dlib_config_contents "${_dlib_config_contents}")
+# Insert find_package calls before the targets file include
+string(REPLACE "# Our library dependencies (contains definitions for IMPORTED targets)" [[
+find_package(BLAS)
+if(NOT TARGET BLAS::BLAS AND BLAS_FOUND AND BLAS_LIBRARIES)
+    add_library(BLAS::BLAS INTERFACE IMPORTED)
+    set_target_properties(BLAS::BLAS PROPERTIES INTERFACE_LINK_LIBRARIES "${BLAS_LIBRARIES}")
+endif()
+find_package(LAPACK)
+if(NOT TARGET LAPACK::LAPACK AND LAPACK_FOUND AND LAPACK_LIBRARIES)
+    add_library(LAPACK::LAPACK INTERFACE IMPORTED)
+    set_target_properties(LAPACK::LAPACK PROPERTIES INTERFACE_LINK_LIBRARIES "${LAPACK_LIBRARIES}")
+endif()
+
+# Our library dependencies (contains definitions for IMPORTED targets)]] _dlib_config_contents "${_dlib_config_contents}")
+file(WRITE "${_dlib_config_file}" "${_dlib_config_contents}")
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/dlib/vcpkg.json
+++ b/ports/dlib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dlib",
   "version": "20.0.1",
+  "port-version": 1,
   "description": "Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++",
   "homepage": "https://github.com/davisking/dlib",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2550,7 +2550,7 @@
     },
     "dlib": {
       "baseline": "20.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "dlpack": {
       "baseline": "1.3",

--- a/versions/d-/dlib.json
+++ b/versions/d-/dlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9c3155cf16d5545fc4e7e3ef1a98537c897bd66",
+      "version": "20.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "0eceb3fc9659854e88aa0a6cb2915c62c0fe1bf1",
       "version": "20.0.1",
       "port-version": 0


### PR DESCRIPTION

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

#Fixes #50976

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
