### PR TITLE
[qtwebengine] fix failing windows build due to system python installation

### DIFF
--- a/ports/qtwebengine/ctypes-fix.patch
+++ b/ports/qtwebengine/ctypes-fix.patch
@@ -1,0 +1,34 @@
+--- a/src/3rdparty/chromium/components/resources/protobufs/binary_proto_generator.py	2026-04-14 04:40:38.000000000 +0000
++++ b/src/3rdparty/chromium/components/resources/protobufs/binary_proto_generator.py	2026-04-14 12:35:58.359518761 +0000
+@@ -17,6 +17,31 @@
+ import sys
+ import traceback
+ 
++# Fix: when a virtualenv is created from an embeddable Python distribution and
++# a different Python version is installed system-wide, running with -S (skip
++# site) can put the system Python's DLLs/ directory on sys.path. Loading
++# extension modules (e.g. _ctypes.pyd) from a different Python version causes
++# "DLL load failed" errors. Remove any Python DLLs/ directories from sys.path
++# that do not belong to the current interpreter's home.
++if os.name == 'nt':
++    _exe_dir = os.path.normcase(os.path.dirname(os.path.abspath(sys.executable)))
++    _home_dir = _exe_dir
++    _cfg = os.path.join(_exe_dir, '..', 'pyvenv.cfg')
++    if os.path.isfile(_cfg):
++        for _line in open(_cfg):
++            if _line.startswith('home = '):
++                _home_dir = os.path.normcase(_line.split('=', 1)[1].strip())
++                break
++    _orig_path = sys.path[:]
++    sys.path = [p for p in sys.path
++                if not (os.path.normcase(p).rstrip('\\/ ').endswith('dlls')
++                        and os.path.isabs(p)
++                        and not os.path.normcase(p).startswith(_exe_dir)
++                        and not os.path.normcase(p).startswith(_home_dir))]
++    if sys.path != _orig_path:
++        import importlib
++        importlib.invalidate_caches()
++
+ 
+ class GoogleProtobufModuleImporter:
+   """A custom module importer for importing google.protobuf.

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -12,6 +12,7 @@ set(${PORT}_PATCHES
       "rpath.diff"
       "include-dir-order.diff"
       "allow-msvc-145.diff"
+      "ctypes-fix.patch"
 )
 
 set(qtwebengine_target "${VCPKG_TARGET_TRIPLET}-${VCPKG_CMAKE_SYSTEM_NAME}")

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.10.2",
+  "port-version": 1,
   "description": "Qt modules for rendering web and PDF content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8458,7 +8458,7 @@
     },
     "qtwebengine": {
       "baseline": "6.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwebsockets": {
       "baseline": "6.10.2",

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70812d9c67be1702498178225d1e98b69874ee20",
+      "version": "6.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "435c8f8e58ccaa2ffc6ff4e129effdaefbc00f30",
       "version": "6.10.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #46606 
(A bug I have been struggling for many months; finally got a fix) :)

NOTE: This workaround did not work anymore for me (Qt 6.10.2, Python 3.14.4 on system): https://github.com/microsoft/vcpkg/pull/48582#issuecomment-3595799561

Explanation of fix in the patch.