### PR TITLE
[orc] update to 2.3.0

### DIFF
--- a/ports/orc/external-project.diff
+++ b/ports/orc/external-project.diff
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 341a4c3..1aaff3e 100644
+index d96e559..1123c35 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -112,6 +112,13 @@ SET(CPACK_PACKAGE_CONTACT "Apache ORC <dev@orc.apache.org>")
+@@ -103,6 +103,14 @@ SET(CPACK_SOURCE_GENERATOR "TGZ")
+ SET(CPACK_PACKAGE_VENDOR "Apache ORC")
+ SET(CPACK_PACKAGE_CONTACT "Apache ORC <dev@orc.apache.org>")
  
- INCLUDE(CPack)
- INCLUDE(ExternalProject)
 +function(ExternalProject_Add name)
 +  z_vcpkg_function_arguments(args 1)
 +  if(NOT "${name}" MATCHES "^orc-format")
@@ -13,14 +13,15 @@ index 341a4c3..1aaff3e 100644
 +  endif()
 +  _ExternalProject_Add(${name} "${args}")
 +endfunction()
- 
- if (BUILD_POSITION_INDEPENDENT_LIB)
-   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
++
+ # Compiler specific flags
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
-index 851cdc4..a23115e 100644
+index c03afa8..fa7e9bc 100644
 --- a/cmake_modules/ThirdpartyToolchain.cmake
 +++ b/cmake_modules/ThirdpartyToolchain.cmake
-@@ -397,7 +397,7 @@ add_library (orc::lz4 ALIAS orc_lz4)
+@@ -588,7 +588,7 @@ add_library (orc::lz4 ALIAS orc_lz4)
  # ----------------------------------------------------------------------
  # IANA - Time Zone Database
  
@@ -28,4 +29,4 @@ index 851cdc4..a23115e 100644
 +if (WIN32 AND BUILD_CPP_TESTS)
    SET(CURRENT_TZDATA_FILE "")
    SET(CURRENT_TZDATA_SHA512 "")
-   File(DOWNLOAD "https://ftp.osuosl.org/pub/cygwin/noarch/release/tzdata/sha512.sum" ${CMAKE_CURRENT_BINARY_DIR}/sha512.sum)
+   File(DOWNLOAD "https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-right/sha512.sum" ${CMAKE_CURRENT_BINARY_DIR}/sha512.sum)

--- a/ports/orc/portfile.cmake
+++ b/ports/orc/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/orc/orc-${VERSION}/orc-${VERSION}.tar.gz"
     FILENAME "orc-${VERSION}.tar.gz"
