### PR TITLE
[nanoarrow] Added support for IPC extension

### DIFF
--- a/ports/flatcc/fix_install_dir.patch
+++ b/ports/flatcc/fix_install_dir.patch
@@ -1,9 +1,9 @@
-﻿diff --git a/src/runtime/CMakeLists.txt b/src/runtime/CMakeLists.txt
-index 127e2a4..f827a79 100644
+diff --git a/src/runtime/CMakeLists.txt b/src/runtime/CMakeLists.txt
+index 68c0feb..925da41 100644
 --- a/src/runtime/CMakeLists.txt
 +++ b/src/runtime/CMakeLists.txt
-@@ -12,5 +12,8 @@ add_library(flatccrt
- )
+@@ -11,5 +11,8 @@ target_include_directories(flatccrt PUBLIC
+     "${PROJECT_SOURCE_DIR}/include")
  
  if (FLATCC_INSTALL)
 -    install(TARGETS flatccrt DESTINATION ${lib_dir})

--- a/ports/flatcc/portfile.cmake
+++ b/ports/flatcc/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dvidelabs/flatcc
-    REF "v${VERSION}"
-    SHA512 46ba5ca75facc7d3360dba797d24ae7bfe539a854a48831e1c7b96528cf9594d8bea22b267678fd7c6d742b6636d9e52930987119b4c6b2e38d4abe89b990cae
+    REF 29201734bf2d12713a7a1a035d31e5123aac9c93
+    SHA512 8c69259b3f314b9ce63e8930f4de9bcd38b164b96d77ad57c748a73510a606749ef40d2b5115c494f7806f8fe86c31b68e5fc3c476f7bca8d7fd70cfcefbe9ce
     HEAD_REF master
     PATCHES
         fix_install_dir.patch
@@ -20,6 +20,7 @@ vcpkg_cmake_configure(
         -DFLATCC_TEST=OFF
         -DFLATCC_CXX_TEST=OFF
         -DFLATCC_RTONLY=ON
+        -DFLATCC_DEBUG_CLANG_SANITIZE=OFF
         ${EXTRA_OPTIONS}
 )
 

--- a/ports/flatcc/vcpkg.json
+++ b/ports/flatcc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flatcc",
-  "version": "0.6.1",
+  "version": "0.6.2-pre-29201734bf2d12713a7a1a035d31e5123aac9c93",
   "description": "FlatBuffers Compiler and Library in C for C",
   "homepage": "https://github.com/dvidelabs/flatcc",
   "license": "Apache-2.0",

--- a/ports/nanoarrow/fix-flatccrt-name.patch
+++ b/ports/nanoarrow/fix-flatccrt-name.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d80849..c414865 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -229,8 +229,10 @@ if(NANOARROW_IPC)
+     set(NANOARROW_FLATCC_INCLUDE_DIR "${NANOARROW_FLATCC_ROOT_DIR}/include")
+     add_library(flatccrt STATIC IMPORTED)
+     set_target_properties(flatccrt
+-                          PROPERTIES IMPORTED_LOCATION
+-                                     "${NANOARROW_FLATCC_ROOT_DIR}/lib/libflatccrt.a"
++                          PROPERTIES IMPORTED_LOCATION_DEBUG
++                                     "${NANOARROW_FLATCC_ROOT_DIR}/debug/lib/${CMAKE_STATIC_LIBRARY_PREFIX}flatccrt_d${CMAKE_STATIC_LIBRARY_SUFFIX}"
++                                     IMPORTED_LOCATION_RELEASE
++                                     "${NANOARROW_FLATCC_ROOT_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}flatccrt${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                                      INTERFACE_INCLUDE_DIRECTORIES
+                                      "${NANOARROW_FLATCC_INCLUDE_DIR}")
+   endif()

