### PR TITLE
[curl] Add apple-sectrust feature

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -15,27 +15,28 @@ vcpkg_replace_string("${SOURCE_PATH}/include/curl/curlver.h" [[LIBCURL_TIMESTAMP
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        http2       USE_NGHTTP2
-        http3       USE_NGTCP2
-        wolfssl     CURL_USE_WOLFSSL
-        openssl     CURL_USE_OPENSSL
-        openssl     CURL_CA_FALLBACK
-        mbedtls     CURL_USE_MBEDTLS
-        ssh         CURL_USE_LIBSSH2
-        tool        BUILD_CURL_EXE
-        c-ares      ENABLE_ARES
-        sspi        CURL_WINDOWS_SSPI
-        brotli      CURL_BROTLI
-        idn2        USE_LIBIDN2
-        winidn      USE_WIN32_IDN
-        zstd        CURL_ZSTD
-        psl         CURL_USE_LIBPSL
-        gssapi      CURL_USE_GSSAPI
-        gsasl       CURL_USE_GSASL
-        gnutls      CURL_USE_GNUTLS
-        rtmp        USE_LIBRTMP
-        httpsrr     USE_HTTPSRR
-        ssls-export USE_SSLS_EXPORT
+        apple-sectrust USE_APPLE_SECTRUST
+        http2          USE_NGHTTP2
+        http3          USE_NGTCP2
+        wolfssl        CURL_USE_WOLFSSL
+        openssl        CURL_USE_OPENSSL
+        openssl        CURL_CA_FALLBACK
+        mbedtls        CURL_USE_MBEDTLS
+        ssh            CURL_USE_LIBSSH2
+        tool           BUILD_CURL_EXE
+        c-ares         ENABLE_ARES
+        sspi           CURL_WINDOWS_SSPI
+        brotli         CURL_BROTLI
+        idn2           USE_LIBIDN2
+        winidn         USE_WIN32_IDN
+        zstd           CURL_ZSTD
+        psl            CURL_USE_LIBPSL
+        gssapi         CURL_USE_GSSAPI
+        gsasl          CURL_USE_GSASL
+        gnutls         CURL_USE_GNUTLS
+        rtmp           USE_LIBRTMP
+        httpsrr        USE_HTTPSRR
+        ssls-export    USE_SSLS_EXPORT
     INVERTED_FEATURES
         ldap        CURL_DISABLE_LDAP
         ldap        CURL_DISABLE_LDAPS
@@ -48,6 +49,25 @@ if("ssl" IN_LIST FEATURES AND
     # (windows & !uwp) | mingw to match curl[ssl]'s "platform"
     ((VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_UWP) OR VCPKG_TARGET_IS_MINGW))
     list(APPEND FEATURE_OPTIONS -DCURL_USE_SCHANNEL=ON)
+endif()
+
+if("apple-sectrust" IN_LIST FEATURES)
+    set(apple_sectrust_has_compatible_backend OFF)
+    if("ssl" IN_LIST FEATURES OR "openssl" IN_LIST FEATURES OR "gnutls" IN_LIST FEATURES)
+        set(apple_sectrust_has_compatible_backend ON)
+    endif()
+
+    if(NOT apple_sectrust_has_compatible_backend AND
+        ("mbedtls" IN_LIST FEATURES OR "wolfssl" IN_LIST FEATURES))
+        message(FATAL_ERROR "apple-sectrust requires curl[ssl], curl[openssl], or curl[gnutls].")
+    endif()
+
+    if(NOT apple_sectrust_has_compatible_backend)
+        list(APPEND FEATURE_OPTIONS
+            -DCURL_USE_OPENSSL=ON
+            -DCURL_CA_FALLBACK=ON
+        )
+    endif()
 endif()
 
 if("http3" IN_LIST FEATURES AND

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "8.19.0",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -20,6 +21,13 @@
     "ssl"
   ],
   "features": {
+    "apple-sectrust": {
+      "description": "Use Apple's SecTrust certificate verification",
+      "supports": "osx",
+      "dependencies": [
+        "openssl"
+      ]
+    },
     "brotli": {
       "description": "brotli support (brotli)",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2290,7 +2290,7 @@
     },
     "curl": {
       "baseline": "8.19.0",
-      "port-version": 0
+      "port-version": 1
     },
     "curlcpp": {
       "baseline": "3.1",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc2715100188e70fd07bae1373ac22025b8ee6a3",
+      "version": "8.19.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2826bbcd8b83d191393e58842c2baa969b9363f9",
       "version": "8.19.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #48355

Expose curl's `USE_APPLE_SECTRUST` option as a macOS-only feature.

This lets ports opt into Apple's native certificate verification for compatible curl TLS backends without changing curl's default behavior.

This can avoid certificate verification failures on macOS for sites that are trusted by the system trust store but not by a plain OpenSSL setup.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.