### PR TITLE
[odbccpp] Fix exported CMake config

### DIFF
--- a/ports/odbccpp/use-vcpkg-unixodbc.patch
+++ b/ports/odbccpp/use-vcpkg-unixodbc.patch
@@ -1,20 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 14a2f91..3c8b1da 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -4,7 +4,15 @@ SET(CMAKE_CXX_STANDARD 11)
- 
+@@ -7,7 +7,12 @@ PROJECT(odbccpp)
  INCLUDE(GNUInstallDirs)
  INCLUDE(CMakePackageConfigHelpers)
  
--FIND_PACKAGE(ODBC REQUIRED)
-+IF(ODBCCPP_USE_UNIXODBC)
-+    FIND_PACKAGE(unofficial-unixodbc CONFIG REQUIRED)
-+    SET(ODBC_TARGET unofficial::unixodbc::unixodbc)
-+    ADD_LIBRARY(ODBC::ODBC ALIAS ${ODBC_TARGET})
-+ELSE()
-+    FIND_PACKAGE(ODBC REQUIRED)
-+    SET(ODBC_TARGET ODBC::ODBC)
-+ENDIF()
-+
++if(ODBCCPP_USE_UNIXODBC)
++    find_package(ODBC NAMES unofficial-unixodbc REQUIRED)
++    add_library(ODBC::ODBC ALIAS unofficial::unixodbc::unixodbc)
++else()
+ FIND_PACKAGE(ODBC REQUIRED)
++endif()
  FIND_PACKAGE(Doxygen)
  FIND_PACKAGE(GTest)
+ 
+diff --git a/cmake/odbccppConfig.cmake.in b/cmake/odbccppConfig.cmake.in
+index 2ac429a..4736820 100644
+--- a/cmake/odbccppConfig.cmake.in
++++ b/cmake/odbccppConfig.cmake.in
+@@ -1,7 +1,11 @@
+ @PACKAGE_INIT@
+ 
+ include(CMakeFindDependencyMacro)
++if("@ODBCCPP_USE_UNIXODBC@")
++    find_dependency(unofficial-unixodbc CONFIG)
++else()
+ find_dependency(ODBC)
++endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/odbccppTargets.cmake")
  

--- a/ports/odbccpp/vcpkg.json
+++ b/ports/odbccpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "odbccpp",
   "version": "1.6",
+  "port-version": 1,
   "description": "An object-oriented C++ wrapper of the ODBC API from SAP",
   "homepage": "https://github.com/SAP/odbc-cpp-wrapper",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7194,7 +7194,7 @@
     },
     "odbccpp": {
       "baseline": "1.6",
-      "port-version": 0
+      "port-version": 1
     },
     "ode": {
       "baseline": "0.16.6",

--- a/versions/o-/odbccpp.json
+++ b/versions/o-/odbccpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fa7cb1697b435139df1bcc3292c1a1c6a2fb98e",
+      "version": "1.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "4cf05da841cdd917850bf0f5d90a6f2fa4f6da87",
       "version": "1.6",
       "port-version": 0


### PR DESCRIPTION
Amends #50152:
If a patch add `find_package` and an imported target, it usually needs `find_dependency`.
Trims the patch.
