### PR TITLE
[mgtt-tinyusdz] add v0.9.1 vcpkg port via forked tinyusdz with CMake install rules

### DIFF
--- a/ports/mgtt-tinyusdz/portfile.cmake
+++ b/ports/mgtt-tinyusdz/portfile.cmake
@@ -1,0 +1,47 @@
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    message(FATAL_ERROR "tinyusdz is not supported on Emscripten")
+endif()
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO MGTheTrain/tinyusdz       
+    REF v0.9.1
+    SHA512 5c4b6bb8407940b1435a4899652d5f536afc3e7c7437e2d49c3662a8d89413efdd4e1abcfce5022eab3b8ada02d8feeabb556ecbc4b15e7405e3ba7b894d2b41
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTINYUSDZ_BUILD_TESTS=OFF
+        -DTINYUSDZ_BUILD_EXAMPLES=OFF
+        -DTINYUSDZ_BUILD_BENCHMARKS=OFF
+        -DTINYUSDZ_WITH_OPENSUBDIV=OFF
+        -DTINYUSDZ_WITH_EXR=OFF
+        -DTINYUSDZ_WITH_AUDIO=OFF
+        -DTINYUSDZ_WITH_USDMTLX=OFF
+        -DTINYUSDZ_WITH_PXR_COMPAT_API=OFF
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/tinyusdz PACKAGE_NAME tinyusdz)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Expose TINYUSDZ_INCLUDE_DIR variable for consumers using target_include_directories
+file(APPEND "${CURRENT_PACKAGES_DIR}/share/tinyusdz/tinyusdzConfig.cmake" "
+get_filename_component(_TINYUSDZ_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}/../../..\" ABSOLUTE)
+set(TINYUSDZ_INCLUDE_DIR \"\${_TINYUSDZ_PREFIX}/include/tinyusdz\")
+")
+
+# Add after vcpkg_install_copyright:
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/tinyusdz/usage"
+"tinyusdz provides the following CMake targets:\n\
+\n\
+    find_package(tinyusdz CONFIG REQUIRED)\n\
+    target_link_libraries(main PRIVATE tinyusdz::tinyusdz_static)\n\
+    target_include_directories(main PRIVATE \${TINYUSDZ_INCLUDE_DIR})\n"
+)

--- a/ports/mgtt-tinyusdz/vcpkg.json
+++ b/ports/mgtt-tinyusdz/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "mgtt-tinyusdz",
+  "version-string": "v0.9.1",
+  "description": "Tiny USDZ/USD loader and writer library (MGTheTrain fork with install rules)",
+  "homepage": "https://github.com/MGTheTrain/tinyusdz",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/tinyusdz/portfile.cmake
+++ b/ports/tinyusdz/portfile.cmake
@@ -1,0 +1,86 @@
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    message(FATAL_ERROR "tinyusdz is not supported on Emscripten")
+endif()
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lighttransport/tinyusdz
+    REF v0.9.1
+    SHA512 26093ec107e1440be1e896ba3da8e0d9196c968455332d1d6961cbe458a26cce86d18f4b22279b5775a5e029e491306346aa4796517fac7e30a6ba1ff84d2e71
+    HEAD_REF dev
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTINYUSDZ_BUILD_TESTS=OFF
+        -DTINYUSDZ_BUILD_EXAMPLES=OFF
+        -DTINYUSDZ_BUILD_BENCHMARKS=OFF
+        -DTINYUSDZ_WITH_OPENSUBDIV=OFF
+        -DTINYUSDZ_WITH_EXR=OFF
+        -DTINYUSDZ_WITH_AUDIO=OFF
+        -DTINYUSDZ_WITH_USDMTLX=OFF
+        -DTINYUSDZ_WITH_PXR_COMPAT_API=OFF
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_build()
+
+file(COPY "${SOURCE_PATH}/src/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/tinyusdz"
+    FILES_MATCHING
+    PATTERN "*.hh"
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.inc"
+)
+
+# Release lib
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(GLOB TINYUSDZ_LIB_REL
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*.lib"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/*.lib"
+    )
+    set(TINYUSDZ_LIB_FILENAME "tinyusdz_static.lib")
+else()
+    file(GLOB TINYUSDZ_LIB_REL
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*.a"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/*.a"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/*.a"
+    )
+    set(TINYUSDZ_LIB_FILENAME "libtinyusdz_static.a")
+endif()
+file(COPY ${TINYUSDZ_LIB_REL} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+# Debug lib
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(GLOB TINYUSDZ_LIB_DBG
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/*.lib"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/*.lib"
+    )
+else()
+    file(GLOB TINYUSDZ_LIB_DBG
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/*.a"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/*.a"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/*.a"
+    )
+endif()
+if(TINYUSDZ_LIB_DBG)
+    file(COPY ${TINYUSDZ_LIB_DBG} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Expose include dir as a variable — same pattern as stb/tinygltf
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/tinyusdz/tinyusdzConfig.cmake" "
+get_filename_component(_TINYUSDZ_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}/../..\" ABSOLUTE)
+set(TINYUSDZ_INCLUDE_DIR \"\${_TINYUSDZ_PREFIX}/include/tinyusdz\")
+
+add_library(tinyusdz::tinyusdz_static STATIC IMPORTED)
+set_target_properties(tinyusdz::tinyusdz_static PROPERTIES
+    IMPORTED_LOCATION \"\${_TINYUSDZ_PREFIX}/lib/${TINYUSDZ_LIB_FILENAME}\"
+    IMPORTED_LOCATION_DEBUG \"\${_TINYUSDZ_PREFIX}/debug/lib/${TINYUSDZ_LIB_FILENAME}\"
+    INTERFACE_INCLUDE_DIRECTORIES \"\${_TINYUSDZ_PREFIX}/include/tinyusdz\"
+)
+")

--- a/ports/tinyusdz/vcpkg.json
+++ b/ports/tinyusdz/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "tinyusdz",
+  "version-string": "v0.9.1",
+  "description": "Tiny USDZ/USD loader and writer library",
+  "homepage": "https://github.com/lighttransport/tinyusdz",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,5 +1,9 @@
 {
   "default": {
+    "mgtt-tinyusdz": {
+      "baseline": "v0.9.1",
+      "port-version": 0
+    },
     "tinyusdz": {
       "baseline": "v0.9.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,5 +1,9 @@
 {
   "default": {
+    "tinyusdz": {
+      "baseline": "v0.9.1",
+      "port-version": 0
+    },
     "3fd": {
       "baseline": "2.6.3",
       "port-version": 5

--- a/versions/m-/mgtt-tinyusdz.json
+++ b/versions/m-/mgtt-tinyusdz.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bc64423ddd7e431626b7b4da291c7082420db79d",
+      "version-string": "v0.9.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tinyusdz.json
+++ b/versions/t-/tinyusdz.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4107d863fc41809371c7b93f20ad6ba926773b37",
+      "version-string": "v0.9.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
