### PR TITLE
[libmypaint] Add Windows support

### DIFF
--- a/ports/libmypaint/disable_tests.diff
+++ b/ports/libmypaint/disable_tests.diff
@@ -1,0 +1,23 @@
+diff --git a/Makefile.am b/Makefile.am
+index 144a5ac..7c0c2d9 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -154,5 +154,4 @@ SUBDIRS = \
+ 	.			\
+ 	doc			\
+ 	gegl		\
+-	tests		\
+ 	$(PODIRS)
+diff --git a/configure.ac b/configure.ac
+index 86e586b..dfd69c0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -313,8 +313,6 @@ AC_CONFIG_FILES([
+   libmypaint.pc:libmypaint.pc.in
+   Makefile
+   po/Makefile.in
+-  tests/Makefile
+-  tests/gegl/Makefile
+ ])
+ 
+ AC_OUTPUT

--- a/ports/libmypaint/fix_i18n.diff
+++ b/ports/libmypaint/fix_i18n.diff
@@ -1,0 +1,10 @@
+diff --git a/configure.ac b/configure.ac
+index 86e586b..7a500f1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,3 +1,5 @@
++m4_pattern_allow([AM_GLIB_GNU_GETTEXT])
++
+ # AC_OPENMP requires autoconf >= 2.62.
+ AC_PREREQ(2.62)
+ 

--- a/ports/libmypaint/portfile.cmake
+++ b/ports/libmypaint/portfile.cmake
@@ -7,10 +7,15 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix_i18n.diff
+        win_math.patch
+        disable_tests.diff
 )
 
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
     OPTIONS
         --disable-i18n
         --disable-introspection

--- a/ports/libmypaint/vcpkg.json
+++ b/ports/libmypaint/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "libmypaint",
   "version": "1.6.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Brush library used by MyPaint",
   "homepage": "https://github.com/mypaint/libmypaint",
   "license": "ISC",
-  "supports": "!windows | mingw",
   "dependencies": [
     "glib",
     "json-c",

--- a/ports/libmypaint/win_math.patch
+++ b/ports/libmypaint/win_math.patch
@@ -1,0 +1,31 @@
+From a5d28fb2d13fb9cd01fcba9f9a88aaa8ecca0e15 Mon Sep 17 00:00:00 2001
+From: Bruno Lopes <brunvonlope@outlook.com>
+Date: Sun, 12 Apr 2026 21:04:24 -0300
+Subject: [PATCH] configure: Do not check for math library functions on Windows
+
+---
+ configure.ac | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index b6e1e0603ef1351549851425a6386fb46d05f817..b10b1d7e2e1ac0fc8a2572372bb049d1e7d4666c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -218,10 +218,13 @@ AC_SUBST(JSON_LIBS)
+ AC_SUBST(JSON_CFLAGS)
+ 
+ ## Standard maths functions ##
+-AC_SEARCH_LIBS([floorf], [m], [], AC_MSG_ERROR([no floorf]))
+-AC_SEARCH_LIBS([powf], [m], [], AC_MSG_ERROR([no powf]))
+-AC_SEARCH_LIBS([expf], [m], [], AC_MSG_ERROR([no expf]))
+-AC_SEARCH_LIBS([fabsf], [m], [], AC_MSG_ERROR([no fabsf]))
++## On Windows, they are provided by the C library (msvcrt or ucrt) ##
++if test "x$platform_win32" != "xyes"; then
++  AC_SEARCH_LIBS([floorf], [m], [], AC_MSG_ERROR([no floorf]))
++  AC_SEARCH_LIBS([powf], [m], [], AC_MSG_ERROR([no powf]))
++  AC_SEARCH_LIBS([expf], [m], [], AC_MSG_ERROR([no expf]))
++  AC_SEARCH_LIBS([fabsf], [m], [], AC_MSG_ERROR([no fabsf]))
++fi
+ 
+ ## Additional compile flags ##
+ 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5290,7 +5290,7 @@
     },
     "libmypaint": {
       "baseline": "1.6.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libmysofa": {
       "baseline": "1.3.4",

--- a/versions/l-/libmypaint.json
+++ b/versions/l-/libmypaint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "465ae952f699c62a05162a277b734bafd4073088",
+      "version": "1.6.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "0834136ddd7d0bbbc963915b18ef1cde2ef44093",
       "version": "1.6.1",
       "port-version": 2


### PR DESCRIPTION
This is needed for GIMP

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This is needed for GIMP