### PR TITLE
[mongo-c-driver, libbson] update to 2.2.4

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 faa03472f646f724b10192540eaaac931f74d7c5b7f2a717b6d6f274a5ab4f2bf088b601d8d5947ae23688e225dd352f335c0234866ada080d3ad7b9190b2ac8
+    SHA512 5864963832dc89928de209da9b41b835b4e25e645d4b8934b132111e5d5c7950e4868de0633a4f03bc4b54318466f319c6591be5d840d329f0c527ef455f64ed
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 faa03472f646f724b10192540eaaac931f74d7c5b7f2a717b6d6f274a5ab4f2bf088b601d8d5947ae23688e225dd352f335c0234866ada080d3ad7b9190b2ac8
+    SHA512 5864963832dc89928de209da9b41b835b4e25e645d4b8934b132111e5d5c7950e4868de0633a4f03bc4b54318466f319c6591be5d840d329f0c527ef455f64ed
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4721,7 +4721,7 @@
       "port-version": 0
     },
     "libbson": {
-      "baseline": "2.2.3",
+      "baseline": "2.2.4",
       "port-version": 0
     },
     "libcaer": {
@@ -6577,7 +6577,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "2.2.3",
+      "baseline": "2.2.4",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f167bcbb9702bdbf1c782162d7339366417ba65",
+      "version": "2.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "71cd0509bc2b4c201d2bdaeccb0b3c6d614b67c6",
       "version": "2.2.3",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b399e3fa4475cea6d2b2e7ce465a522e5a6547e9",
+      "version": "2.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ca6eaaa2c2ef07fa057949aeaba18c91a80814f",
       "version": "2.2.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/mongodb/mongo-c-driver/releases/tag/2.2.4
