### PR TITLE
[mimalloc] Install minject tool on windows platform

### DIFF
--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -43,6 +43,15 @@ file(COPY
 )
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mimalloc)
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL
+        "${SOURCE_PATH}/bin/minject.exe"
+        "${SOURCE_PATH}/bin/minject32.exe"
+        "${SOURCE_PATH}/bin/minject-arm64.exe"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/"
+    )
+endif()
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string(
         "${CURRENT_PACKAGES_DIR}/include/mimalloc.h"

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mimalloc",
   "version": "3.3.0",
+  "port-version": 1,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3796,10 +3796,10 @@
       "baseline": "2.11.1",
       "port-version": 0
     },
-	"hical61-hical": {
-	  "baseline": "1.0.1",
-	  "port-version": 0
-	},
+    "hical61-hical": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "hidapi": {
       "baseline": "0.15.0",
       "port-version": 1
@@ -6498,7 +6498,7 @@
     },
     "mimalloc": {
       "baseline": "3.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "mimicpp": {
       "baseline": "9.3.0",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc6fc14cf9c98de519520ff49c0504422266681a",
+      "version": "3.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8f41fd3b0c556519d0bb71488917d8bf0fcb23b5",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Add installation of the minject tool on Windows. The minject executables are provided by mimalloc and can be used to injects the mimalloc dll and ensures that it comes first in the import table.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.