### PR TITLE
[gtk3] do not require X11 deps on Windows and macOS

### DIFF
--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.52",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -46,8 +47,14 @@
       "host": true
     },
     "libepoxy",
-    "libxi",
-    "libxrandr",
+    {
+      "name": "libxi",
+      "platform": "!windows & !osx"
+    },
+    {
+      "name": "libxrandr",
+      "platform": "!windows & !osx"
+    },
     "pango",
     {
       "name": "vcpkg-tool-meson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3606,7 +3606,7 @@
     },
     "gtk3": {
       "baseline": "3.24.52",
-      "port-version": 0
+      "port-version": 1
     },
     "gtkmm": {
       "baseline": "4.22.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afdd4189312de678e0fe7da05ffa6277847205a2",
+      "version": "3.24.52",
+      "port-version": 1
+    },
+    {
       "git-tree": "85c5ba56dfbf47290085e87597a6507d75eabf02",
       "version": "3.24.52",
       "port-version": 0


### PR DESCRIPTION
gtk3 meson.build was already not building X11 backend on these OSes at all. Looking the buildtrees/ confirms that. So, let's not waste time building these non-native libraries.

(This will also save some time on CI)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
