### PR TITLE
[sdl3-image] update to 3.4.2

### DIFF
--- a/ports/sdl3-image/portfile.cmake
+++ b/ports/sdl3-image/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_image
     REF "release-${VERSION}"
-    SHA512 3e98854f92b2fbb3489408b413ce2e0cfbb3e3eea58fa6e7037948a9fa7bf6bf5af38c4087285d4b7340b1115699c2c4b9626ce65a3e3b449bd5d4ec2078c957
+    SHA512 bd2b1c8abdf5b207901fa76f6636830f813b67f3e6854e623af6c7fbd27cf34e0d9f3d62f5eaf8b269fb0e1fbb309adad0e1ce9b55da01db5fbe0f21fb7f93b4
     HEAD_REF main
     PATCHES
         dependencies.diff

--- a/ports/sdl3-image/vcpkg.json
+++ b/ports/sdl3-image/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3-image",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1341,7 +1341,6 @@ sdl2-net:arm64-linux=cascade
 sdl2-ttf:arm64-linux=cascade
 sdl2pp:arm64-linux=cascade
 sdl3[dbus]:arm64-linux=cascade
-sdl3-image:arm64-linux=cascade
 sdl3-shadercross((!windows | arm32 | uwp | xbox) & (!linux | !x64))=cascade
 sdl3-ttf:arm64-linux=cascade
 seacas[mpi]:arm64-linux=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9037,7 +9037,7 @@
       "port-version": 1
     },
     "sdl3-image": {
-      "baseline": "3.4.0",
+      "baseline": "3.4.2",
       "port-version": 0
     },
     "sdl3-mixer": {

--- a/versions/s-/sdl3-image.json
+++ b/versions/s-/sdl3-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2621596cc09e39b1ab98298f4f9e126c1764a6c4",
+      "version": "3.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "03ff42d864ca8e4dc391835a5a4819b8178c403c",
       "version": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libsdl-org/SDL_image/releases/tag/release-3.4.2
