### PR TITLE
[icey] Devendor nlohmann-json.

### DIFF
--- a/ports/icey/001-devendor-nlohmann-json.patch
+++ b/ports/icey/001-devendor-nlohmann-json.patch
@@ -1,20 +1,50 @@
+diff --git a/cmake/icey_build_config.cmake.in b/cmake/icey_build_config.cmake.in
+index aae2c22c..ccf13c38 100644
+--- a/cmake/icey_build_config.cmake.in
++++ b/cmake/icey_build_config.cmake.in
+@@ -44,6 +44,9 @@ if(_icey_have_libdatachannel AND DEFINED icey_FIND_COMPONENTS AND "webrtc" IN_LI
+ endif()
+ 
+ if(@USE_SYSTEM_DEPS@)
++  if("json" IN_LIST _icey_supported_components)
++    find_dependency(nlohmann_json CONFIG)
++  endif()
+   find_package(libuv CONFIG QUIET)
+   if(NOT TARGET libuv::uv_a AND NOT TARGET libuv::uv AND NOT TARGET libuv::libuv AND PkgConfig_FOUND)
+     pkg_check_modules(LIBUV QUIET IMPORTED_TARGET GLOBAL libuv)
+diff --git a/cmake/icey_config.cmake.in b/cmake/icey_config.cmake.in
+index 447929b9..0e14d025 100644
+--- a/cmake/icey_config.cmake.in
++++ b/cmake/icey_config.cmake.in
+@@ -59,6 +59,9 @@ if(NOT TARGET llhttp_static)
+ endif()
+ 
+ if(@USE_SYSTEM_DEPS@)
++  if("json" IN_LIST _icey_supported_components)
++    find_dependency(nlohmann_json CONFIG)
++  endif()
+   find_dependency(ZLIB)
+   if("archo" IN_LIST _icey_supported_components OR "pacm" IN_LIST _icey_supported_components)
+     find_dependency(unofficial-minizip CONFIG QUIET)
 diff --git a/icey.cmake b/icey.cmake
-index 816f1c3..f472b9d 100644
+index f99c4f7f..0d766619 100644
 --- a/icey.cmake
 +++ b/icey.cmake
-@@ -195,6 +195,7 @@ else()
+@@ -210,6 +210,9 @@ else()
      pkg_check_modules(LIBUV QUIET IMPORTED_TARGET GLOBAL libuv)
    endif()
    find_package(llhttp CONFIG QUIET)
-+  find_package(nlohmann_json CONFIG REQUIRED)
++  if(BUILD_MODULES AND (NOT DEFINED BUILD_MODULE_json OR BUILD_MODULE_json))
++    find_package(nlohmann_json CONFIG REQUIRED)
++  endif()
    find_package(ZLIB REQUIRED)
    if(NOT TARGET llhttp_static
       AND NOT TARGET llhttp::llhttp_static
 diff --git a/src/json/CMakeLists.txt b/src/json/CMakeLists.txt
-index 8983ef5..976899e 100644
+index 8983ef5c..905c5008 100644
 --- a/src/json/CMakeLists.txt
 +++ b/src/json/CMakeLists.txt
-@@ -1,6 +1,12 @@
+@@ -1,6 +1,20 @@
 -icy_add_module(json
 -  DEPENDS base
 -  PRETTY_NAME JSON
@@ -32,4 +62,16 @@ index 8983ef5..976899e 100644
 +    DEPENDS base
 +    PRETTY_NAME JSON
 +  )
++  target_include_directories(json
++    PUBLIC
++      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor>
++  )
++  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/vendor/"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    COMPONENT dev
++  )
 +endif()
+diff --git a/src/json/include/nlohmann/json.hpp b/src/json/vendor/nlohmann/json.hpp
+similarity index 100%
+rename from src/json/include/nlohmann/json.hpp
+rename to src/json/vendor/nlohmann/json.hpp

--- a/ports/icey/001-devendor-nlohmann-json.patch
+++ b/ports/icey/001-devendor-nlohmann-json.patch
@@ -1,0 +1,35 @@
+diff --git a/icey.cmake b/icey.cmake
+index 816f1c3..f472b9d 100644
+--- a/icey.cmake
++++ b/icey.cmake
+@@ -195,6 +195,7 @@ else()
+     pkg_check_modules(LIBUV QUIET IMPORTED_TARGET GLOBAL libuv)
+   endif()
+   find_package(llhttp CONFIG QUIET)
++  find_package(nlohmann_json CONFIG REQUIRED)
+   find_package(ZLIB REQUIRED)
+   if(NOT TARGET llhttp_static
+      AND NOT TARGET llhttp::llhttp_static
+diff --git a/src/json/CMakeLists.txt b/src/json/CMakeLists.txt
+index 8983ef5..976899e 100644
+--- a/src/json/CMakeLists.txt
++++ b/src/json/CMakeLists.txt
+@@ -1,6 +1,12 @@
+-icy_add_module(json
+-  DEPENDS base
+-  PRETTY_NAME JSON
+-)
+-# nlohmann/json.hpp is vendored in include/nlohmann/ (MIT licensed, single-header)
+-# so no external dependency is needed - icy_add_module already adds our include dir.
++if(USE_SYSTEM_DEPS)
++  icy_add_module(json
++    DEPENDS base
++    PACKAGES nlohmann_json::nlohmann_json
++    PRETTY_NAME JSON
++  )
++else()
++  icy_add_module(json
++    DEPENDS base
++    PRETTY_NAME JSON
++  )
++endif()

--- a/ports/icey/portfile.cmake
+++ b/ports/icey/portfile.cmake
@@ -14,8 +14,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         opencv   WITH_OPENCV
 )
 
-file(REMOVE_RECURSE "${SOURCE_PATH}/src/json/include/nlohmann")
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/icey/portfile.cmake
+++ b/ports/icey/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nilstate/icey
-    REF "2.4.2"
-    SHA512 1b56b3c9f082d4d35f9150c75c1c23972c696f853f3f0627787f33882e07c44de843b3896dc4a54f04cefd20dd7b4a6f64a52c5cdabc11d98b5be57c17193dfb
+    REF 6692243b82e687279ed40f6df54ab93d8964b6a1 # 2.4.2
+    SHA512 c1956e7035c2f4aef8cd1005fc8f6373d4b90c4409bd1dd104b5f9f415f9e347da7b1c530ac8f1192f7953a076ec21f0a8aed9618e236324e0c5154f12e79dce
     HEAD_REF main
+    PATCHES
+        001-devendor-nlohmann-json.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -11,6 +13,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         ffmpeg   WITH_FFMPEG
         opencv   WITH_OPENCV
 )
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/src/json/include/nlohmann")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/icey/vcpkg.json
+++ b/ports/icey/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "icey",
   "version": "2.4.2",
