### PR TITLE
[quickjs-ng] update to 0.14.0

### DIFF
--- a/ports/quickjs-ng/portfile.cmake
+++ b/ports/quickjs-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO quickjs-ng/quickjs
     REF v${VERSION}
-    SHA512 39870b7dbe82ffe4cf9ae25b9aa653af536c83460302126b3e868a29cf657d0f1206fd66eebbc37dd46c5bb991c8b00230f6850bf743561bc1f48233c45c327b
+    SHA512 a6679a61da1ad232afb59e6c997106f9909084b853c3c615b2410681c4272071a69fcad213374bec60fa3187569de874daa6d6bfcc2cd6e47ca5a0d978d63392
     HEAD_REF master
     PATCHES
         pdb_name_conflict.patch

--- a/ports/quickjs-ng/vcpkg.json
+++ b/ports/quickjs-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quickjs-ng",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "QuickJS, the Next Generation: a mighty JavaScript engine. A small and embeddable JavaScript engine supporting the latest ECMAScript specification.",
   "homepage": "https://github.com/quickjs-ng/quickjs",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8497,7 +8497,7 @@
       "port-version": 9
     },
     "quickjs-ng": {
-      "baseline": "0.13.0",
+      "baseline": "0.14.0",
       "port-version": 0
     },
     "quill": {

--- a/versions/q-/quickjs-ng.json
+++ b/versions/q-/quickjs-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9628871eaad08b24f81ff5aa0364dba31b6da239",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad59e37e572d1f219738e25017bfa5768c56196e",
       "version": "0.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/quickjs-ng/quickjs/releases/tag/v0.14.0
