### PR TITLE
[bootstrap-vcpkg.sh] Do not download tool on Android

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -101,6 +101,7 @@ vcpkgCheckRepoTool tar
 
 UNAME="$(uname)"
 ARCH="$(uname -m)"
+OS="$(uname -o)"
 
 if [ -e /etc/alpine-release ]; then
     vcpkgUseSystem="ON"
@@ -193,11 +194,11 @@ elif [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "ON" ] && [ "$ARCH" = "x86_6
     echo "Downloading vcpkg-muslc..."
     vcpkgToolReleaseSha=$VCPKG_MUSLC_SHA
     vcpkgToolName="vcpkg-muslc"
-elif [ "$UNAME" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
+elif [ "$OS" != "Android" ] && [ "$UNAME" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_SHA
     vcpkgToolName="vcpkg-glibc"
-elif [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
+elif [ "$OS" != "Android" ] && [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
     echo "Downloading vcpkg-arm64-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_ARM64_SHA
     vcpkgToolName="vcpkg-glibc-arm64"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -105,6 +105,7 @@ vcpkgCheckRepoTool tar
 
 UNAME="$(uname)"
 ARCH="$(uname -m)"
+OS="$(uname -o)"
 
 if [ -e /etc/alpine-release ]; then
     vcpkgUseSystem="ON"
@@ -197,11 +198,11 @@ elif [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "ON" ] && [ "$ARCH" = "x86_6
     echo "Downloading vcpkg-muslc..."
     vcpkgToolReleaseSha=$VCPKG_MUSLC_SHA
     vcpkgToolName="vcpkg-muslc"
-elif [ "$UNAME" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
+elif [ "$OS" != "Android" ] && [ "$UNAME" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_SHA
     vcpkgToolName="vcpkg-glibc"
-elif [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
+elif [ "$OS" != "Android" ] && [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
     echo "Downloading vcpkg-arm64-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_ARM64_SHA
     vcpkgToolName="vcpkg-glibc-arm64"


### PR DESCRIPTION
Reopen #45497

Answer to @BillyONeal [comment](https://github.com/microsoft/vcpkg/pull/45497#issuecomment-4208751957):
>To be clear, I was suggesting docker because I know that's a system where I know one should be able to start from "nothing", post command lines, and we should be able to show that it works by following those exact lines. End to end instructions on an Android device would be OK too. But the aforementioned problem where bootstrap needs to explain needs to get fixed before we would merge this.

Try it via `Dockerfile` (edited):

```Dockerfile
FROM termux/termux-docker:x86_64

SHELL ["/entrypoint.sh", "bash", "-c"]

RUN pkg update && pkg install -yq git zip clang cmake ninja

RUN git clone https://github.com/microsoft/vcpkg.git

WORKDIR ${HOME}/vcpkg

RUN git fetch origin pull/51073/head && git checkout FETCH_HEAD

# NOT NEEDED SINCE: https://github.com/microsoft/vcpkg/pull/52055
# To fix error: vcpkg was unable to find a libcurl.so.4
# RUN cp $PREFIX/lib/libcurl.so $PREFIX/lib/libcurl.so.4

RUN ./bootstrap-vcpkg.sh

# For example, now installing flecs, that missing in termux
RUN pkg install -yq patchelf && ./vcpkg install --triplet x64-linux --host-triplet x64-linux flecs
```