### PR TITLE
 [tinyusdz] add v0.9.1 vcpkg port with manual header and static library install

### DIFF
--- a/ports/tinyusdz/portfile.cmake
+++ b/ports/tinyusdz/portfile.cmake
@@ -1,0 +1,66 @@
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    message(FATAL_ERROR "tinyusdz is not supported on Emscripten")
+endif()
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lighttransport/tinyusdz
+    REF v0.9.1
+    SHA512 26093ec107e1440be1e896ba3da8e0d9196c968455332d1d6961cbe458a26cce86d18f4b22279b5775a5e029e491306346aa4796517fac7e30a6ba1ff84d2e71
+    HEAD_REF dev
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTINYUSDZ_BUILD_TESTS=OFF
+        -DTINYUSDZ_BUILD_EXAMPLES=OFF
+        -DTINYUSDZ_BUILD_BENCHMARKS=OFF
+        -DTINYUSDZ_WITH_OPENSUBDIV=OFF
+        -DTINYUSDZ_WITH_EXR=OFF
+        -DTINYUSDZ_WITH_AUDIO=OFF
+        -DTINYUSDZ_WITH_USDMTLX=OFF
+        -DTINYUSDZ_WITH_PXR_COMPAT_API=OFF
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_build()
+
+file(COPY "${SOURCE_PATH}/src/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/tinyusdz"
+    FILES_MATCHING
+    PATTERN "*.hh"
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.inc"
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(GLOB TINYUSDZ_LIB
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*.lib"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/*.lib"
+    )
+    set(TINYUSDZ_LIB_FILENAME "tinyusdz_static.lib")
+else()
+    file(GLOB TINYUSDZ_LIB
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*.a"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/*.a"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/*.a"
+    )
+    set(TINYUSDZ_LIB_FILENAME "libtinyusdz_static.a")
+endif()
+
+file(COPY ${TINYUSDZ_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/tinyusdz/tinyusdzConfig.cmake" "
+get_filename_component(_TINYUSDZ_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}/../..\" ABSOLUTE)
+
+add_library(tinyusdz::tinyusdz_static STATIC IMPORTED)
+set_target_properties(tinyusdz::tinyusdz_static PROPERTIES
+    IMPORTED_LOCATION \"\${_TINYUSDZ_PREFIX}/lib/${TINYUSDZ_LIB_FILENAME}\"
+    INTERFACE_INCLUDE_DIRECTORIES \"\${_TINYUSDZ_PREFIX}/include/tinyusdz\"
+)
+")

--- a/ports/tinyusdz/vcpkg.json
+++ b/ports/tinyusdz/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "tinyusdz",
+  "version-string": "v0.9.1",
+  "description": "Tiny USDZ/USD loader and writer library",
+  "homepage": "https://github.com/lighttransport/tinyusdz",
+  "license": "MIT",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,5 +1,9 @@
 {
   "default": {
+    "tinyusdz": {
+      "baseline": "v0.9.1",
+      "port-version": 0
+    },
     "3fd": {
       "baseline": "2.6.3",
       "port-version": 5

--- a/versions/t-/tinyusdz.json
+++ b/versions/t-/tinyusdz.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "version-string": "v0.9.1",
+      "git-tree": ""  
+    }
+  ]
+}


### PR DESCRIPTION

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
