### PR TITLE
[vcpkg scripts] Update Strawberry Perl to `5.42.2.1`

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program(PERL).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(PERL).cmake
@@ -1,13 +1,13 @@
 set(program_name perl)
-set(program_version 5.42.0.1)
+set(program_version 5.42.2.1)
 set(brew_package_name "perl")
 set(apt_package_name "perl")
 if(CMAKE_HOST_WIN32)
     set(download_urls
-        "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_54201_64bit/strawberry-perl-5.42.0.1-64bit-portable.zip"
+        "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_54221_64bit/strawberry-perl-5.42.2.1-64bit-portable.zip"
     )
-    set(download_filename "strawberry-perl-5.42.0.1-64bit-portable.zip")
-    set(download_sha512 e78fc86eb76dc34f2fd8a911537b20378e1ce486a3ea1a167001fd040c2468e8db5e711a895314e7ead3511f3caafccc1ffbfd0bd4096c0360d712a9668fe69b)
+    set(download_filename "strawberry-perl-5.42.2.1-64bit-portable.zip")
+    set(download_sha512 e37c541bb6c4f1c0187bf8ba22b19ce9ead87f6bd1e68c05e7fc4eb2c10a4183c3ee732bf1b26071939f525861fae62b6bef04100b31504ab50fffe7526f84e3)
     set(tool_subdirectory ${program_version})
     set(paths_to_search ${DOWNLOADS}/tools/perl/${tool_subdirectory}/perl/bin)
 endif()


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.
____

[vcpkg scripts] Update Strawberry Perl to `5.42.2.1`
https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases
https://strawberryperl.com/