### PR TITLE
[doctest] update to 2.5.1

### DIFF
--- a/ports/doctest/portfile.cmake
+++ b/ports/doctest/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO doctest/doctest
     REF "v${VERSION}"
-    SHA512 16c2d195ae13f08dd1c9ee12af25135b69ed13ce569d1344f61ace6bc6a42898bb8d24358546049d82552db0759fac82fccfb59e4f970b4a80b3d06be6c95f2b
+    SHA512 6a1b44707cc409e106d02c1efa8d28b0c86e26dfa4c0fc6f7050b0cfd9b02859fbd502c067dcc88e70ee23b7adb35869f0555deebd8615c5342eb87c0f271fac
     HEAD_REF master
 )
 

--- a/ports/doctest/vcpkg.json
+++ b/ports/doctest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "doctest",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "The fastest feature-rich C++11/14/17/20 single-header testing framework",
   "homepage": "https://github.com/doctest/doctest",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2569,7 +2569,7 @@
       "port-version": 0
     },
     "doctest": {
-      "baseline": "2.5.0",
+      "baseline": "2.5.1",
       "port-version": 0
     },
     "double-conversion": {

--- a/versions/d-/doctest.json
+++ b/versions/d-/doctest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "181669715c6f4274b20c129d1ebac260434a6b4b",
+      "version": "2.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d3370dd0dbc85c029695b1c0635c85d021596154",
       "version": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/doctest/doctest/releases/tag/v2.5.1
