### PR TITLE
[x509cert-banned] New port

### DIFF
--- a/ports/x509cert-banned/portfile.cmake
+++ b/ports/x509cert-banned/portfile.cmake
@@ -1,0 +1,16 @@
+# header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO x509cert/banned
+    REF 8b631004dd1465971f8ee33354d29d7fd59b9896
+    SHA512 e51a4eeafd5d8e07b8bc9dd1b7ad52243acc94009ef4e8e65aa2472c8289258e0a8300a1a5702888d1bd4ea3d84b6532b4c97b23f3347f70226c4072e5804991
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/banned.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/x509cert")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/x509cert-banned/usage
+++ b/ports/x509cert-banned/usage
@@ -1,0 +1,4 @@
+x509cert-banned is header-only and can be used from CMake via:
+
+  find_path(X509_CERT_BANNED_INCLUDE_DIR "x509cert/banned.h")
+  target_include_directories(main PRIVATE "${X509_CERT_BANNED_INCLUDE_DIR}")

--- a/ports/x509cert-banned/vcpkg.json
+++ b/ports/x509cert-banned/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "x509cert-banned",
+  "version-date": "2022-04-19",
+  "description": "Deprecated C runtime functions",
+  "homepage": "https://github.com/x509cert/banned",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10888,6 +10888,10 @@
       "baseline": "4.1",
       "port-version": 1
     },
+    "x509cert-banned": {
+      "baseline": "2022-04-19",
+      "port-version": 0
+    },
     "x86-simd-sort": {
       "baseline": "7.0",
       "port-version": 0

--- a/versions/x-/x509cert-banned.json
+++ b/versions/x-/x509cert-banned.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8032467b6fffbf80484e273b582211f2641c77ce",
+      "version-date": "2022-04-19",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
