### PR TITLE
[librdkafka] Update to 2.14.1

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO confluentinc/librdkafka
     REF "v${VERSION}"
-    SHA512 af9a84e576c6edf21fc7e434bbd966b29a800ff1237c3f5ffe5eceececa39300dcbdd4daa6d6e3caf276e6cdc178016d974d8e039b1bc8b0925142c0585ed143
+    SHA512 27f42712a96ce5b7d687a8d257b069caed7655768c4758cf8e88674b6e9133b1d1461b9a07e092b5a065324f4b5021f88f63e01b74352eef57288e2b8cff0546
     HEAD_REF master
     PATCHES
         lz4.patch

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "librdkafka",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/confluentinc/librdkafka",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5489,7 +5489,7 @@
       "port-version": 0
     },
     "librdkafka": {
-      "baseline": "2.14.0",
+      "baseline": "2.14.1",
       "port-version": 0
     },
     "libredwg": {

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "140538f7e5a9efba319a1d2767ade6980c9987c4",
+      "version": "2.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b14d6a0dddb061cfae65e1dc65454890863ef45",
       "version": "2.14.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.