### PR TITLE
[tofupilot] Add new port (v2.0.0)

### DIFF
--- a/ports/tofupilot/portfile.cmake
+++ b/ports/tofupilot/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tofupilot/cpp
+    REF v${VERSION}
+    SHA512 733ed3489162ca339586a5d2ba069d974e5bbe44f59c6ef135266827386d66d0cf6b98bcca2274752c1b490f95ca4647474236d9a7bbe34a5b8c33572389fd23
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME tofupilot CONFIG_PATH lib/cmake/tofupilot)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tofupilot/vcpkg.json
+++ b/ports/tofupilot/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "tofupilot",
+  "version": "2.0.0",
+  "description": "Official C++ SDK for TofuPilot test & measurement platform",
+  "homepage": "https://github.com/tofupilot/cpp",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "cpp-httplib",
+      "features": [
+        "openssl"
+      ]
+    },
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10120,6 +10120,10 @@
       "baseline": "2024-09-10",
       "port-version": 0
     },
+    "tofupilot": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "toml11": {
       "baseline": "4.4.0",
       "port-version": 0

--- a/versions/t-/tofupilot.json
+++ b/versions/t-/tofupilot.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "52e9ce2541908fe0fffab30f2aa9d726f476356b",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## New port: tofupilot

**Version:** 2.0.0  
**Homepage:** https://github.com/tofupilot/cpp  
**License:** MIT  
**Supports:** All platforms except UWP

### Description

Official C++ SDK for the [TofuPilot](https://tofupilot.com) test & measurement platform. Header-only library providing a typed, synchronous REST API client with builder-pattern operations, automatic retries with exponential backoff, and a comprehensive error hierarchy.

### Dependencies

- `nlohmann-json`
- `cpp-httplib` (with OpenSSL)
- `vcpkg-cmake` (host)
- `vcpkg-cmake-config` (host)