### PR TITLE
[libstemmer] update to 3.0.1

### DIFF
--- a/ports/libstemmer/portfile.cmake
+++ b/ports/libstemmer/portfile.cmake
@@ -4,7 +4,7 @@ string(SUBSTRING "${VERSION}" 5 -1 VERSION)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://snowballstem.org/dist/libstemmer_c-${VERSION}.tar.gz"
     FILENAME "libstemmer_c-${VERSION}.tar.gz"
-    SHA512 a61a06a046a6a5e9ada12310653c71afb27b5833fa9e21992ba4bdf615255de991352186a8736d0156ed754248a0ffb7b7712e8d5ea16f75174d1c8ddd37ba4a
+    SHA512 6b76a94fd5bdb557c041c937bdfc1887927346a87c987fe3b964a7286e176543b578729e9d7ed97b521faee0d8b484df1aa9be23522b191a87f3a65dc12c5f15
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libstemmer/vcpkg.json
+++ b/ports/libstemmer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libstemmer",
-  "version": "2021.2.2.0",
+  "version": "2025.3.0.1",
   "description": "Snowball is a small string processing language designed for creating stemming algorithms for use in Information Retrieval",
   "homepage": "https://snowballstem.org/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5645,7 +5645,7 @@
       "port-version": 2
     },
     "libstemmer": {
-      "baseline": "2021.2.2.0",
+      "baseline": "2025.3.0.1",
       "port-version": 0
     },
     "libstk": {

--- a/versions/l-/libstemmer.json
+++ b/versions/l-/libstemmer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dce91db02275f9973a04b46e52c4147d84bec94b",
+      "version": "2025.3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "121970e398a11c25667cd1393158fb76a105ba9b",
       "version": "2021.2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/snowballstem/snowball/releases/tag/v3.0.1
