### PR TITLE
[imgui] Add vulkan-headers-binding feature to avoid linking with the Vulkan Loader

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -113,10 +113,23 @@ if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.cpp)
 endif()
 
+if(IMGUI_BUILD_VULKAN_BINDING AND IMGUI_BUILD_VULKAN_HEADERS_BINDING)
+    message(FATAL_ERROR "imgui: vulkan-binding and vulkan-headers-binding are mutually exclusive")
+endif()
+
 if(IMGUI_BUILD_VULKAN_BINDING)
     find_package(Vulkan REQUIRED)
     target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp)
+endif()
+
+if(IMGUI_BUILD_VULKAN_HEADERS_BINDING)
+    find_package(VulkanHeaders CONFIG)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Headers)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
+    if (NOT IMGUI_BUILD_VULKAN_BINDING)
+        target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp)
+    endif()
 endif()
 
 if(IMGUI_BUILD_WIN32_BINDING)
@@ -275,6 +288,10 @@ if(NOT IMGUI_SKIP_HEADERS)
 
     if(IMGUI_BUILD_VULKAN_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_VULKAN_HEADERS_BINDING)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.h DESTINATION include)
     endif()
 
     if(IMGUI_BUILD_WIN32_BINDING)

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -22,6 +22,10 @@ if (@IMGUI_BUILD_VULKAN_BINDING@)
     find_dependency(Vulkan)
 endif()
 
+if (@IMGUI_BUILD_VULKAN_HEADERS_BINDING@)
+    find_dependency(VulkanHeaders CONFIG)
+endif()
+
 if (@IMGUI_BUILD_WEBGPU_BINDING@)
     find_dependency(Dawn)
 endif()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     sdlgpu3-binding             IMGUI_BUILD_SDLGPU3_BINDING
     sdl3-renderer-binding       IMGUI_BUILD_SDL3_RENDERER_BINDING
     vulkan-binding              IMGUI_BUILD_VULKAN_BINDING
+    vulkan-headers-binding      IMGUI_BUILD_VULKAN_HEADERS_BINDING
     win32-binding               IMGUI_BUILD_WIN32_BINDING
     webgpu-binding              IMGUI_BUILD_WEBGPU_BINDING
     freetype                    IMGUI_FREETYPE

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.92.7",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",
@@ -133,9 +134,15 @@
       ]
     },
     "vulkan-binding": {
-      "description": "Make available Vulkan binding",
+      "description": "Make available Vulkan binding (links vulkan-loader)",
       "dependencies": [
         "vulkan"
+      ]
+    },
+    "vulkan-headers-binding": {
+      "description": "Make available Vulkan binding using headers-only dispatch (no vulkan-loader linkage, requires ImGui_ImplVulkan_LoadFunctions)",
+      "dependencies": [
+        "vulkan-headers"
       ]
     },
     "wchar32": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3954,7 +3954,7 @@
     },
     "imgui": {
       "baseline": "1.92.7",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65b1b06c47a92fba8219ebccd3eec702c49180bc",
+      "version": "1.92.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "28bd3aa7937eeaaa7881c7cc4ece5b5d52a77657",
       "version": "1.92.7",
       "port-version": 0


### PR DESCRIPTION
Adds a new `vulkan-headers-binding` feature as an alternative to the existing `vulkan-binding`. The new feature compiles `imgui_impl_vulkan.cpp` with `IMGUI_IMPL_VULKAN_NO_PROTOTYPES` defined and links against `Vulkan::Headers` (header-only) instead of `Vulkan::Vulkan` (the Vulkan loader). This allows applications using dynamic Vulkan dispatch (`vulkan.hpp` with `VULKAN_HPP_DISPATCH_LOADER_DYNAMIC` or Volk) to use imgui's Vulkan backend without being forced to link against `vulkan-1.dll` / `libvulkan.so`.

The existing `vulkan-binding` feature is **unchanged**.

`vulkan-binding` and `vulkan-headers-binding` are mutually exclusive. I made enabling both produce a `CMake FATAL_ERROR` due to conflicting compile definitions and potential ODR violations from the shared `imgui_impl_vulkan.cpp` translation unit. I'm not sure of any way aside from mutual exclusion to do this cleanly; if there are any better solutions than a new feature flag I'd be happy to learn.

Users of the new feature must call `ImGui_ImplVulkan_LoadFunctions()` before `ImGui_ImplVulkan_Init()`. This is the intended and documented usage path when `IMGUI_IMPL_VULKAN_NO_PROTOTYPES` is set, per imgui upstream.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md) (**caveat mentioned above**).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

