### PR TITLE
[dingo] Update to 0.2.0

### DIFF
--- a/ports/dingo/portfile.cmake
+++ b/ports/dingo/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     REPO romanpauk/dingo
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 9fb6cf64b1a9ee99404d69d9756530c9ffc591116579469ad39b5fa458a127628899bcac4e99a9bedaf7cae6c19c1a0e5816043868e9daf6d60858a1c2e17c0b
+    SHA512 d40def7e3f28675dd399703f0f5890822503e5b8dcfcd96628010dc9854b61dbac9e3cb863740a40744abca0eae3ad69c21b3c17202c5d68cc17a22faab9830c
 )
 
 vcpkg_cmake_configure(

--- a/ports/dingo/vcpkg.json
+++ b/ports/dingo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dingo",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Dependency Injection Container for C++",
   "homepage": "https://github.com/romanpauk/dingo",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2473,7 +2473,7 @@
       "port-version": 0
     },
     "dingo": {
-      "baseline": "0.1.2",
+      "baseline": "0.2.0",
       "port-version": 0
     },
     "directfb2": {

--- a/versions/d-/dingo.json
+++ b/versions/d-/dingo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82cd328a2251c7e780bc4cb2f19d03f47ce76c02",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5762d703e83829ef813621103d0ca080820a08c",
       "version": "0.1.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.