### PR TITLE
[gtk] Update to 4.22.2

### DIFF
--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 bfea8825c5cdaaaea95055bf522c384b23bb26e9b8205081d055f85dc5df5d357827139115a4b7efe4d42418714b2ac062349459f761b383bed170354ecfa7f4
+    SHA512 e5bb42320b53adcee71712d948f0ff7616867edc01d41f8833c03ae1594fa2dbb4b4143d038a9a9638751091154abdd0164468d5b8113d40c747a2a0b5a437cd
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtk",
-  "version": "4.22.0",
+  "version": "4.22.2",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3601,7 +3601,7 @@
       "port-version": 2
     },
     "gtk": {
-      "baseline": "4.22.0",
+      "baseline": "4.22.2",
       "port-version": 0
     },
     "gtk3": {

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c502040418981474e9b883a2d7ce88fb1c39b0d3",
+      "version": "4.22.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a00d8b7fc33fb6fa4794606fa5a83d682dc94e70",
       "version": "4.22.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
