### PR TITLE
[aom] avoid nasm on non-x86

### DIFF
--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -9,8 +9,24 @@ vcpkg_from_git(
         aom-fix-nasm.diff # TODO: remove this patch after the next release
 )
 
-vcpkg_find_acquire_program(NASM)
 vcpkg_find_acquire_program(PERL)
+
+set(aom_configure_options
+    -DENABLE_DOCS=OFF
+    -DENABLE_EXAMPLES=OFF
+    -DENABLE_TESTDATA=OFF
+    -DENABLE_TESTS=OFF
+    -DENABLE_TOOLS=OFF
+    -DTHREADS_PREFER_PTHREAD_FLAG=ON
+    "-DPERL_EXECUTABLE=${PERL}"
+)
+
+if(VCPKG_TARGET_ARCHITECTURE MATCHES "^(x86|x64)$")
+    # Upstream AOM only uses NASM on x86-family targets. Non-x86 targets such as
+    # Apple Silicon configure with ENABLE_NASM=OFF and should not require nasm.
+    vcpkg_find_acquire_program(NASM)
+    list(APPEND aom_configure_options "-DCMAKE_ASM_NASM_COMPILER=${NASM}")
+endif()
 
 set(aom_target_cpu "")
 if(VCPKG_TARGET_IS_UWP OR (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "^arm"))
@@ -27,14 +43,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         ${aom_target_cpu}
-        -DENABLE_DOCS=OFF
-        -DENABLE_EXAMPLES=OFF
-        -DENABLE_TESTDATA=OFF
-        -DENABLE_TESTS=OFF
-        -DENABLE_TOOLS=OFF
-        -DTHREADS_PREFER_PTHREAD_FLAG=ON
-        "-DCMAKE_ASM_NASM_COMPILER=${NASM}"
-        "-DPERL_EXECUTABLE=${PERL}"
+        ${aom_configure_options}
 )
 
 vcpkg_cmake_install()

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -11,21 +11,11 @@ vcpkg_from_git(
 
 vcpkg_find_acquire_program(PERL)
 
-set(aom_configure_options
-    -DENABLE_DOCS=OFF
-    -DENABLE_EXAMPLES=OFF
-    -DENABLE_TESTDATA=OFF
-    -DENABLE_TESTS=OFF
-    -DENABLE_TOOLS=OFF
-    -DTHREADS_PREFER_PTHREAD_FLAG=ON
-    "-DPERL_EXECUTABLE=${PERL}"
-)
-
 if(VCPKG_TARGET_ARCHITECTURE MATCHES "^(x86|x64)$")
     # Upstream AOM only uses NASM on x86-family targets. Non-x86 targets such as
     # Apple Silicon configure with ENABLE_NASM=OFF and should not require nasm.
     vcpkg_find_acquire_program(NASM)
-    list(APPEND aom_configure_options "-DCMAKE_ASM_NASM_COMPILER=${NASM}")
+    set(aom_nasm_compiler "-DCMAKE_ASM_NASM_COMPILER=${NASM}")
 endif()
 
 set(aom_target_cpu "")
@@ -43,7 +33,14 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         ${aom_target_cpu}
-        ${aom_configure_options}
+        -DENABLE_DOCS=OFF
+        -DENABLE_EXAMPLES=OFF
+        -DENABLE_TESTDATA=OFF
+        -DENABLE_TESTS=OFF
+        -DENABLE_TOOLS=OFF
+        -DTHREADS_PREFER_PTHREAD_FLAG=ON
+        ${aom_nasm_compiler}
+        "-DPERL_EXECUTABLE=${PERL}"
 )
 
 vcpkg_cmake_install()

--- a/ports/aom/vcpkg.json
+++ b/ports/aom/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "aom",
   "version-semver": "3.13.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "AV1 codec library",
   "homepage": "https://aomedia.googlesource.com/aom",
   "license": "BSD-2-Clause",

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "76c75f778039bd69a76158b1d8750c24242b33a5",
+      "git-tree": "6af4ddae16c64f2cab705d49ed1055c2d99fd837",
       "version-semver": "3.13.1",
       "port-version": 2
     },

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76c75f778039bd69a76158b1d8750c24242b33a5",
+      "version-semver": "3.13.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "26fd05f1c9967caa611538c4e2f11edb8303288f",
       "version-semver": "3.13.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -178,7 +178,7 @@
     },
     "aom": {
       "baseline": "3.13.1",
-      "port-version": 1
+      "port-version": 2
     },
     "apache-datasketches": {
       "baseline": "5.2.0",


### PR DESCRIPTION
Fixes #50980.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

