### PR TITLE
[libdjinterop] Add missing find_dependency(date) call

### DIFF
--- a/ports/libdjinterop/devendor_libs.diff
+++ b/ports/libdjinterop/devendor_libs.diff
@@ -30,6 +30,18 @@ index 7ca2d6f..f317c4d 100644
  
  if(SYSTEM_SQLITE)
      # Search for system installation of SQLite and use that.
+diff --git a/DjInteropConfig.cmake.in b/DjInteropConfig.cmake.in
+index 1234567..abcdefg 100644
+--- a/DjInteropConfig.cmake.in
++++ b/DjInteropConfig.cmake.in
+@@ -4,6 +4,7 @@ set(DJINTEROP_SYSTEM_SQLITE @SYSTEM_SQLITE@)
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+ 
+ include(CMakeFindDependencyMacro)
++find_dependency(date)
+ find_dependency(ZLIB)
+ if(DJINTEROP_SYSTEM_SQLITE)
+   find_dependency(SQLite3)
 diff --git a/src/djinterop/util/chrono.cpp b/src/djinterop/util/chrono.cpp
 index 0d551dd..475aece 100644
 --- a/src/djinterop/util/chrono.cpp

--- a/ports/libdjinterop/vcpkg.json
+++ b/ports/libdjinterop/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdjinterop",
   "version": "0.27.1",
+  "port-version": 1,
   "description": "C++ library for access to DJ record libraries. Currently only supports Denon Engine Prime databases",
   "homepage": "https://github.com/xsco/libdjinterop",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4846,7 +4846,7 @@
     },
     "libdjinterop": {
       "baseline": "0.27.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libdmtx": {
       "baseline": "0.7.7",

--- a/versions/l-/libdjinterop.json
+++ b/versions/l-/libdjinterop.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e092d4726edc3929d8dc36c2ab4ebfe187888fa4",
+      "version": "0.27.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "07808e552bb04ad62cb87a63a5249bf888162c57",
       "version": "0.27.1",
       "port-version": 0


### PR DESCRIPTION
Fixes static linking in the target project: 

```
CMake Error at /Users/runner/buildenv/mixxx-deps-2.6-x64-osx-rel-e82160b/scripts/buildsystems/vcpkg.cmake:639 (_add_library):
  Target "mixxx-lib" links to target "date::date" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
