### PR TITLE
[babl] support introspection on windows

### DIFF
--- a/ports/babl/gir-header-only-on-windows.patch
+++ b/ports/babl/gir-header-only-on-windows.patch
@@ -1,0 +1,26 @@
+diff --git a/babl/meson.build b/babl/meson.build
+index f6dd81c..ec42f68 100644
+--- a/babl/meson.build
++++ b/babl/meson.build
+@@ -159,15 +159,19 @@ if build_gir
+   # identity filter, so GIR doesn't choke on the Babl type
+   # (since it has the same name as the Babl namespace)
+   babl_gir = gnome.generate_gir(
+     babl,
+     sources: babl_headers,
+     extra_args: [
+       '--identifier-filter-cmd=@0@ @1@'.format(python.full_path(), 
+       '"' + meson.current_source_dir() / 'identfilter.py' + '"'),
+       '-DBABL_IS_BEING_COMPILED',
++      # Windows DLL resolution for the temporary GIR helper executable is
++      # unreliable in vcpkg builds. Babl does not expose GObject runtime
++      # types, so a header-only scan is sufficient here.
++      platform_win32 ? '--header-only' : '',
+       '--quiet',
+     ],
+     namespace: 'Babl',
+     nsversion: api_version,
+     header: 'babl.h',
+     export_packages: 'babl-0.1',
+     install: true,
+   )

--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -11,10 +11,13 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         support-plugins.patch
+        gir-header-only-on-windows.patch
         remove-consistency-check.patch
 )
 
 set(feature_options "")
+set(debug_options "")
+set(release_options "")
 if("cmyk-icc" IN_LIST FEATURES)
     list(APPEND feature_options "-Dwith-lcms=enabled")
 else()
@@ -23,6 +26,12 @@ endif()
 
 if("introspection" IN_LIST FEATURES)
     list(APPEND feature_options "-Denable-gir=true")
+    if(VCPKG_TARGET_IS_WINDOWS)
+        # The Windows debug scanner path is currently brittle; generate the
+        # GIR/typelib from release only and package those artifacts.
+        list(APPEND debug_options "-Denable-gir=false")
+        list(APPEND release_options "-Denable-gir=true")
+    endif()
     vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
 else()
     list(APPEND feature_options "-Denable-gir=false")
@@ -33,6 +42,10 @@ vcpkg_configure_meson(
     OPTIONS
         ${feature_options}
         -Dwith-docs=false
+    OPTIONS_DEBUG
+        ${debug_options}
+    OPTIONS_RELEASE
+        ${release_options}
     ADDITIONAL_BINARIES
         "g-ir-compiler='${GIR_COMPILER}'"
         "g-ir-scanner='${GIR_SCANNER}'"

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "babl",
   "version": "0.1.126",
+  "port-version": 1,
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",
@@ -19,7 +20,6 @@
     },
     "introspection": {
       "description": "Enable introspection",
-      "supports": "!windows | mingw",
       "dependencies": [
         "gobject-introspection"
       ]

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9bf6eefd4f512c818e8cb0a3c99325a827898ae1",
+      "version": "0.1.126",
+      "port-version": 1
+    },
+    {
       "git-tree": "16be1f5ab43c471b63e6fd5c01b58bd18f8401ee",
       "version": "0.1.126",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -622,7 +622,7 @@
     },
     "babl": {
       "baseline": "0.1.126",
-      "port-version": 0
+      "port-version": 1
     },
     "backward-cpp": {
       "baseline": "2023-11-24",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
