### PR TITLE
[libarchive] update to 3.8.7

### DIFF
--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libarchive/libarchive
     REF "v${VERSION}"
-    SHA512 33c8173e6a1bb28b1bd131400b64a618c8984efd9287adb54b5133927bd4268184e7e0fa23a81ada4a8de831ef9f4a35973cc4b795ee885eb927b4c73433b889
+    SHA512 de485dbca636803fce6720dede7d0a6c3315cb209489c94167dd9388ebe56ba8819d3118045308f05b935c954950202d0adb0485bc074bc04ca8c47877f1fe60
     HEAD_REF master
     PATCHES
         fix-buildsystem.patch

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libarchive",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://www.libarchive.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4681,7 +4681,7 @@
       "port-version": 6
     },
     "libarchive": {
-      "baseline": "3.8.6",
+      "baseline": "3.8.7",
       "port-version": 0
     },
     "libaribcaption": {

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fa6c30380bdf44dc81d78116c3a1f01a87a86b5",
+      "version": "3.8.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "f745eacd8abd3950cff3072c2878931a01469176",
       "version": "3.8.6",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

