### PR TITLE
[velodyne-decoder] Update to 3.1.0

### DIFF
--- a/ports/velodyne-decoder/portfile.cmake
+++ b/ports/velodyne-decoder/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO valgur/velodyne_decoder
     REF "v${VERSION}"
-    SHA512 f09dd173cdea6b651a023d799bed7047ee2ac8518446d57e289a6eed9a92ff1ec2644ec49b78bd29ecfebb2046cb89455910bcb476db852a14e42e106b9881ce
+    SHA512 aba310e06ded29699233dabb7588a0044661754777d0811b735ef92184ce1499680aa39cf1ad28e813330a89ea59d73882ec9a148b45b461433ce140b3dae680
     HEAD_REF develop
     PATCHES
         0001-fix-msvc-flags.patch

--- a/ports/velodyne-decoder/vcpkg.json
+++ b/ports/velodyne-decoder/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "velodyne-decoder",
-  "version": "3.0.0",
-  "port-version": 1,
+  "version": "3.1.0",
   "description": "A decoder library for raw Velodyne data and telemetry info",
   "homepage": "https://github.com/valgur/velodyne_decoder",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10537,8 +10537,8 @@
       "port-version": 0
     },
     "velodyne-decoder": {
-      "baseline": "3.0.0",
-      "port-version": 1
+      "baseline": "3.1.0",
+      "port-version": 0
     },
     "verdict": {
       "baseline": "1.4.2",

--- a/versions/v-/velodyne-decoder.json
+++ b/versions/v-/velodyne-decoder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05fd21ccbd59f46420905be806ba5059eebf5df6",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "750a76436e6efb88a97b30a3a4c17ccafe869f2a",
       "version": "3.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.