### PR TITLE
[wayland] Update to 1.25.0

### DIFF
--- a/ports/wayland/portfile.cmake
+++ b/ports/wayland/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wayland/wayland
     REF  ${VERSION}
-    SHA512 454a4d7cab9fb9eafe3505114e9dfafed94c985fb7f156eb2d67f258bf2bf8418598ab75c237aa75fabe81a811981dbc72363870f2f81ddcbfb3adfaa95d4947
+    SHA512 24c8cb42598d0d0d78831b200630cb2254c81241661b7977f30d4d733f6efceac91768784db64d0991e2044adf04049a6d3f5b27a5d9ceab8605dd89589abb68
     HEAD_REF master
     PATCHES
         cross-build.diff

--- a/ports/wayland/vcpkg.json
+++ b/ports/wayland/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wayland",
-  "version": "1.23.1",
+  "version": "1.25.0",
   "description": "Core Wayland window system code and protocol",
   "homepage": "https://wayland.freedesktop.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10713,7 +10713,7 @@
       "port-version": 0
     },
     "wayland": {
-      "baseline": "1.23.1",
+      "baseline": "1.25.0",
       "port-version": 0
     },
     "wayland-protocols": {

--- a/versions/w-/wayland.json
+++ b/versions/w-/wayland.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3a3a7b35b73fc9b2b8bca3a8050a3a5e19c924e",
+      "git-tree": "8a7a61298eab57084fa6a490268ea0e76b237950",
       "version": "1.25.0",
       "port-version": 0
     },

--- a/versions/w-/wayland.json
+++ b/versions/w-/wayland.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3a3a7b35b73fc9b2b8bca3a8050a3a5e19c924e",
+      "version": "1.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "15e4d3bdaff7f31a3e77ad8df8ea405705388db0",
       "version": "1.23.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
