### PR TITLE
[xmlsec] Update to 1.3.10

### DIFF
--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required (VERSION 3.8)
-project (xmlsec1 C CXX) # CXX needed when libxml2 is built with icu
+
+message(STATUS "Reading version info from configure.ac")
+file(STRINGS "configure.ac" _xmlsec_ac_init REGEX "^AC_INIT\\(")
+if(_xmlsec_ac_init MATCHES "AC_INIT\\(\\[[^]]+\\],\\[([0-9]+\\.[0-9]+\\.[0-9]+)\\]")
+    set(XMLSEC_VERSION "${CMAKE_MATCH_1}")
+else()
+    message(FATAL_ERROR "Could not parse version from configure.ac")
+endif()
+
+project(xmlsec1 VERSION ${XMLSEC_VERSION} LANGUAGES C CXX) # CXX needed when libxml2 is built with icu
+
 
 include(CMakeDependentOption)
+include(GNUInstallDirs)
 
 option(INSTALL_HEADERS "Install headers" ON)
 cmake_dependent_option(BUILD_WITH_DYNAMIC_LOADING "Enable dynamic loading of xmlsec-crypto libraries" OFF BUILD_SHARED_LIBS OFF)
@@ -19,21 +30,11 @@ FILE(GLOB SOURCESXMLSECOPENSSL
     src/strings.c
 )
 
