### PR TITLE
[sdl3-shadercross] Update to 3.0.0-preview2

### DIFF
--- a/ports/sdl3-shadercross/portfile.cmake
+++ b/ports/sdl3-shadercross/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_shadercross
-    REF 7b7365a86611b2a7b6462e521cf1c43a037d0970
-    SHA512 52efd2c2507d6ae874cdc177945e15494920f11148e9e9cf8da27fb5ccacb5fcbe44581005e132a84631e9d438616aa1247b7ae23f4ef1785203cdcb08af19af
+    REF 1ca46e0ef7a9e50c706e7be6ef73ce467bac3b2e
+    SHA512 61feb70137b1a8e9037b0f9113a28b1f59578d6604423ef2a66173d9772b15a001f661cb4b53b0f3be941c0178d3562b0ae4d7a7f35404b137204bdce95f537f
     HEAD_REF main
     PATCHES
         fix-directx-shader-compiler-includes.patch

--- a/ports/sdl3-shadercross/vcpkg.json
+++ b/ports/sdl3-shadercross/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3-shadercross",
-  "version": "3.0.0-preview1",
+  "version": "3.0.0-preview2",
   "description": "This is a library for translating shaders to different formats, intended for use with SDL's GPU API. It takes SPIRV or HLSL as the source and outputs DXBC, DXIL, SPIRV, MSL, or HLSL.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "directx-dxc",
-      "version>=": "2025-05-30"
+      "version>=": "2026-02-20"
     },
     {
       "name": "sdl3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9057,7 +9057,7 @@
       "port-version": 1
     },
     "sdl3-shadercross": {
-      "baseline": "3.0.0-preview1",
+      "baseline": "3.0.0-preview2",
       "port-version": 0
     },
     "sdl3-ttf": {

--- a/versions/s-/sdl3-shadercross.json
+++ b/versions/s-/sdl3-shadercross.json
@@ -3,6 +3,10 @@
     {
       "git-tree": "32add254f0076dfd47cbcd75123ca8a3079cb71c",
       "version": "3.0.0-preview2",
+    },
+    {
+      "git-tree": "f0ef26c4b7d241bd684718c7884fe944426b2d56",
+      "version": "3.0.0-preview1",
       "port-version": 0
     }
   ]

--- a/versions/s-/sdl3-shadercross.json
+++ b/versions/s-/sdl3-shadercross.json
@@ -1,8 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "32add254f0076dfd47cbcd75123ca8a3079cb71c",
+      "git-tree": "50bcb42fe8f4356bcd5987cca2ec50c83b8d5132",
       "version": "3.0.0-preview2",
+      "port-version": 0
     },
     {
       "git-tree": "f0ef26c4b7d241bd684718c7884fe944426b2d56",

--- a/versions/s-/sdl3-shadercross.json
+++ b/versions/s-/sdl3-shadercross.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "f0ef26c4b7d241bd684718c7884fe944426b2d56",
-      "version": "3.0.0-preview1",
+      "git-tree": "32add254f0076dfd47cbcd75123ca8a3079cb71c",
+      "version": "3.0.0-preview2",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.