--- a/ports/nanoarrow/fix-flatccrt-name.patch
+++ b/ports/nanoarrow/fix-flatccrt-name.patch
@@ -1,29 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index db08f06..14da6c8 100644
+index 2d80849..c414865 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -229,10 +229,21 @@ if(NANOARROW_IPC)
+@@ -229,8 +229,10 @@ if(NANOARROW_IPC)
      set(NANOARROW_FLATCC_INCLUDE_DIR "${NANOARROW_FLATCC_ROOT_DIR}/include")
      add_library(flatccrt STATIC IMPORTED)
      set_target_properties(flatccrt
 -                          PROPERTIES IMPORTED_LOCATION
 -                                     "${NANOARROW_FLATCC_ROOT_DIR}/lib/libflatccrt.a"
--                                     INTERFACE_INCLUDE_DIRECTORIES
-+                          PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
++                          PROPERTIES IMPORTED_LOCATION_DEBUG
++                                     "${NANOARROW_FLATCC_ROOT_DIR}/debug/lib/${CMAKE_STATIC_LIBRARY_PREFIX}flatccrt_d${CMAKE_STATIC_LIBRARY_SUFFIX}"
++                                     IMPORTED_LOCATION_RELEASE
++                                     "${NANOARROW_FLATCC_ROOT_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}flatccrt${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                                      INTERFACE_INCLUDE_DIRECTORIES
                                       "${NANOARROW_FLATCC_INCLUDE_DIR}")
-+    if (WIN32)
-+      set_target_properties(flatccrt
-+                            PROPERTIES IMPORTED_LOCATION_DEBUG
-+                                       "${NANOARROW_FLATCC_ROOT_DIR}/debug/lib/flatccrt_d.lib"
-+                                       IMPORTED_LOCATION_RELEASE
-+                                       "${NANOARROW_FLATCC_ROOT_DIR}/lib/flatccrt.lib")
-+    else()
-+      set_target_properties(flatccrt
-+                            PROPERTIES IMPORTED_LOCATION_DEBUG
-+                                       "${NANOARROW_FLATCC_ROOT_DIR}/debug/lib/libflatccrt_d.a"
-+                                       IMPORTED_LOCATION_RELEASE
-+                                       "${NANOARROW_FLATCC_ROOT_DIR}/lib/libflatccrt.a")
-+    endif()
    endif()
- 
-   if(NANOARROW_IPC_WITH_ZSTD)

--- a/ports/nanoarrow/fix-flatccrt-name.patch
+++ b/ports/nanoarrow/fix-flatccrt-name.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index db08f06..14da6c8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -229,10 +229,21 @@ if(NANOARROW_IPC)
+     set(NANOARROW_FLATCC_INCLUDE_DIR "${NANOARROW_FLATCC_ROOT_DIR}/include")
+     add_library(flatccrt STATIC IMPORTED)
+     set_target_properties(flatccrt
+-                          PROPERTIES IMPORTED_LOCATION
+-                                     "${NANOARROW_FLATCC_ROOT_DIR}/lib/libflatccrt.a"
+-                                     INTERFACE_INCLUDE_DIRECTORIES
++                          PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                      "${NANOARROW_FLATCC_INCLUDE_DIR}")
++    if (WIN32)
++      set_target_properties(flatccrt
++                            PROPERTIES IMPORTED_LOCATION_DEBUG
++                                       "${NANOARROW_FLATCC_ROOT_DIR}/debug/lib/flatccrt_d.lib"
++                                       IMPORTED_LOCATION_RELEASE
++                                       "${NANOARROW_FLATCC_ROOT_DIR}/lib/flatccrt.lib")
++    else()
++      set_target_properties(flatccrt
++                            PROPERTIES IMPORTED_LOCATION_DEBUG
++                                       "${NANOARROW_FLATCC_ROOT_DIR}/debug/lib/libflatccrt_d.a"
++                                       IMPORTED_LOCATION_RELEASE
++                                       "${NANOARROW_FLATCC_ROOT_DIR}/lib/libflatccrt.a")
++    endif()
+   endif()
+ 
+   if(NANOARROW_IPC_WITH_ZSTD)

