### PR TITLE
[ltla-subpar] Devendor ltla-sanisizer

### DIFF
--- a/ports/ltla-subpar/portfile.cmake
+++ b/ports/ltla-subpar/portfile.cmake
@@ -11,6 +11,7 @@ set(VCPKG_BUILD_TYPE "release") # header-only port
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DSUBPAR_FETCH_EXTERN=OFF
         -DSUBPAR_TESTS=OFF
 )
 

--- a/ports/ltla-subpar/vcpkg.json
+++ b/ports/ltla-subpar/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/LTLA/subpar",
   "license": "MIT",
   "dependencies": [
+    "ltla-sanisizer",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/ltla-subpar/vcpkg.json
+++ b/ports/ltla-subpar/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ltla-subpar",
   "version": "0.5.0",
+  "port-version": 1,
   "description": "Substitutable parallelization for C++ libraries",
   "homepage": "https://github.com/LTLA/subpar",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6142,7 +6142,7 @@
     },
     "ltla-subpar": {
       "baseline": "0.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "lua": {
       "baseline": "5.5.0",

--- a/versions/l-/ltla-subpar.json
+++ b/versions/l-/ltla-subpar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad40a730ac08bcfe57d79ac15abee29c43a599a7",
+      "version": "0.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f3c5c760fb88925c2939b64196349cb92d1b9510",
       "version": "0.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Might help with CI build failures in https://github.com/microsoft/vcpkg/pull/50497 where `ltla-powerit` does not build. `ltla-powerit` depends on `ltla-subpar` which in turn cannot find `ltla_sanisizer` correctly.