### PR TITLE
[rego-cpp] Update to version 1.4.1

### DIFF
--- a/ports/rego-cpp/portfile.cmake
+++ b/ports/rego-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/rego-cpp
     REF "v${VERSION}"
-    SHA512 d600bc65b9bc142944a56a63c09a3124978799463046d0f048ae1ce7b7652f0c1469a16387c2495070cf3ffd6eca1ea5ed667eb5e2c236f989d49ec748f9a519
+    SHA512 a9e7b6202fdc7b7168433227c7bc67492d52bdf10c5d9b2c0954aa66a9eb5a16a9b4de7eb7385a335c6685111393aad6840c171ab12b3e6b2fd493b5bffea21c
     HEAD_REF main
 )
 
@@ -29,7 +29,6 @@ vcpkg_cmake_configure(
         -DREGOCPP_BUILD_TOOLS=${BUILD_TOOLS}
         -DREGOCPP_BUILD_TESTS=OFF
         -DREGOCPP_BUILD_DOCS=OFF
-        -DREGOCPP_USE_SNMALLOC=OFF
         -DREGOCPP_CRYPTO_BACKEND=${CRYPTO_BACKEND}
 )
 
@@ -41,6 +40,7 @@ endif()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME regocpp CONFIG_PATH share/regocpp/cmake)
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rego-cpp/vcpkg.json
+++ b/ports/rego-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rego-cpp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A C++ interpreter for the OPA Rego policy language",
   "homepage": "https://github.com/microsoft/rego-cpp",
   "license": "MIT",
@@ -10,7 +10,8 @@
       "name": "trieste",
       "features": [
         "parsers"
-      ]
+      ],
+      "version>=": "1.1.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8685,7 +8685,7 @@
       "port-version": 0
     },
     "rego-cpp": {
-      "baseline": "1.4.0",
+      "baseline": "1.4.1",
       "port-version": 0
     },
     "rendergraph": {

--- a/versions/r-/rego-cpp.json
+++ b/versions/r-/rego-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71925bf69323a0a51e027f46a4049ac8faca103a",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "011ba55c6ab2462630b31f28fa5ff57b2a618f8a",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