--- a/ports/nanoarrow/fix-flatccrt-warning.patch
+++ b/ports/nanoarrow/fix-flatccrt-warning.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d80849..a8b2296 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -550,6 +550,10 @@ foreach(target
+                                        -Wconversion
+                                        -Wno-sign-conversion>)
+       endif()
++    else()
++      if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
++        target_compile_options(${target} PRIVATE -Wno-error=implicit-function-declaration)
++      endif()
+     endif()
+   endif()
+ endforeach()

--- a/ports/nanoarrow/portfile.cmake
+++ b/ports/nanoarrow/portfile.cmake
@@ -8,17 +8,25 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES fix-flatccrt-name.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/thirdparty")
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" NANOARROW_INSTALL_SHARED)
 
+if ("ipc" IN_LIST FEATURES)
+    set(FEATURE_OPTIONS "-DNANOARROW_IPC=ON")
+    set(FLATCCRT_OPTIONS "-DNANOARROW_FLATCC_ROOT_DIR=${CURRENT_INSTALLED_DIR}")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DNANOARROW_INSTALL_SHARED=${NANOARROW_INSTALL_SHARED}
         -DNANOARROW_DEBUG_EXTRA_WARNINGS=OFF
+        ${FEATURE_OPTIONS}
+        ${FLATCCRT_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/nanoarrow/portfile.cmake
+++ b/ports/nanoarrow/portfile.cmake
@@ -20,7 +20,7 @@ if ("ipc" IN_LIST FEATURES)
     set(FLATCCRT_OPTIONS "-DNANOARROW_FLATCC_ROOT_DIR=${CURRENT_INSTALLED_DIR}")
 
     if (VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_OSX)
-        set(ADDITIONAL_FLAGS "-DCMAKE_C_FLAGS=\"-Wno-implicit-function-declaration\"")
+        set(ADDITIONAL_FLAGS "-DCMAKE_C_FLAGS=-Wno-implicit-function-declaration")
     endif()
 endif()
 

--- a/ports/nanoarrow/portfile.cmake
+++ b/ports/nanoarrow/portfile.cmake
@@ -18,6 +18,10 @@ string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" NANOARROW_INSTALL_SHARED
 if ("ipc" IN_LIST FEATURES)
     set(FEATURE_OPTIONS "-DNANOARROW_IPC=ON")
     set(FLATCCRT_OPTIONS "-DNANOARROW_FLATCC_ROOT_DIR=${CURRENT_INSTALLED_DIR}")
+
+    if (VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_OSX)
+        set(ADDITIONAL_FLAGS "-DCMAKE_C_FLAGS=\"-Wno-implicit-function-declaration\"")
+    endif()
 endif()
 
 vcpkg_cmake_configure(
@@ -27,6 +31,7 @@ vcpkg_cmake_configure(
         -DNANOARROW_DEBUG_EXTRA_WARNINGS=OFF
         ${FEATURE_OPTIONS}
         ${FLATCCRT_OPTIONS}
+        ${ADDITIONAL_FLAGS}
 )
 
 vcpkg_cmake_install()

--- a/ports/nanoarrow/portfile.cmake
+++ b/ports/nanoarrow/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES fix-flatccrt-name.patch
+    PATCHES fix-flatccrt-warning.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/thirdparty")
@@ -18,10 +19,6 @@ string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" NANOARROW_INSTALL_SHARED
 if ("ipc" IN_LIST FEATURES)
     set(FEATURE_OPTIONS "-DNANOARROW_IPC=ON")
     set(FLATCCRT_OPTIONS "-DNANOARROW_FLATCC_ROOT_DIR=${CURRENT_INSTALLED_DIR}")
-
-    if (VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_OSX)
-        set(ADDITIONAL_FLAGS "-DCMAKE_C_FLAGS=-Wno-implicit-function-declaration")
-    endif()
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/nanoarrow/portfile.cmake
+++ b/ports/nanoarrow/portfile.cmake
@@ -28,7 +28,6 @@ vcpkg_cmake_configure(
         -DNANOARROW_DEBUG_EXTRA_WARNINGS=OFF
         ${FEATURE_OPTIONS}
         ${FLATCCRT_OPTIONS}
-        ${ADDITIONAL_FLAGS}
 )
 
 vcpkg_cmake_install()

--- a/ports/nanoarrow/vcpkg.json
+++ b/ports/nanoarrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nanoarrow",
   "version": "0.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Helpers for Arrow C Data & Arrow C Stream interfaces",
   "homepage": "https://arrow.apache.org/nanoarrow",
   "license": "Apache-2.0",

--- a/ports/nanoarrow/vcpkg.json
+++ b/ports/nanoarrow/vcpkg.json
@@ -14,5 +14,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "ipc": {
+      "description": "IPC support",
+      "dependencies": [
+        "flatcc"
+      ]
+    }
+  }
 }

