### PR TITLE
Upgrade Log4cxx to 1.7.0

### DIFF
--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_extract_source_archive(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         qt        LOG4CXX_QT_SUPPORT
+        qt6       LOG4CXX_QT_SUPPORT
         fmt       ENABLE_FMT_LAYOUT
         fmt       ENABLE_FMT_ASYNC
         fmt       VCPKG_LOCK_FIND_PACKAGE_fmt

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/logging/log4cxx/${VERSION}/apache-log4cxx-${VERSION}.tar.gz"
     FILENAME "apache-log4cxx-${VERSION}.tar.gz"
-    SHA512 6ee406314bd7ab02a46c98cc8a0d5ad5aec8928a23716a81a152775ca315cd3b950d600b2e221d5b4a88416ae9bbda1215fae43626107feea4df2f3e074303ad
+    SHA512 0e94946457423689af6d85074ab97b717e0cec85a4f548e6650b060e8f98b780f980b7d4a7780410fa64681376fb4bc62fab6ed9068fc944e07f9f32ac0413af
 )
 
 vcpkg_extract_source_archive(

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -11,7 +11,6 @@ vcpkg_extract_source_archive(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         qt        LOG4CXX_QT_SUPPORT
-        qt6       LOG4CXX_QT_SUPPORT
         fmt       ENABLE_FMT_LAYOUT
         fmt       ENABLE_FMT_ASYNC
         fmt       VCPKG_LOCK_FIND_PACKAGE_fmt

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "log4cxx",
-  "version": "1.6.1",
-  "port-version": 1,
+  "version": "1.7.0",
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",
@@ -34,6 +33,15 @@
       "dependencies": [
         {
           "name": "qt5-base",
+          "default-features": false
+        }
+      ]
+    },
+    "qt6": {
+      "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
+      "dependencies": [
+        {
+          "name": "qtbase",
           "default-features": false
         }
       ]

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -32,15 +32,6 @@
       "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
       "dependencies": [
         {
-          "name": "qt5-base",
-          "default-features": false
-        }
-      ]
-    },
-    "qt6": {
-      "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
-      "dependencies": [
-        {
           "name": "qtbase",
           "default-features": false
         }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6101,8 +6101,8 @@
       "port-version": 0
     },
     "log4cxx": {
-      "baseline": "1.6.1",
-      "port-version": 1
+      "baseline": "1.7.0",
+      "port-version": 0
     },
     "logme": {
       "baseline": "2.4.14",

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff79bc9d3882ee12ae5613c6af0c172ad7df367f",
+      "git-tree": "daf90f7b7ad960ae47322d5b339725c7980972c9",
       "version": "1.7.0",
       "port-version": 0
     },

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "daf90f7b7ad960ae47322d5b339725c7980972c9",
+      "git-tree": "5cd7c09e1cb7f87e7d8d1b42cf6d2b0848a0b12e",
       "version": "1.7.0",
       "port-version": 0
     },

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff79bc9d3882ee12ae5613c6af0c172ad7df367f",
+      "version": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5c8b00c1fc97b2cd862922240686dc170692226c",
       "version": "1.6.1",
       "port-version": 1


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.
