### PR TITLE
[poppler] update to 26.4.0

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(FIX_UPSTREAM_0ad9529
+    URLS https://github.com/OSGeo/gdal/commit/0ad9529d5fd5e03880147221d56bfee08383d7dc.patch?full_index=1
+    SHA512 0a022e350d9a1a4f0a218bbfbc09dca2e521e42e0af57f8e4797c74b9d96d777f73807b86fa04606c7d2d67e5a75fc0975d9948e2d5e0fdb1ce5a9ea587119c3
+    FILENAME gdal-0ad9529d5fd5e03880147221d56bfee08383d7dc.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/gdal
@@ -7,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         find-link-libraries.patch
         fix-gdal-target-interfaces.patch
+        "${FIX_UPSTREAM_0ad9529}"
         iconv.diff
         libkml.patch
         sqlite3.diff

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.12.3",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
     REF "poppler-${POPPLER_VERSION}"
-    SHA512 24184d73503c77d614b20d8a2c2f8d77e40fd445ea2ceabdc5b77b5241ed45e053cc582af563284b1c9fd585bde3af5695cfe8fceff2efaf380499fb5f620f8c
+    SHA512 f7385776fc96044eda16d67ef5bf9fcd3ff593bcac4c2860f0f6dc48a136e6d5dac1ed61f031210f51838d6b2f3bc281a768cefc332e6cb6fda781ebaa428d4a
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poppler",
-  "version": "25.7.0",
+  "version": "26.4.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3310,7 +3310,7 @@
     },
     "gdal": {
       "baseline": "3.12.3",
-      "port-version": 0
+      "port-version": 1
     },
     "gdbm": {
       "baseline": "1.24",
@@ -7837,7 +7837,7 @@
       "port-version": 0
     },
     "poppler": {
-      "baseline": "25.7.0",
+      "baseline": "26.4.0",
       "port-version": 0
     },
     "poppler-data": {

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d0d81ab4c0422b07ee04fbfbfe36c1ec0dc5d5a",
+      "version-semver": "3.12.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "a6bd9594728015e96a114c21238029a9bd152a54",
       "version-semver": "3.12.3",
       "port-version": 0

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a438b58ac614393496ca68741f285adaed245289",
+      "version": "26.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c73865a02ec6e51f9510a24114e27ad9a0720d23",
       "version": "25.7.0",
       "port-version": 0


### PR DESCRIPTION
~Depends on https://github.com/microsoft/vcpkg/pull/51124~

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

~Depends on https://github.com/microsoft/vcpkg/pull/51124~