### PR TITLE
[nxpp] add new port

### DIFF
--- a/ports/nxpp/portfile.cmake
+++ b/ports/nxpp/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Mik1810/nxpp
+    REF v1.0.1
+    SHA512 107a7878989981819dcd606c0a824ec3f1e4b4416456a4c7e7520c72537e6cb25a8249418b29158cd0195a52c8fe0d5de36ab809dcabfb9312fd2d30ac39b383
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DNXPP_BUILD_TESTS=OFF
+        -DNXPP_BUILD_SMOKE_TESTS=OFF
+        -DNXPP_BUILD_LARGE_GRAPH_COMPARE=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME nxpp CONFIG_PATH lib/cmake/nxpp)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/debug"
+)
+
+file(INSTALL
+    "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    RENAME copyright
+)

--- a/ports/nxpp/vcpkg.json
+++ b/ports/nxpp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "nxpp",
+  "version-semver": "1.0.1",
+  "description": "Header-only C++20 graph library on top of Boost Graph Library",
+  "homepage": "https://github.com/Mik1810/nxpp",
+  "license": "MIT",
+  "dependencies": [
+    "boost-graph",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7100,6 +7100,10 @@
       "baseline": "2.1.2",
       "port-version": 9
     },
+    "nxpp": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "nyan-lang": {
       "baseline": "0.3.1",
       "port-version": 0

--- a/versions/n-/nxpp.json
+++ b/versions/n-/nxpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "965b416cf7d1cc705f87f8d6ca95339ca12c4e48",
+      "version-semver": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new header-only port for `nxpp` based on the `v1.0.1` source tag.

Summary:
- adds `ports/nxpp/portfile.cmake`
- adds `ports/nxpp/vcpkg.json`
- adds versioning entries under `versions/`

Validation performed locally:
- `vcpkg install nxpp --overlay-ports=/tmp/vcpkg-upstream/ports`
- external CMake consumer using:
  - `find_package(nxpp CONFIG REQUIRED)`
  - `target_link_libraries(... PRIVATE nxpp::nxpp)`

`nxpp` is a header-only C++20 graph library built on top of Boost Graph Library.
