### PR TITLE
[pangolin] update to 0.9.5

### DIFF
--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stevenlovegrove/Pangolin
     REF "v${VERSION}"
-    SHA512 d303f0d9f02492e4fe0eb844db4fda563404ba73d1350a5b3ed45745c40022726b27cbd92cd1d0990186d1438ba0d2710fc614028b725f054486741ae30fd490
+    SHA512 fc08c85f66bb10a361b775841fff45976d6c9e0232f6a2949f18963c317c13b66b9aae11bcabbd903dbfc8e02a3638007be1e0542b13ac0a6641b0762f762dff
     HEAD_REF master
     PATCHES
         devendor-palsigslot.patch

--- a/ports/pangolin/vcpkg.json
+++ b/ports/pangolin/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pangolin",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Lightweight GUI Library",
   "homepage": "https://github.com/stevenlovegrove/Pangolin",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7553,7 +7553,7 @@
       "port-version": 0
     },
     "pangolin": {
-      "baseline": "0.9.4",
+      "baseline": "0.9.5",
       "port-version": 0
     },
     "pangomm": {

--- a/versions/p-/pangolin.json
+++ b/versions/p-/pangolin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50ffb9ac50a2858e4bbe0c07f4d1c560377f898d",
+      "version": "0.9.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "c9f388c0661009c72dd4acd4cf6fe77d25ed7597",
       "version": "0.9.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stevenlovegrove/Pangolin/releases/tag/v0.9.5
