### PR TITLE
[vcpkg-ci-duktape] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-duktape/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-duktape/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-duktape/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-duktape/portfile.cmake
@@ -1,4 +1,10 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
 vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-duktape/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-duktape/project/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(vcpkg_ci_duktape)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(unofficial-duktape CONFIG REQUIRED)
+
+add_executable(vcpkg_ci_duktape main.cpp)
+target_link_libraries(vcpkg_ci_duktape PRIVATE unofficial::duktape::duktape)

--- a/scripts/test_ports/vcpkg-ci-duktape/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-duktape/project/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(vcpkg_ci_duktape PRIVATE unofficial::duktape::duktape)
 ################################################################################
 #                                Use pkg-config                                #
 ################################################################################
-find_package(PkgConfig)
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(duktape REQUIRED IMPORTED_TARGET duktape)
 add_executable(vcpkg_ci_duktape_pc main.cpp)
 target_link_libraries(vcpkg_ci_duktape_pc PRIVATE PkgConfig::duktape)

--- a/scripts/test_ports/vcpkg-ci-duktape/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-duktape/project/CMakeLists.txt
@@ -3,7 +3,17 @@ project(vcpkg_ci_duktape)
 
 set(CMAKE_CXX_STANDARD 17)
 
+################################################################################
+#                              Use cmake config                                #
+################################################################################
 find_package(unofficial-duktape CONFIG REQUIRED)
-
 add_executable(vcpkg_ci_duktape main.cpp)
 target_link_libraries(vcpkg_ci_duktape PRIVATE unofficial::duktape::duktape)
+
+################################################################################
+#                                Use pkg-config                                #
+################################################################################
+find_package(PkgConfig)
+pkg_check_modules(duktape REQUIRED IMPORTED_TARGET duktape)
+add_executable(vcpkg_ci_duktape_pc main.cpp)
+target_link_libraries(vcpkg_ci_duktape_pc PRIVATE PkgConfig::duktape)

--- a/scripts/test_ports/vcpkg-ci-duktape/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-duktape/project/main.cpp
@@ -1,4 +1,4 @@
-#include "duk_bridge.h"
+#include "duktape.h"
 #include <cassert>
 #include <iostream>
 

--- a/scripts/test_ports/vcpkg-ci-duktape/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-duktape/project/main.cpp
@@ -1,4 +1,4 @@
-#include "duktape.h"
+#include <duktape.h>
 #include <cassert>
 #include <iostream>
 

--- a/scripts/test_ports/vcpkg-ci-duktape/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-duktape/project/main.cpp
@@ -1,0 +1,14 @@
+#include "duk_bridge.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    duk_context *ctx = duk_create_heap(nullptr, nullptr, nullptr, nullptr, nullptr);
+    duk_eval_string(ctx, "function add(a, b) { return a + b; }");
+    duk_eval_string(ctx, "add(1, 2)");
+    int ret = duk_get_int(ctx, -1);
+    std::cout << "add(1, 2) == " << ret << std::endl;
+    assert(ret == 3);
+    duk_destroy_heap(ctx);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-duktape/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-duktape/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "vcpkg-ci-duktape",
-  "version-date": "2026-04-07",
+  "version-string": "ci",
   "description": "Validates duktape",
-  "license": null,
   "dependencies": [
     "duktape",
     {

--- a/scripts/test_ports/vcpkg-ci-duktape/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-duktape/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "vcpkg-ci-duktape",
+  "version-date": "2026-04-07",
+  "description": "Validates duktape",
+  "license": null,
+  "dependencies": [
+    "duktape",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

