### PR TITLE
[rego-cpp] Add new port (version 1.3.1)

### DIFF
--- a/ports/rego-cpp/portfile.cmake
+++ b/ports/rego-cpp/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/rego-cpp
+    REF "v${VERSION}"
+    SHA512 76bdec6d86b4192290e3f140068216a11d65d49f34cabb44bf775a0385e4ac8281390a4f4e89ad636c6ef417feac71a0004894f76e9462f4764e1a3d1379937b
+    HEAD_REF main
+)
+
+# NOTE: The CI overlay port (see .github/workflows/pr_gate.yml,
+# vcpkg-integration) uses sed to extract from the "if" line below onwards to
+# build a portfile that points at the local checkout. If you reorder code above
+# this line, update the sed pattern there.
+if("openssl3" IN_LIST FEATURES)
+  set(CRYPTO_BACKEND "openssl3")
+else()
+  set(CRYPTO_BACKEND "")
+endif()
+
+if("tools" IN_LIST FEATURES)
+  set(BUILD_TOOLS ON)
+else()
+  set(BUILD_TOOLS OFF)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DREGOCPP_USE_FETCH_CONTENT=OFF
+        -DREGOCPP_BUILD_TOOLS=${BUILD_TOOLS}
+        -DREGOCPP_BUILD_TESTS=OFF
+        -DREGOCPP_BUILD_DOCS=OFF
+        -DREGOCPP_USE_SNMALLOC=OFF
+        -DREGOCPP_CRYPTO_BACKEND=${CRYPTO_BACKEND}
+)
+
+vcpkg_cmake_install()
+
+if("tools" IN_LIST FEATURES)
+  vcpkg_copy_tools(TOOL_NAMES rego AUTO_CLEAN)
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME regocpp CONFIG_PATH share/regocpp/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/rego-cpp/usage
+++ b/ports/rego-cpp/usage
@@ -1,0 +1,8 @@
+rego-cpp provides CMake targets:
+
+    find_package(regocpp CONFIG REQUIRED)
+    target_link_libraries(<your-target> PRIVATE regocpp::rego)
+
+When installed with the "tools" feature, the rego CLI is available at:
+
+    $(vcpkg_installed)/<triplet>/tools/rego-cpp/rego

--- a/ports/rego-cpp/vcpkg.json
+++ b/ports/rego-cpp/vcpkg.json
@@ -1,0 +1,38 @@
+{
+  "name": "rego-cpp",
+  "version": "1.3.1",
+  "description": "A C++ interpreter for the OPA Rego policy language",
+  "homepage": "https://github.com/microsoft/rego-cpp",
+  "license": "MIT",
+  "supports": "!x86",
+  "dependencies": [
+    {
+      "name": "trieste",
+      "features": [
+        "parsers"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "openssl3": {
+      "description": "Enable crypto/JWT builtins using OpenSSL 3",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.0.2"
+        }
+      ]
+    },
+    "tools": {
+      "description": "Build and install the rego command-line interpreter"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8672,6 +8672,10 @@
       "baseline": "2022-12-07",
       "port-version": 0
     },
+    "rego-cpp": {
+      "baseline": "1.3.1",
+      "port-version": 0
+    },
     "rendergraph": {
       "baseline": "2.1.0",
       "port-version": 0

--- a/versions/r-/rego-cpp.json
+++ b/versions/r-/rego-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e20af4cc2ce3b012c7a39dcf669fe049d5fed86a",
+      "version": "1.3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="927" height="1151" alt="image" src="https://github.com/user-attachments/assets/ec8c0f96-fb37-4963-bbea-6e18aab1bcb1" />
