### PR TITLE
[gegl] update to 0.4.70

### DIFF
--- a/ports/gegl/portfile.cmake
+++ b/ports/gegl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS https://download.gimp.org/pub/gegl/${VERSION_MAJOR_MINOR}/gegl-${VERSION}.tar.xz
     FILENAME "gegl-${VERSION}.tar.xz"
-    SHA512 e13b1885b0cd6aa439cdb7c1d56b81c754d41da1af6ed17eab3e1beb7b7fe74094e0da9d8bacaea9ec5d4ec95eea682cf4764ea828bda4a7d7acec9b273c537e
+    SHA512 9f47480dc2fad58c052aa3df3ac914d500614e7acb0dc46677bea4228350a00a0fe38b5b0572303251210e3e544b5b7cb51415476586630df4da8f4b7c6486d8
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gegl/remove-consistency-check.patch
+++ b/ports/gegl/remove-consistency-check.patch
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index 083bc7afd..a2ecde108 100644
+index c8ef26f..eecee7a 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -661,7 +661,7 @@ subdir('po')
+@@ -660,7 +660,7 @@ subdir('po')
  subdir('docs')
  
  
 -if not os_osx and host_cpu_family != 'x86'
 +if false
+   nm = find_program('nm', required: false)
+ 
    # Verify .def files for Windows linking.
-   # We check this on non-Windows platform on CI, and on Windows itself.
-   custom_target('check-def-files',

--- a/ports/gegl/vcpkg.json
+++ b/ports/gegl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gegl",
-  "version": "0.4.68",
+  "version": "0.4.70",
   "description": "Generic Graphical Library.",
   "homepage": "https://gegl.org/",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3325,7 +3325,7 @@
       "port-version": 6
     },
     "gegl": {
-      "baseline": "0.4.68",
+      "baseline": "0.4.70",
       "port-version": 0
     },
     "gemmlowp": {

--- a/versions/g-/gegl.json
+++ b/versions/g-/gegl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24ef813e729c2db7af765cf5c0aa2a3fe4fddd4b",
+      "version": "0.4.70",
+      "port-version": 0
+    },
+    {
       "git-tree": "b956e19006098c3cc95946dcb8697736daaf3c5b",
       "version": "0.4.68",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/GNOME/gegl/releases/tag/GEGL_0_4_70
