### PR TITLE
[vmaware-vm-detection] update to 2.7.0

### DIFF
--- a/ports/vmaware-vm-detection/portfile.cmake
+++ b/ports/vmaware-vm-detection/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kernelwernel/VMAware
     REF v${VERSION}
-    SHA512 ff6bdb4c34a08df59ccedb1714ce2ade7656c3f664ed4e11b2e05f9ed4d94f608a566a93aa16784000ed0fd2cca6f34c624db27f2e3fe2f06cb48df6ec161ac3
+    SHA512 585e2918b48da4c9a01c46e35440b19b9a4b6544aeb10fb6e4439d8071a4f9da033c8f33941749480dcaa54c6d1bf4129ef0649eeef6df5a97a73fb61ea0185b
     HEAD_REF master
 )
 

--- a/ports/vmaware-vm-detection/vcpkg.json
+++ b/ports/vmaware-vm-detection/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vmaware-vm-detection",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "VM detection library",
   "homepage": "https://github.com/kernelwernel/VMAware",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10565,7 +10565,7 @@
       "port-version": 0
     },
     "vmaware-vm-detection": {
-      "baseline": "2.6.0",
+      "baseline": "2.7.0",
       "port-version": 0
     },
     "volk": {

--- a/versions/v-/vmaware-vm-detection.json
+++ b/versions/v-/vmaware-vm-detection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c414310846621a5f50b3e3cf4ce7500015434a78",
+      "version": "2.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4fd80f043c234f7a063654f1b9086f66f39f1de2",
       "version": "2.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/kernelwernel/VMAware/releases/tag/v2.7.0
