### PR TITLE
[stillwater-universal] update to 4.6.9

### DIFF
--- a/ports/stillwater-universal/portfile.cmake
+++ b/ports/stillwater-universal/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stillwater-sc/universal
     REF "v${VERSION}"
-    SHA512 7370e60cb54bcccc40eb612c0c57a4de060670c39a9379285a21044f6c5dd38f75e8588351f978a807cafea1aedcd3b367560f642faa5eda754701751ca0f379
+    SHA512 c4b9d0ed4a46f8ce7b2eb12c2afa3ee3b75f1bda8817568a2fb00a65dfa115b552ddd8863d65eca565f91bb2faa7e808a0d7f4d7a2983beafba8e0e1ba75b937
     HEAD_REF master
     PATCHES
         fix-install-path.patch

--- a/ports/stillwater-universal/vcpkg.json
+++ b/ports/stillwater-universal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stillwater-universal",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "description": "A header-only C++ library for plug-in replacement number systems for native types",
   "homepage": "https://github.com/stillwater-sc/universal",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9653,7 +9653,7 @@
       "port-version": 0
     },
     "stillwater-universal": {
-      "baseline": "4.6.8",
+      "baseline": "4.6.9",
       "port-version": 0
     },
     "stlab": {

--- a/versions/s-/stillwater-universal.json
+++ b/versions/s-/stillwater-universal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aebf952d784d29600a2d27e615ffc451e1a6f059",
+      "version": "4.6.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "4507cdf2ade369cfa5759a1a07a90d07a488f390",
       "version": "4.6.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stillwater-sc/universal/releases/tag/v4.6.9
