### PR TITLE
fix(soundtouch): remove invalid include directories from exported targets

### DIFF
--- a/ports/soundtouch/portfile.cmake
+++ b/ports/soundtouch/portfile.cmake
@@ -24,6 +24,23 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SoundTouch)
+file(GLOB _targets_files
+        "${CURRENT_PACKAGES_DIR}/share/soundtouch/*Targets.cmake"
+)
+
+foreach(_file IN LISTS _targets_files)
+  file(READ "${_file}" _content)
+
+  # 直接重写 include（更安全）
+  string(REGEX REPLACE
+          "INTERFACE_INCLUDE_DIRECTORIES \"[^\"]*\""
+          "INTERFACE_INCLUDE_DIRECTORIES \"\${_IMPORT_PREFIX}/include\""
+          _content
+          "${_content}"
+  )
+
+  file(WRITE "${_file}" "${_content}")
+endforeach()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "soundtouch",
   "version": "2.4.0",
+  "port-version": 1,
   "description": "SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.",
   "homepage": "https://www.surina.net/soundtouch",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9418,7 +9418,7 @@
     },
     "soundtouch": {
       "baseline": "2.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "soxr": {
       "baseline": "0.1.3",

--- a/versions/s-/soundtouch.json
+++ b/versions/s-/soundtouch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99ba3c6d6f8d8a29226abbc6dbc4a7521582044a",
+      "version": "2.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bc13dd17e35d60c64e0af1b3ee27cbe3b816e7d5",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
### Description

The SoundTouch port generates invalid include directories in exported targets:

- ${_IMPORT_PREFIX}/SoundTouch
- ${_IMPORT_PREFIX}/COMPONENT

These paths do not exist and cause CMake configure failure:

Imported target "SoundTouch::SoundTouch" includes non-existent path

### Root Cause

The issue appears to come from vcpkg_cmake_config_fixup incorrectly handling
the COMPONENT field from install(EXPORT ...).

This is not an upstream issue.

### Fix

This patch removes invalid include directories from generated *Targets.cmake files.

### Testing

- vcpkg remove soundtouch --recurse
- vcpkg install soundtouch
- Verified that INTERFACE_INCLUDE_DIRECTORIES only contains valid include path

### Impact

- No breaking changes
- Only removes invalid paths
- Safe across platforms

This patch is scoped only to SoundTouch and does not affect other ports.