### PR TITLE
[numkong] update to 7.5.0

### DIFF
--- a/ports/numkong/export-target.patch
+++ b/ports/numkong/export-target.patch
@@ -1,36 +1,36 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index bbd1f21..f66b914 100644
+index 01a7c60..70f8ce7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -232,7 +232,7 @@ if (MSVC)
+@@ -266,7 +266,7 @@ if (MSVC)
  endif ()
- 
+
  # Enable Clang C modules for incremental compilation
 -if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 +if (FALSE)
      target_compile_options(
          numkong INTERFACE $<$<COMPILE_LANGUAGE:C>:-fmodules> $<$<COMPILE_LANGUAGE:C>:-fimplicit-module-maps>
                            $<$<COMPILE_LANGUAGE:C>:-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache>
-@@ -567,7 +567,7 @@ if (NK_BUILD_SHARED)
+@@ -601,7 +601,7 @@ if (NK_BUILD_SHARED)
          )
- 
+
          add_executable(nk_shared ${NK_SOURCES} "${CMAKE_BINARY_DIR}/emscripten_stub.c")
 -        target_include_directories(nk_shared PUBLIC "${PROJECT_SOURCE_DIR}/include")
 +        target_include_directories(nk_shared PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
- 
+
          if (NK_WASM64_)
              set_target_properties(
-@@ -613,7 +613,7 @@ if (NK_BUILD_SHARED)
+@@ -647,7 +647,7 @@ if (NK_BUILD_SHARED)
          endif ()
      else ()
          add_library(nk_shared SHARED ${NK_SOURCES})
 -        target_include_directories(nk_shared PUBLIC "${PROJECT_SOURCE_DIR}/include")
 +        target_include_directories(nk_shared PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
          set_target_properties(nk_shared PROPERTIES OUTPUT_NAME numkong)
- 
+
          # Hide all symbols by default; only NK_DYNAMIC-annotated API functions are exported.
-@@ -665,15 +665,22 @@ if (NK_BUILD_SHARED)
- 
+@@ -705,15 +705,21 @@ if (NK_BUILD_SHARED)
+
      install(
          TARGETS nk_shared
 -        ARCHIVE
@@ -38,8 +38,8 @@ index bbd1f21..f66b914 100644
 +        ARCHIVE DESTINATION lib
          BUNDLE
          FRAMEWORK
+-        LIBRARY
 +        LIBRARY DESTINATION lib
-         LIBRARY
          OBJECTS
          PRIVATE_HEADER
          PUBLIC_HEADER
@@ -53,11 +53,11 @@ index bbd1f21..f66b914 100644
 +        DESTINATION share/unofficial-numkong
      )
  endif ()
- 
-@@ -699,5 +706,4 @@ if (NK_BUILD_SHARED_TEST)
+
+@@ -756,5 +762,4 @@ if (NK_BUILD_SHARED_TEST)
      add_test(NAME nk_shared_test COMMAND nk_shared_test)
  endif ()
- 
+
 -install(DIRECTORY include/ DESTINATION include)
 -install(DIRECTORY c/ DESTINATION share/doc/${PROJECT_NAME}/src)
 +install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN *.h)

--- a/ports/numkong/export-target.patch
+++ b/ports/numkong/export-target.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dfbc4a2..92c84aa 100644
+index bbd1f21..f66b914 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -225,7 +225,7 @@ target_sources(numkong INTERFACE ${NK_SOURCES})
- target_include_directories(numkong INTERFACE "${PROJECT_SOURCE_DIR}/include")
+@@ -232,7 +232,7 @@ if (MSVC)
+ endif ()
  
  # Enable Clang C modules for incremental compilation
 -if (CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -11,7 +11,16 @@ index dfbc4a2..92c84aa 100644
      target_compile_options(
          numkong INTERFACE $<$<COMPILE_LANGUAGE:C>:-fmodules> $<$<COMPILE_LANGUAGE:C>:-fimplicit-module-maps>
                            $<$<COMPILE_LANGUAGE:C>:-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache>
-@@ -606,7 +606,7 @@ if (NK_BUILD_SHARED)
+@@ -567,7 +567,7 @@ if (NK_BUILD_SHARED)
+         )
+ 
+         add_executable(nk_shared ${NK_SOURCES} "${CMAKE_BINARY_DIR}/emscripten_stub.c")
+-        target_include_directories(nk_shared PUBLIC "${PROJECT_SOURCE_DIR}/include")
++        target_include_directories(nk_shared PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+ 
+         if (NK_WASM64_)
+             set_target_properties(
+@@ -613,7 +613,7 @@ if (NK_BUILD_SHARED)
          endif ()
      else ()
          add_library(nk_shared SHARED ${NK_SOURCES})
@@ -20,7 +29,7 @@ index dfbc4a2..92c84aa 100644
          set_target_properties(nk_shared PROPERTIES OUTPUT_NAME numkong)
  
          # Hide all symbols by default; only NK_DYNAMIC-annotated API functions are exported.
-@@ -658,15 +658,21 @@ if (NK_BUILD_SHARED)
+@@ -665,15 +665,22 @@ if (NK_BUILD_SHARED)
  
      install(
          TARGETS nk_shared
@@ -29,8 +38,8 @@ index dfbc4a2..92c84aa 100644
 +        ARCHIVE DESTINATION lib
          BUNDLE
          FRAMEWORK
--        LIBRARY
 +        LIBRARY DESTINATION lib
+         LIBRARY
          OBJECTS
          PRIVATE_HEADER
          PUBLIC_HEADER
@@ -45,7 +54,7 @@ index dfbc4a2..92c84aa 100644
      )
  endif ()
  
-@@ -692,5 +698,4 @@ if (NK_BUILD_SHARED_TEST)
+@@ -699,5 +706,4 @@ if (NK_BUILD_SHARED_TEST)
      add_test(NAME nk_shared_test COMMAND nk_shared_test)
  endif ()
  

--- a/ports/numkong/portfile.cmake
+++ b/ports/numkong/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/NumKong
     REF "v${VERSION}"
-    SHA512 e3514bd8520babdb47058c5693eb329d57053d45640f300db38a9704ecf427b40ac2f0c1f8f5c28a8feb5a8bdd38b5fb2a52577ca0ace56d47bdbbe4178b6fcf
+    SHA512 5af620701996ea1ca7df4bcada0303d4560d0f50e5a48489c30990a3991a67f2a66f7a7683ac1b5c5d7f5153864b0349b9e85c117402ec4a9b72442021f917fe
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/numkong/portfile.cmake
+++ b/ports/numkong/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/NumKong
     REF "v${VERSION}"
-    SHA512 5af620701996ea1ca7df4bcada0303d4560d0f50e5a48489c30990a3991a67f2a66f7a7683ac1b5c5d7f5153864b0349b9e85c117402ec4a9b72442021f917fe
+    SHA512 fdb0d0190890fdf802c5ec9b3164d52b5721efcdff98e33eb1cf06558b6e3c00ecfba44d22492dd9619749b77237e0d94ba366c39ee543f9ae744552faf6e2bc
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/numkong/vcpkg.json
+++ b/ports/numkong/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "numkong",
-  "version": "7.4.4",
+  "version": "7.5.0",
   "description": "NumKong (previously SimSIMD) delivers mixed-precision numerics that are often faster and more accurate than standard BLAS libraries",
   "homepage": "https://github.com/ashvardanian/NumKong",
   "license": "Apache-2.0",

--- a/ports/numkong/vcpkg.json
+++ b/ports/numkong/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "numkong",
-  "version": "7.3.0",
+  "version": "7.4.4",
   "description": "NumKong (previously SimSIMD) delivers mixed-precision numerics that are often faster and more accurate than standard BLAS libraries",
   "homepage": "https://github.com/ashvardanian/NumKong",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7069,7 +7069,7 @@
       "port-version": 0
     },
     "numkong": {
-      "baseline": "7.4.4",
+      "baseline": "7.5.0",
       "port-version": 0
     },
     "nuraft": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7069,7 +7069,7 @@
       "port-version": 0
     },
     "numkong": {
-      "baseline": "7.3.0",
+      "baseline": "7.4.4",
       "port-version": 0
     },
     "nuraft": {

--- a/versions/n-/numkong.json
+++ b/versions/n-/numkong.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "89cbd2055b8d863aef1ac063111f05a7d0ef485d",
-      "version": "7.4.4",
+      "git-tree": "60c65c4d7561b9aaaab0d8db75b9c3e0350df50e",
+      "version": "7.5.0",
       "port-version": 0
     },
     {

--- a/versions/n-/numkong.json
+++ b/versions/n-/numkong.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89cbd2055b8d863aef1ac063111f05a7d0ef485d",
+      "version": "7.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8a97a83c6a684230df214d40f82386fe3a797ac",
       "version": "7.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ashvardanian/NumKong/releases/tag/v7.5.0
