### PR TITLE
[vincentlaucsb-csv-parser] update to 3.1.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 197d815ce9a30ba6caee4defa8bc818ca9c329649f220317da9e8b5d8a5f4782b4b4d3d96cefef3e991d43d746d3723a8c7dcafaea6e770651f9a6a8aca1732c
+    SHA512 409edec53974ba0358932739bf0872ed98e77f402638712e3b44ec6b8a9f1acf8129f27edc8b64129a8f311ac55e29726c58c6e03256c0f67389195195972ad9
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10545,7 +10545,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "3.0.0",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "748651a72b9c64327ed2373d390599bd91988e4a",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b38d2a76f5455d0b0770b486dc4afe6c845e5af2",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/3.1.0
