### PR TITLE
[yoctolib] update to 2.1.12708

### DIFF
--- a/ports/yoctolib/portfile.cmake
+++ b/ports/yoctolib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yoctopuce/yoctolib_cpp
     REF "v${VERSION}"
-    SHA512 6af8df55dc7dd021944d776c23c0ecd8b110b318127e35e110b155f5cc963625fed4f3f0055067b0b19e74ceb44a47d964d351964ed9a6744eb446ea9e16e1e8
+    SHA512 89cf1390610913a9114b0a0edd219d6c353cbec4b76c3655efe44bab0989b4ee3371cc4b671fd78068bf3d6a67d4cc52b35d9bbb9eb2df50628a4b10255b6fe1
     HEAD_REF master
     PATCHES
         001-cmake_config.patch

--- a/ports/yoctolib/vcpkg.json
+++ b/ports/yoctolib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yoctolib",
-  "version": "2.1.12672",
+  "version": "2.1.12708",
   "description": "Official Yoctopuce Library for C++",
   "homepage": "https://github.com/yoctopuce/yoctolib_cpp",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11097,7 +11097,7 @@
       "port-version": 0
     },
     "yoctolib": {
-      "baseline": "2.1.12672",
+      "baseline": "2.1.12708",
       "port-version": 0
     },
     "yoga": {

--- a/versions/y-/yoctolib.json
+++ b/versions/y-/yoctolib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bdad51b2ed134507c38cfa28223f4df66b630481",
+      "version": "2.1.12708",
+      "port-version": 0
+    },
+    {
       "git-tree": "ca99916ddfe4096cd01920c198852c7e2ef31b38",
       "version": "2.1.12672",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/yoctopuce/yoctolib_cpp/releases/tag/v2.1.12708
