### PR TITLE
[robotraconteur-companion] Add patch to fix eigen3 5 version in cmake package config files

### DIFF
--- a/ports/robotraconteur-companion/0001-support-eigen3-5.patch
+++ b/ports/robotraconteur-companion/0001-support-eigen3-5.patch
@@ -11,3 +11,13 @@ index 531f4c5..beff998 100644
  find_package(OpenCV)
  
  if(NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/robdef/group1")
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index b4c8633..f626a78 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -9,4 +9,4 @@ set(RobotRaconteur_STANDARD_ROBDEF_FILES @RR_INSTALLED_ROBDEF@)
+ set(RobotRaconteur_STANDARD_ROBDEF_DIRS @RR_INSTALLED_ROBDEF_DIRS@)
+ 
+ find_package(yaml-cpp REQUIRED)
+-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
++find_package(Eigen3 3.3...5 REQUIRED NO_MODULE)

--- a/ports/robotraconteur-companion/vcpkg.json
+++ b/ports/robotraconteur-companion/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "robotraconteur-companion",
   "version-semver": "0.4.2",
-  "port-version": 1,
+  "port-version": 2,
   "homepage": "https://github.com/robotraconteur/robotraconteur_companion",
   "license": "Apache-2.0",
   "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64 | arm32)) | (osx & (x64 | arm64))",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8818,7 +8818,7 @@
     },
     "robotraconteur-companion": {
       "baseline": "0.4.2",
-      "port-version": 1
+      "port-version": 2
     },
     "rocksdb": {
       "baseline": "11.0.4",

--- a/versions/r-/robotraconteur-companion.json
+++ b/versions/r-/robotraconteur-companion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36d4a083ef6a48e6614788bf7b89df770596faff",
+      "version-semver": "0.4.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "d96b2913b98c2b0c267078e21cd9e99d93ac3734",
       "version-semver": "0.4.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This PR adds a patch to the `robotraconteur-companion` package to fix finding `eigen3` version 5 or higher in the cmake package configuration files.