-message(STATUS "Reading version info from configure.ac")
-
-file(STRINGS "configure.ac"
-    _xmlsec_version_defines REGEX "XMLSEC_VERSION_(MAJOR|MINOR|SUBMINOR)=([0-9]+)$")
-
-foreach(ver ${_xmlsec_version_defines})
-    if(ver MATCHES "XMLSEC_VERSION_(MAJOR|MINOR|SUBMINOR)=([0-9]+)$")
-        set(XMLSEC_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
-    endif()
-endforeach()
-
-set(XMLSEC_VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR}.${XMLSEC_VERSION_SUBMINOR})
-math(EXPR XMLSEC_VERSION_INFO_NUMBER "${XMLSEC_VERSION_MAJOR} + ${XMLSEC_VERSION_MINOR}")
-set(XMLSEC_VERSION_INFO ${XMLSEC_VERSION_INFO_NUMBER}:${XMLSEC_VERSION_SUBMINOR}:${XMLSEC_VERSION_MINOR})
-
+set(XMLSEC_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
+set(XMLSEC_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
+set(XMLSEC_VERSION_SUBMINOR "${PROJECT_VERSION_PATCH}")
+math(EXPR _xmlsec_version_current "10000 * ${PROJECT_VERSION_MAJOR} + 100 * ${PROJECT_VERSION_MINOR} + ${PROJECT_VERSION_PATCH}")
+set(XMLSEC_VERSION_INFO "${_xmlsec_version_current}:0:0")
 message(STATUS "XMLSEC_VERSION: ${XMLSEC_VERSION}")
 message(STATUS "XMLSEC_VERSION_MAJOR: ${XMLSEC_VERSION_MAJOR}")
 message(STATUS "XMLSEC_VERSION_MINOR: ${XMLSEC_VERSION_MINOR}")
@@ -49,6 +50,38 @@ if(BUILD_SHARED_LIBS)
 else()
     string(REPLACE "!defined(XMLSEC_STATIC)" "0" EXPORTS_H "${EXPORTS_H}")
 endif()
+set(EXPORTS_H "${EXPORTS_H}
+#ifndef XMLSEC_NO_XSLT
+#define XMLSEC_NO_XSLT 1
+#endif
+#ifndef XMLSEC_CRYPTO_OPENSSL
+#define XMLSEC_CRYPTO_OPENSSL 1
+#endif
+#ifndef XMLSEC_NO_FTP
+#define XMLSEC_NO_FTP 1
+#endif
+#ifndef XMLSEC_NO_HTTP
+#define XMLSEC_NO_HTTP 1
+#endif
+#ifndef XMLSEC_NO_MD5
+#define XMLSEC_NO_MD5 1
+#endif
+#ifndef XMLSEC_NO_RIPEMD160
+#define XMLSEC_NO_RIPEMD160 1
+#endif
+#ifndef XMLSEC_NO_GOST
+#define XMLSEC_NO_GOST 1
+#endif
+#ifndef XMLSEC_NO_GOST2012
+#define XMLSEC_NO_GOST2012 1
+#endif
+#ifndef XMLSEC_NO_MLDSA
+#define XMLSEC_NO_MLDSA 1
+#endif
+#ifndef XMLSEC_NO_SLHDSA
+#define XMLSEC_NO_SLHDSA 1
+#endif
+")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/include/xmlsec/exports.h "${EXPORTS_H}")
 
 if(MSVC)
@@ -70,14 +103,7 @@ target_link_libraries(xmlsec1 PUBLIC LibXml2::LibXml2)
 target_link_libraries(xmlsec1-openssl PUBLIC xmlsec1 OpenSSL::Crypto)
 
 add_compile_definitions(
-    inline=__inline
     PACKAGE="xmlsec1"
-    HAVE_STDIO_H
-    HAVE_STDLIB_H
-    HAVE_STRING_H
-    HAVE_CTYPE_H
-    HAVE_MALLOC_H
-    HAVE_MEMORY_H
     XMLSEC_DEFAULT_CRYPTO="openssl"
     UNICODE
     _UNICODE
@@ -92,7 +118,7 @@ set(XMLSEC_CORE_CFLAGS XMLSEC_NO_XSLT XMLSEC_CRYPTO_OPENSSL XMLSEC_NO_FTP XMLSEC
 if(NOT BUILD_SHARED_LIBS)
     list(APPEND XMLSEC_CORE_CFLAGS XMLSEC_STATIC)
 endif()
-set(XMLSEC_OPENSSL_CFLAGS XMLSEC_NO_MD5 XMLSEC_NO_RIPEMD160 XMLSEC_NO_GOST XMLSEC_NO_GOST2012)
+set(XMLSEC_OPENSSL_CFLAGS XMLSEC_NO_MD5 XMLSEC_NO_RIPEMD160 XMLSEC_NO_GOST XMLSEC_NO_GOST2012 XMLSEC_NO_MLDSA XMLSEC_NO_SLHDSA)
 
 if(BUILD_WITH_DYNAMIC_LOADING)
     if(NOT WIN32)

--- a/ports/xmlsec/pkgconfig_fixes.patch
+++ b/ports/xmlsec/pkgconfig_fixes.patch
@@ -1,13 +1,3 @@
-diff --git a/xmlsec-openssl.pc.in b/xmlsec-openssl.pc.in
-index af3ae29..40635cf 100644
---- a/xmlsec-openssl.pc.in
-+++ b/xmlsec-openssl.pc.in
-@@ -8,5 +8,4 @@ Version: @VERSION@
- Description: XML Security Library implements XML Signature and XML Encryption standards
- Requires: libxml-2.0 >= @LIBXML_MIN_VERSION@ @LIBXSLT_PC_FILE_COND@
- Cflags: @XMLSEC_OPENSSL_CFLAGS@
--Cflags.private: -DXMLSEC_STATIC
- Libs: @XMLSEC_OPENSSL_LIBS@
 diff --git a/xmlsec.pc.in b/xmlsec.pc.in
 index 2d5a3ad..0f72d68 100644
 --- a/xmlsec.pc.in

--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 1c5f0c0dc667cabaedce9e26b988a82a19677647c530ea16959a499472eb1de2338a0b3b0d74a6ff5320efd65c6eae55f98919f371a89d0ad40e0253909d4fbe
+    SHA512 a13862f4c6278a5719897ec65df5ed31fb01bdb22a29a62f2cd1bf71a1c932eb8d887ce5e7ec2e0492a4a0d7f8b36f6889a708e29bb9d7d0f0bb61ca69a8423a
     HEAD_REF master
     PATCHES
         pkgconfig_fixes.patch

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.3.9",
-  "port-version": 1,
+  "version": "1.3.10",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10997,8 +10997,8 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.3.9",
-      "port-version": 1
+      "baseline": "1.3.10",
+      "port-version": 0
     },
     "xnnpack": {
       "baseline": "2024-08-20",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44626ef4c29dcaebec4a9bc33fe435e1eaf07de5",
+      "version": "1.3.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "47990f6bfcca4dde5fa2ce5f889ceb6f7ecdebba",
       "version": "1.3.9",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
Signed-off-by: Raul Metsma <raul@metsma.ee>