### PR TITLE
[codepy] Add new port: write Python code in C++ (header-only)

### DIFF
--- a/ports/codepy/portfile.cmake
+++ b/ports/codepy/portfile.cmake
@@ -1,0 +1,8 @@
+{
+  "name": "codepy",
+  "version": "1.1.0",
+  "description": "Write Python code in C++ - a header-only library",
+  "homepage": "https://github.com/WangHaiPi/codepy",
+  "license": "MIT",
+  "dependencies": []
+}

--- a/ports/codepy/usage
+++ b/ports/codepy/usage
@@ -1,0 +1,11 @@
+codepy provides a header-only library.
+
+To use it:
+   #include <codepy.h>
+
+Then link with:
+   target_link_libraries(your_target PRIVATE codepy)
+
+Example:
+   py << \"print('hello')\";
+   py.run();

--- a/ports/portfile.cmake
+++ b/ports/portfile.cmake
@@ -1,0 +1,10 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO WangHaiPi/codepy
+    REF v1.1.0
+    SHA512 0
+)
+
+file(COPY ${SOURCE_PATH}/codepy.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/usage
+++ b/ports/usage
@@ -1,0 +1,11 @@
+codepy provides a header-only library.
+
+To use it:
+   #include <codepy.h>
+
+Then link with:
+   target_link_libraries(your_target PRIVATE codepy)
+
+Example:
+   py << \"print('hello')\";
+   py.run();

--- a/ports/vcpkg.json
+++ b/ports/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "codepy",
+  "version": "1.0.0",
+  "description": "Write Python code in C++ - a header-only library",
+  "homepage": "https://github.com/WangHaipi/codepy",
+  "license": "MIT",
+  "dependencies": [
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
+}


### PR DESCRIPTION
This PR adds `codepy`, a header-only C++ library that allows writing Python code directly in C++.

## Features
- Stream-based Python execution (`<<` operator)
- Single-line execution (`exec()`)
- Multi-line support (preserves indentation)
- Python package management (`pip`, `pipun`, `piplist`)
- Environment detection (`has_python`, `has_package`)
- Cross-platform (Windows, Linux, macOS)
- Automatic encoding conversion (GBK ↔ UTF-8)
- Built‑in PyPI mirrors for Chinese users

## Usage
```cpp
#include <codepy.h>

int main() {
    py << "print('Hello from Python')";
    py.run();
}
Homepage
https://github.com/WangHaiPi/codepy

Notes
Header-only, no compilation required

Requires Python 3.6+ in PATH