### PR TITLE
[rtmfp-cpp] Update to 1.7.0

### DIFF
--- a/ports/rtmfp-cpp/portfile.cmake
+++ b/ports/rtmfp-cpp/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(ADD_CSTDINT
-    URLS https://github.com/zenomt/rtmfp-cpp/commit/9c53bde974e6463537a4e5573a548e59eb45786c.diff?full_index=1
-    FILENAME rtmfp-cpp-add-cstdint-9c53bde974e6463537a4e5573a548e59eb45786c.diff
-    SHA512 7c6c4bf04f541c06a6f24b0e5033a26c13e1f985b5fa33bddcea8374e50e97bdfd768a2a16cb84ba0e67f1525036fd17af298053c909f48fd45f6974b1857d56
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zenomt/rtmfp-cpp
     REF "v${VERSION}"
-    SHA512 cc8eac88c70b6a00a92a76bee66a3b319857a009fbfd82e9a710fe1c0fc452cf9fdf4128529e3f10931ed33c26eaf69253cab3b3e5a739eca6dd37a13f72800b
+    SHA512 c051ddc289f5b1a0d211058f9ed388e3219f796d97de5c403a70c715ec811efcfe1e7526996672687b42c9a45d57bccd5fa9b03415633d6341e3534ae24cd39c
     HEAD_REF main
-    PATCHES
-        "${ADD_CSTDINT}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/rtmfp-cpp/vcpkg.json
+++ b/ports/rtmfp-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rtmfp-cpp",
-  "version": "1.5.1",
-  "port-version": 1,
+  "version": "1.7.0",
   "description": "Secure Real-Time Media Flow Protocol Library (RTMFP)",
   "homepage": "https://github.com/zenomt/rtmfp-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8865,8 +8865,8 @@
       "port-version": 0
     },
     "rtmfp-cpp": {
-      "baseline": "1.5.1",
-      "port-version": 1
+      "baseline": "1.7.0",
+      "port-version": 0
     },
     "rtmidi": {
       "baseline": "6.0.0",

--- a/versions/r-/rtmfp-cpp.json
+++ b/versions/r-/rtmfp-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "504d49e24dbb4c326698bc4e8d74938e3e381773",
+      "version": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5a858aa5eebe403fcdfb01d0d4a6ff08e275507a",
       "version": "1.5.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.