--- a/ports/nanoarrow/vcpkg.json
+++ b/ports/nanoarrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nanoarrow",
   "version": "0.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Helpers for Arrow C Data & Arrow C Stream interfaces",
   "homepage": "https://arrow.apache.org/nanoarrow",
   "license": "Apache-2.0",
@@ -14,5 +14,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "ipc": {
+      "description": "IPC support",
+      "dependencies": [
+        "flatcc"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6810,7 +6810,7 @@
     },
     "nanoarrow": {
       "baseline": "0.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "nanobench": {
       "baseline": "4.3.11",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3081,7 +3081,7 @@
       "port-version": 0
     },
     "flatcc": {
-      "baseline": "0.6.1",
+      "baseline": "0.6.2-pre-29201734bf2d12713a7a1a035d31e5123aac9c93",
       "port-version": 0
     },
     "flecs": {
@@ -6806,7 +6806,7 @@
     },
     "nanoarrow": {
       "baseline": "0.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "nanobench": {
       "baseline": "4.3.11",

--- a/versions/f-/flatcc.json
+++ b/versions/f-/flatcc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7f6939cd46d01746a51baecc77c725b5fdf7491",
+      "version": "0.6.2-pre-29201734bf2d12713a7a1a035d31e5123aac9c93",
+      "port-version": 0
+    },
+    {
       "git-tree": "28d1a0bee8befc0e62a445d01923d96ae800d19e",
       "version": "0.6.1",
       "port-version": 0

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6ca69f111fea9acc8a8bf1f312d9a3db3e74180c",
+      "git-tree": "a19afc51f89586b56cf4c8ecd37a2595128d9b7c",
       "version": "0.8.0",
       "port-version": 2
     },

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc14f5c698ee35ee03bc04badde43cc32701570f",
+      "git-tree": "6ca69f111fea9acc8a8bf1f312d9a3db3e74180c",
       "version": "0.8.0",
       "port-version": 2
     },

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae9df1096d3fa61030db831cc917f815a0bd7b93",
+      "git-tree": "bc14f5c698ee35ee03bc04badde43cc32701570f",
       "version": "0.8.0",
       "port-version": 2
     },

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae9df1096d3fa61030db831cc917f815a0bd7b93",
+      "version": "0.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "9c1146b9c9360cc05905f6ecd1bff7ba0fb9cf73",
       "version": "0.8.0",
       "port-version": 1

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d377a0f822e3932778415133cff512d00c74b17a",
+      "version": "0.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "9c1146b9c9360cc05905f6ecd1bff7ba0fb9cf73",
       "version": "0.8.0",
       "port-version": 1

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a19afc51f89586b56cf4c8ecd37a2595128d9b7c",
+      "git-tree": "3ab7347e01f07b1f7d77ba2873a20406df562283",
       "version": "0.8.0",
       "port-version": 2
     },

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ab7347e01f07b1f7d77ba2873a20406df562283",
+      "git-tree": "87b5bcf29cf0edbec453ee736f5145f552da7795",
       "version": "0.8.0",
       "port-version": 2
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
