### PR TITLE
[qoi] update to 2025-05-09

### DIFF
--- a/ports/qoi/portfile.cmake
+++ b/ports/qoi/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO phoboslab/qoi
-    REF 19b3b4087b66963a3699ee45f05ec9ef205d7c0e # committed on 2023-08-10
-    SHA512 8131031ba4b3b3c50838eb83db44bed0bf2e3fc820f18a9e48202801aebef4179f9b465354487070d7bc1feea79461abe581eecde00d61a21e27fe2b8a52699f
+    REF 4461cc37ef08b24f157a5ab7c3f7d6c9e6caa6c0 # committed on 2025-05-09
+    SHA512 ab3f8e0e6a02e9e481e4d44a1b7809360ad013e25c8c58e84ea0ea03317dd5fc0acc26f7a30ac226714c45cc9dabe45f979dd7a4b0571ae5c6051f4bb0db6d9f
     HEAD_REF master
 )
 

--- a/ports/qoi/vcpkg.json
+++ b/ports/qoi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qoi",
-  "version-date": "2023-08-10",
+  "version-date": "2025-05-09",
   "description": "The Quite OK Image Format for fast, lossless image compression",
   "homepage": "https://qoiformat.org/",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8069,7 +8069,7 @@
       "port-version": 5
     },
     "qoi": {
-      "baseline": "2023-08-10",
+      "baseline": "2025-05-09",
       "port-version": 0
     },
     "qoixx": {

--- a/versions/q-/qoi.json
+++ b/versions/q-/qoi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5eca25f8c2ff18993ef2475b2f2eb3f31b9331c",
+      "version-date": "2025-05-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "2501f06dad0450b48676652e4f8b053071f874fb",
       "version-date": "2023-08-10",
       "port-version": 0


### PR DESCRIPTION
This version have 1.4% faster encoding

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
