### PR TITLE
[pipewire] update to 1.6.3

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pipewire/pipewire
     REF "${VERSION}"
-    SHA512 aa5a01fe812bfb439147885fdef89edfcd9f97943eb3fb209b698896d0092a9bdba02de3df4c39d14f5c1792b69927c36eb7af134e9a85e7a794bcbf9def3986
+    SHA512 d6221e985081f0f33fc613ff1c5b3a55cb854f5edb43787c22bfb8aed4ea7af5f4fbfe0ff0a294c2cb17573256557d8756708731c9fd1d667417cbade6103fd3
     HEAD_REF master
 )
 
@@ -58,7 +58,7 @@ vcpkg_configure_meson(
         -Dsystemd-system-unit-dir=disabled
         -Dsystemd-user-service=disabled
         -Dsystemd-user-unit-dir=disabled
-        -Dsystemd=disabled
+#        -Dsystemd=disabled
         -Dtest=disabled
         -Dtests=disabled
         -Dudev=disabled

--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -58,7 +58,6 @@ vcpkg_configure_meson(
         -Dsystemd-system-unit-dir=disabled
         -Dsystemd-user-service=disabled
         -Dsystemd-user-unit-dir=disabled
-#        -Dsystemd=disabled
         -Dtest=disabled
         -Dtests=disabled
         -Dudev=disabled

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pipewire",
-  "version": "1.4.10",
+  "version": "1.6.3",
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7693,7 +7693,7 @@
       "port-version": 2
     },
     "pipewire": {
-      "baseline": "1.4.10",
+      "baseline": "1.6.3",
       "port-version": 0
     },
     "pistache": {

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2d12a1ea1ac34a7e72529ef1cedb68581902e77",
+      "version": "1.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "9543fa1c15b170abb3ce44f4f33e174cc45ec1c0",
       "version": "1.4.10",
       "port-version": 0

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2d12a1ea1ac34a7e72529ef1cedb68581902e77",
+      "git-tree": "7485708c1e1067e77b49c3be0692ccc04f5d7e8b",
       "version": "1.6.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/1.6.3