+  "port-version": 1,
   "maintainers": "0state OSS <oss@0state.com>",
   "description": "C++20 media stack and libwebrtc alternative for real-time video, signalling, TURN, and media servers",
   "homepage": "https://0state.com/icey/",
@@ -10,6 +11,7 @@
     "libuv",
     "llhttp",
     "minizip",
+    "nlohmann-json",
     "openssl",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3894,7 +3894,7 @@
     },
     "icey": {
       "baseline": "2.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "icu": {
       "baseline": "78.2",

--- a/versions/i-/icey.json
+++ b/versions/i-/icey.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6724e8a90f18a1d309db3d354524c42f3fc77807",
+      "git-tree": "bf0aa15dc2cf655705528a6d4a19a7d1f3d5a6a6",
       "version": "2.4.2",
       "port-version": 1
     },

--- a/versions/i-/icey.json
+++ b/versions/i-/icey.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6724e8a90f18a1d309db3d354524c42f3fc77807",
+      "version": "2.4.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "df041864a584d605aae51c2b8f8cb6f1c3fda56e",
       "version": "2.4.2",
       "port-version": 0


### PR DESCRIPTION
Hopefully resolves e.g.

```
Installing 1220/2747 icey:x64-windows@2.4.2...
icey:x64-windows@2.4.2 package ABI: 85408d9e1e319534d59b77fda8ea8922aa8a14879f509dd5dac321395eda1ca8
Building icey:x64-windows@2.4.2...
Trying to download nilstate-icey-2.4.2.tar.gz using asset cache https://vcpkgassetcachewus.blob.core.windows.net/cache/1b56b3c9f082d4d35f9150c75c1c23972c696f853f3f0627787f33882e07c44de843b3896dc4a54f04cefd20dd7b4a6f64a52c5cdabc11d98b5be57c17193dfb?*** SECRET ***
Download successful! Asset cache hit, did not try authoritative source https://github.com/nilstate/icey/archive/2.4.2.tar.gz
-- Extracting source D:/downloads/nilstate-icey-2.4.2.tar.gz
-- Using source at D:/b/icey/src/2.4.2-6836c8b6b9.clean
-- Configuring x64-windows
CMake Warning at D:/installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:344 (message):
  The following variables are not used in CMakeLists.txt:

      ENABLE_NATIVE_ARCH

  Please recheck them and remove the unnecessary options from the
  `vcpkg_cmake_configure` call.

  If these options should still be passed for whatever reason, please use the
  `MAYBE_UNUSED_VARIABLES` argument.
Call Stack (most recent call first):
  ports/icey/portfile.cmake:15 (vcpkg_cmake_configure)
  scripts/ports.cmake:206 (include)


-- Building x64-windows-dbg
-- Building x64-windows-rel
-- Fixing pkgconfig file: D:/p/icey_x64-windows/lib/pkgconfig/icey.pc
-- Using cached msys2-mingw-w64-x86_64-pkgconf-1~2.5.1-1-any.pkg.tar.zst
-- Using cached msys2-msys2-runtime-3.6.5-1-x86_64.pkg.tar.zst
-- Using msys root at D:/downloads/tools/msys2/3e71d1f8e22ab23f
-- Fixing pkgconfig file: D:/p/icey_x64-windows/debug/lib/pkgconfig/icey.pc
-- Installing: D:/p/icey_x64-windows/share/icey/copyright
-- Performing post-build validation
error: The following files are already installed in D:/installed/x64-windows and are in conflict with icey:x64-windows
Installed by nlohmann-json:x64-windows: include/nlohmann/json.hpp
Starting submission of icey:x64-windows@2.4.2 to 1 binary cache(s) in the background
Elapsed time to handle icey:x64-windows: 1 min
```