### PR TITLE
[glog] Drop obsolete customprefix feature

### DIFF
--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -14,9 +14,7 @@ vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         unwind          WITH_UNWIND
-        customprefix    WITH_CUSTOM_PREFIX
-    INVERTED_FEATURES
-        unwind          CMAKE_DISABLE_FIND_PACKAGE_Unwind
+        unwind          VCPKG_LOCK_FIND_PACKAGE_Unwind
 )
 file(REMOVE "${SOURCE_PATH}/glog-modules.cmake.in")
 

--- a/ports/glog/vcpkg.json
+++ b/ports/glog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glog",
   "version": "0.7.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ implementation of the Google logging module",
   "homepage": "https://github.com/google/glog",
   "license": "BSD-3-Clause",
@@ -17,9 +17,6 @@
     }
   ],
   "features": {
-    "customprefix": {
-      "description": "Enable support for user-generated message prefixes"
-    },
     "unwind": {
       "description": "Enable libunwind support",
       "supports": "linux",

--- a/ports/ripper37-libbase/vcpkg.json
+++ b/ports/ripper37-libbase/vcpkg.json
@@ -1,17 +1,13 @@
 {
   "name": "ripper37-libbase",
   "version": "1.1.2",
+  "port-version": 1,
   "description": "Standalone reimplementation of //base module from Chromium",
   "homepage": "https://github.com/RippeR37/libbase",
   "documentation": "https://ripper37.github.io/libbase",
   "license": "MIT",
   "dependencies": [
-    {
-      "name": "glog",
-      "features": [
-        "customprefix"
-      ]
-    },
+    "glog",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8774,7 +8774,7 @@
     },
     "ripper37-libbase": {
       "baseline": "1.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "rivers": {
       "baseline": "2022-05-16",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3462,7 +3462,7 @@
     },
     "glog": {
       "baseline": "0.7.1",
-      "port-version": 1
+      "port-version": 2
     },
     "gloo": {
       "baseline": "20240626",
@@ -3796,10 +3796,10 @@
       "baseline": "2.11.1",
       "port-version": 0
     },
-	"hical61-hical": {
-	  "baseline": "1.0.1",
-	  "port-version": 0
-	},
+    "hical61-hical": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "hidapi": {
       "baseline": "0.15.0",
       "port-version": 1

--- a/versions/g-/glog.json
+++ b/versions/g-/glog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96e7f5eb08b6e94e85f0bb734eac654dcf0ad06d",
+      "version": "0.7.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "eb5d2744754ff4d687c5dc984bb63ecf08eb3ca0",
       "version": "0.7.1",
       "port-version": 1

--- a/versions/r-/ripper37-libbase.json
+++ b/versions/r-/ripper37-libbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb106ffbc07940d5121b627105619ca7ba557d82",
+      "version": "1.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "899698832275b0bb6292dd9d23a8be92f3ab9566",
       "version": "1.1.2",
       "port-version": 0


### PR DESCRIPTION
Removed by upstream in 0.7.0. Resolves CMake warning
~~~
  The following variables are not used in CMakeLists.txt:

      WITH_CUSTOM_PREFIX
~~~
