### PR TITLE
[ffmpeg] Fix ncrypt library resolution for windows target

### DIFF
--- a/ports/ffmpeg/FindFFMPEG.cmake.in
+++ b/ports/ffmpeg/FindFFMPEG.cmake.in
@@ -55,7 +55,7 @@ function(append_dependencies out)
     endif()
     set(pass_through
         ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}
-        advapi32 bcrypt crypt32 gdi32 mfuuid ole32 oleaut32 psapi secur32 shlwapi strmiids user32 uuid vfw32 ws2_32 usp10 cfgmgr32 rpcrt4
+        advapi32 bcrypt crypt32 gdi32 mfuuid ncrypt ole32 oleaut32 psapi secur32 shlwapi strmiids user32 uuid vfw32 ws2_32 usp10 cfgmgr32 rpcrt4
         -pthread -pthreads pthread atomic m
     )
     cmake_policy(SET CMP0057 NEW)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "8.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3002,7 +3002,7 @@
     },
     "ffmpeg": {
       "baseline": "8.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ffmpeg-bin2c": {
       "baseline": "8.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aeae74ea92c2de847098317487ff646c77c9f28f",
+      "version": "8.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "a084a0a06b57f2e7f4e50fdfda2855fa0a16c48e",
       "version": "8.1",
       "port-version": 1


### PR DESCRIPTION
Starting FFMpeg 8.0+ a new library is requested while building FFMpeg if openssl is not used. When it is not, `schannel` is enabled by default ( https://github.com/microsoft/vcpkg/blob/master/ports/ffmpeg/portfile.cmake#L423-L433 ) which pulls `ncrypt` ( https://github.com/FFmpeg/FFmpeg/blob/master/configure#L7617-L7623 ).

Unfortunately the library though is not whitelisted in `FindFFmpeg.cmake` ( https://github.com/microsoft/vcpkg/blob/master/ports/ffmpeg/FindFFMPEG.cmake.in#L58-L59 ) so it goes through `find_library` and fails to resolve, when attempted to be used in a project via `find_package(FFMPEG REQUIRED)`.

This PR addresses that by adding `ncrypt` into the `pass_through` list.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.