### PR TITLE
Fix 7zip selection on arm64, delete 7zip_msi.

### DIFF
--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -240,15 +240,6 @@
       "sha512": "9b025da7830a875195c3f7232497b76adb78650fb5c9c7cd279d0938e3c496ed699cd763501c8f28ba5b9fcfe689aa21bea098f801204c5cbdbfd38dbd27b72f"
     },
     {
-      "name": "7zip_msi",
-      "os": "windows",
-      "version": "26.00",
-      "executable": "Files/7-Zip/7z.exe",
-      "url": "https://github.com/ip7z/7zip/releases/download/26.00/7z2600-x64.msi",
-      "sha512": "a8556706f2ab18953c4f22497d593a4c85f73d49c450c3dafbf827ce313219c7d247ffa6c5b3764075f6cac096490935e9c6ed8449f50c935d396353b84358db",
-      "archive": "7z2600-x64.msi"
-    },
-    {
       "name": "7zip",
       "os": "windows",
       "arch": "amd64",

--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -251,11 +251,22 @@
     {
       "name": "7zip",
       "os": "windows",
+      "arch": "amd64",
       "version": "26.00",
       "executable": "7z.exe",
-      "url": "https://github.com/ip7z/7zip/releases/download/26.00/7z2600.exe",
-      "sha512": "9dcbb5d370f6270e0f4a383b5ee7452024f5283e52f838938a7bcca110b5647ffdb2c549677a70b23fea21a349ea4ad1898e6bc976afc3e7e49b4755b6b27150",
-      "archive": "7z2600.7z.exe"
+      "url": "https://github.com/ip7z/7zip/releases/download/26.00/7z2600-x64.exe",
+      "sha512": "d50e76ca3299fa131156d758ba54079ee347fea30708d0dbcba40d72f307f4d16446ea13041549cb78aabd032fb5dd048d3bbf192821ad9ce89eea5d96581001",
+      "archive": "7z2600-x64.7z.exe"
+    },
+    {
+      "name": "7zip",
+      "os": "windows",
+      "arch": "arm64",
+      "version": "26.00",
+      "executable": "7z.exe",
+      "url": "https://github.com/ip7z/7zip/releases/download/26.00/7z2600-arm64.exe",
+      "sha512": "1d691c8350ba55ced6f5f5ddbb90895593d083d5609a7b8932d1ae12db8a7eb7581c3705a35d562d94068622dc6a8a3d4034f0757da5abc51d162efc9101b2f8",
+      "archive": "7z2600-arm64.7z.exe"
     },
     {
       "name": "7zr",


### PR DESCRIPTION
I got my hands on a Snapdragon X2 Elite X2-E94-100 machine, and tried to use vcpkg on it, and immediately observed that we try to use the x64 7zip instead of the arm64 one.

I also deleted 7zip_msi because that workaround was only ever relevant for Windows 7, and its use was entirely burninated in the product in https://github.com/microsoft/vcpkg-tool/pull/1477