### PR TITLE
[yoctolib] update to 2.1.12672

### DIFF
--- a/ports/yoctolib/portfile.cmake
+++ b/ports/yoctolib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yoctopuce/yoctolib_cpp
     REF "v${VERSION}"
-    SHA512 ed405d77c05288e123851a79e86beaf9778cce487c5d5d4a556f47b3a690517e71b004e5b3e0ae5532cb24ed46a1c04ce4f18c34cccf475fc1ca45a331808c43
+    SHA512 6af8df55dc7dd021944d776c23c0ecd8b110b318127e35e110b155f5cc963625fed4f3f0055067b0b19e74ceb44a47d964d351964ed9a6744eb446ea9e16e1e8
     HEAD_REF master
     PATCHES
         001-cmake_config.patch

--- a/ports/yoctolib/vcpkg.json
+++ b/ports/yoctolib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yoctolib",
-  "version": "2.1.11761",
+  "version": "2.1.12672",
   "description": "Official Yoctopuce Library for C++",
   "homepage": "https://github.com/yoctopuce/yoctolib_cpp",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11081,7 +11081,7 @@
       "port-version": 0
     },
     "yoctolib": {
-      "baseline": "2.1.11761",
+      "baseline": "2.1.12672",
       "port-version": 0
     },
     "yoga": {

--- a/versions/y-/yoctolib.json
+++ b/versions/y-/yoctolib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca99916ddfe4096cd01920c198852c7e2ef31b38",
+      "version": "2.1.12672",
+      "port-version": 0
+    },
+    {
       "git-tree": "dea1c905ed8620b38ec44b68a0beaecfc9453d4c",
       "version": "2.1.11761",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/yoctopuce/yoctolib_cpp/releases/tag/v2.1.12672
