### PR TITLE
[ecm] Update to 6.25.0

### DIFF
--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/extra-cmake-modules
     REF "v${VERSION}"
-    SHA512 960ef31c95c754a2a98749ba876310433ef2299d12b9bab56480238fb59a2361afc076463578597685dbc9be98727a5f100b47d489e60f3b1f14e736223b87a7
+    SHA512 b5169c07c3c1635beaee0e73263dd97065de788c2aec2d72aa35a9212355f03f4789e80a9ee79608e146139a6305facaaf1b693d2003b42c453a3d3593c78fd7
     HEAD_REF master
     PATCHES
         fix_generateqmltypes.patch # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/201

--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ecm",
-  "version": "6.24.0",
+  "version": "6.25.0",
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://invent.kde.org/frameworks/extra-cmake-modules",
   "documentation": "https://api.kde.org/ecm/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2725,7 +2725,7 @@
       "port-version": 0
     },
     "ecm": {
-      "baseline": "6.24.0",
+      "baseline": "6.25.0",
       "port-version": 0
     },
     "ecos": {

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0a91b791d83015910bfb302096e92fec281f706",
+      "version": "6.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "033c60f56d910aec773f29daec2ab618904ff413",
       "version": "6.24.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.