-    SHA512 6be97bf80ca89765bfecdb7d24b7f2967af79f2cbf659ce835ab9345e2a356400942143f4c6b3c25e6ded1f5df811bd6be6d1005e8b99716d842b43072f61786
+    SHA512 88dce434497806b3239e8310ce8c3a21bc858f3ac20130c68c682b4c457bcdb039b399ed367be5feae81ca32bb8db673839d52cd0918c6d8e00fe1ab1b0c7f68
 )
 
 vcpkg_extract_source_archive(

--- a/ports/orc/tools-build.diff
+++ b/ports/orc/tools-build.diff
@@ -1,55 +1,8 @@
 diff --git a/tools/src/CMakeLists.txt b/tools/src/CMakeLists.txt
-index d247f90..498d369 100644
+index 81e2da6..3987bb3 100644
 --- a/tools/src/CMakeLists.txt
 +++ b/tools/src/CMakeLists.txt
-@@ -36,8 +36,12 @@
- 
- set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${CXX17_FLAGS} ${WARN_FLAGS}")
- 
--add_library (orc-tools-common INTERFACE)
--target_include_directories (orc-tools-common INTERFACE
-+add_library (orc-tools-common STATIC ToolsHelper.cc)
-+if(WIN32 AND NOT MINGW)
-+  find_package(getopt CONFIG REQUIRED)
-+  target_link_libraries(orc-tools-common PUBLIC $<IF:$<TARGET_EXISTS:getopt::getopt_shared>,getopt::getopt_shared,getopt::getopt_static>)
-+endif()
-+target_include_directories (orc-tools-common PUBLIC
-   ${PROJECT_BINARY_DIR}/c++/include
-   ${PROJECT_BINARY_DIR}/c++/src
-   ${PROJECT_SOURCE_DIR}/c++/include
-@@ -50,7 +54,6 @@ target_link_libraries (orc-tools-common INTERFACE
- 
- add_executable (orc-contents
-   FileContents.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-contents
-@@ -59,7 +62,6 @@ target_link_libraries (orc-contents
- 
- add_executable (orc-scan
-   FileScan.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-scan
-@@ -68,7 +70,6 @@ target_link_libraries (orc-scan
- 
- add_executable (orc-metadata
-   FileMetadata.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-metadata
-@@ -86,7 +87,6 @@ target_link_libraries (orc-statistics
- 
- add_executable (orc-memory
-   FileMemory.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-memory
-@@ -108,6 +108,14 @@ add_executable (csv-import
+@@ -98,6 +98,14 @@ add_executable (csv-import
  target_link_libraries (csv-import
    orc-tools-common
    )

--- a/ports/orc/tools-build.diff
+++ b/ports/orc/tools-build.diff
@@ -2,31 +2,7 @@ diff --git a/tools/src/CMakeLists.txt b/tools/src/CMakeLists.txt
 index 81e2da6..f785c51 100644
 --- a/tools/src/CMakeLists.txt
 +++ b/tools/src/CMakeLists.txt
-@@ -49,7 +49,6 @@ target_link_libraries (orc-contents
- 
- add_executable (orc-scan
-   FileScan.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-scan
-@@ -58,7 +57,6 @@ target_link_libraries (orc-scan
- 
- add_executable (orc-metadata
-   FileMetadata.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-metadata
-@@ -76,7 +74,6 @@ target_link_libraries (orc-statistics
- 
- add_executable (orc-memory
-   FileMemory.cc
--  ToolsHelper.cc
-   )
- 
- target_link_libraries (orc-memory
-@@ -98,6 +95,14 @@ add_executable (csv-import
+@@ -98,6 +98,14 @@ add_executable (csv-import
  target_link_libraries (csv-import
    orc-tools-common
    )
@@ -38,6 +14,6 @@ index 81e2da6..f785c51 100644
 +  find_library(GETTIMEOFDAY_LIBRARY gettimeofday PATH_SUFFIXES manual-link REQUIRED)
 +  target_link_libraries(csv-import "${GETTIMEOFDAY_LIBRARY}")
 +endif()
- 
+
  set(CPP_TOOL_NAMES
    orc-contents

--- a/ports/orc/tools-build.diff
+++ b/ports/orc/tools-build.diff
@@ -1,8 +1,32 @@
 diff --git a/tools/src/CMakeLists.txt b/tools/src/CMakeLists.txt
-index 81e2da6..3987bb3 100644
+index 81e2da6..f785c51 100644
 --- a/tools/src/CMakeLists.txt
 +++ b/tools/src/CMakeLists.txt
-@@ -98,6 +98,14 @@ add_executable (csv-import
+@@ -49,7 +49,6 @@ target_link_libraries (orc-contents
+ 
+ add_executable (orc-scan
+   FileScan.cc
+-  ToolsHelper.cc
+   )
+ 
+ target_link_libraries (orc-scan
+@@ -58,7 +57,6 @@ target_link_libraries (orc-scan
+ 
+ add_executable (orc-metadata
+   FileMetadata.cc
+-  ToolsHelper.cc
+   )
+ 
+ target_link_libraries (orc-metadata
+@@ -76,7 +74,6 @@ target_link_libraries (orc-statistics
+ 
+ add_executable (orc-memory
+   FileMemory.cc
+-  ToolsHelper.cc
+   )
+ 
+ target_link_libraries (orc-memory
+@@ -98,6 +95,14 @@ add_executable (csv-import
  target_link_libraries (csv-import
    orc-tools-common
    )

--- a/ports/orc/vcpkg.json
+++ b/ports/orc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "orc",
-  "version": "2.2.2",
-  "port-version": 1,
+  "version": "2.3.0",
   "description": "The smallest, fastest columnar storage for Hadoop workloads.",
   "homepage": "https://orc.apache.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7461,8 +7461,8 @@
       "port-version": 0
     },
     "orc": {
-      "baseline": "2.2.2",
-      "port-version": 1
+      "baseline": "2.3.0",
+      "port-version": 0
     },
     "orefkov-simstr": {
       "baseline": "1.8.1",

--- a/versions/o-/orc.json
+++ b/versions/o-/orc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "40820c672dd4f7e02233536bbc4ca49eee934823",
+      "git-tree": "a70719513574d63938793209f6b3506a903235e9",
       "version": "2.3.0",
       "port-version": 0
     },

--- a/versions/o-/orc.json
+++ b/versions/o-/orc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40820c672dd4f7e02233536bbc4ca49eee934823",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b2e0ea633827bba3347f9e976a10028d6e0442da",
       "version": "2.2.2",
       "port-version": 1

--- a/versions/o-/orc.json
+++ b/versions/o-/orc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a70719513574d63938793209f6b3506a903235e9",
+      "git-tree": "136a4996af080ac8478484ed1eadc4ff878f90c9",
       "version": "2.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/apache/orc/releases/tag/v2.3.0
