### PR TITLE
[vincentlaucsb-csv-parser] update to 3.0.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a14387c..3db06b2 100644
+index 6556ac5..bece9d9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,5 +1,8 @@
@@ -11,7 +11,7 @@ index a14387c..3db06b2 100644
  
  if(CSV_CXX_STANDARD)
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
-@@ -49,10 +52,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
+@@ -66,10 +69,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  
  include_directories(${CSV_INCLUDE_DIR})
  
@@ -23,7 +23,7 @@ index a14387c..3db06b2 100644
  
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
-@@ -69,6 +69,23 @@ if (CSV_BUILD_PROGRAMS)
+@@ -86,6 +86,23 @@ if (CSV_BUILD_PROGRAMS)
      add_subdirectory("programs")
  endif()
  
@@ -48,17 +48,23 @@ index a14387c..3db06b2 100644
  if (CSV_DEVELOPER)
      # Allow for performance profiling
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index 7da751c..855804f 100644
+index 8502088..d4cad4d 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
-@@ -26,6 +26,8 @@ target_sources(csv
+@@ -28,7 +28,7 @@ target_sources(csv
  		thread_safe_deque.hpp
  		)
  
 -set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX)
--target_link_libraries(csv PRIVATE Threads::Threads)
--target_include_directories(csv INTERFACE ../)
 +set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX OUTPUT_NAME "vincentlaucsb-csv-parser-csv")
+ 
+ if(CSV_ENABLE_THREADS)
+ 	target_compile_definitions(csv PUBLIC CSV_ENABLE_THREADS=1)
+@@ -37,4 +37,7 @@ else()
+ 	target_compile_definitions(csv PUBLIC CSV_ENABLE_THREADS=0)
+ endif()
+ 
+-target_include_directories(csv INTERFACE ../)
 +target_include_directories(csv
 +	INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vincentlaucsb-csv-parser>
 +)

--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -1,21 +1,21 @@
 diff --git a/include/internal/basic_csv_parser.hpp b/include/internal/basic_csv_parser.hpp
-index 6e1efb0..fac6ebf 100644
+index f8b598e..1d352d4 100644
 --- a/include/internal/basic_csv_parser.hpp
 +++ b/include/internal/basic_csv_parser.hpp
 @@ -12,7 +12,7 @@
- #include <thread>
  #include <vector>
  
+ #if !defined(__EMSCRIPTEN__)
 -#include "../external/mio.hpp"
 +#include "mio/mmap.hpp"
+ #endif
  #include "col_names.hpp"
  #include "common.hpp"
- #include "csv_format.hpp"
 diff --git a/include/internal/common.hpp b/include/internal/common.hpp
-index f7668d8..dc42f63 100644
+index 62f27d5..16ad9f4 100644
 --- a/include/internal/common.hpp
 +++ b/include/internal/common.hpp
-@@ -86,10 +86,8 @@
+@@ -97,10 +97,8 @@
  #endif
  
  // Include string_view BEFORE csv namespace to avoid namespace pollution issues
@@ -27,7 +27,7 @@ index f7668d8..dc42f63 100644
  #endif
  
  namespace csv {
-@@ -111,7 +109,7 @@ namespace csv {
+@@ -122,7 +120,7 @@ namespace csv {
  
  #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
  
@@ -36,16 +36,3 @@ index f7668d8..dc42f63 100644
       /** @typedef string_view
        *  The string_view class used by this library.
        */
-diff --git a/include/internal/csv_reader.hpp b/include/internal/csv_reader.hpp
-index 7e66666..1382cfb 100644
---- a/include/internal/csv_reader.hpp
-+++ b/include/internal/csv_reader.hpp
-@@ -16,7 +16,7 @@
- #include <string>
- #include <vector>
- 
--#include "../external/mio.hpp"
-+#include "mio/mmap.hpp"
- #include "basic_csv_parser.hpp"
- #include "common.hpp"
- #include "data_type.hpp"

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 2422a91685d68b8fe958c28b506856af0648725ea6de8b6c145346ef3fcbdfb1f9b42379c7fd0822bdca7f7382d1b1babf36bd6206efcf006b2b50ad4518ed9e
+    SHA512 197d815ce9a30ba6caee4defa8bc818ca9c329649f220317da9e8b5d8a5f4782b4b4d3d96cefef3e991d43d746d3723a8c7dcafaea6e770651f9a6a8aca1732c
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "2.5.2",
+  "version": "3.0.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10533,7 +10533,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "2.5.2",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b38d2a76f5455d0b0770b486dc4afe6c845e5af2",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "77aa8434a9508c5ac172056bc5969fa7786b998e",
       "version": "2.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/3.0.0
