### PR TITLE
[telnetpp] update to 4.0.2

### DIFF
--- a/ports/telnetpp/fix_include.patch
+++ b/ports/telnetpp/fix_include.patch
@@ -1,10 +1,10 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4d53fa6..c426e70 100644
+index 488b52b..260aaf3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -218,7 +218,7 @@ target_compile_features(telnetpp
- target_include_directories(telnetpp
+@@ -235,7 +235,7 @@ target_include_directories(telnetpp
      PUBLIC
+         $<BUILD_INTERFACE:${TELNETPP_GENERATED_INCLUDE_DIR}>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 -        $<INSTALL_INTERFACE:include/telnetpp-${TELNETPP_VERSION}>
 +        $<INSTALL_INTERFACE:include>

--- a/ports/telnetpp/portfile.cmake
+++ b/ports/telnetpp/portfile.cmake
@@ -2,9 +2,9 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KazDragon/telnetpp
   REF "v${VERSION}"
-  SHA512 0ff458675a44462655ff3869ff1c3390eec9d594a57a9ed95fb18f9b627b740b4f4be5e1fee3a5b9558553a05aae33134f8f8d26a85b8e4d2e01a927a8337c32
+  SHA512 71046b8831a9e48d01cec61ed854ee703e042e33b4b1c8c15afaf7b7f0b74da581d7a2eff4c906a5d2ffae7f84798f94cc4e39a7cc53aa534b4690ef95569757
   HEAD_REF master
-  PATCHES 
+  PATCHES
       fix-install-paths-v3.patch
       fix_include.patch
 
@@ -26,7 +26,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH share/telnetpp)
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/telnetpp-config.cmake" "####################################################################################" 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/telnetpp-config.cmake" "####################################################################################"
                     [[####################################################################################
                       include(CMakeFindDependencyMacro)
                       find_dependency(Boost)
@@ -35,7 +35,7 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/telnetpp-config.cmak
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE 
-    "${CURRENT_PACKAGES_DIR}/include/telnetpp/version.hpp.in" 
+file(REMOVE
+    "${CURRENT_PACKAGES_DIR}/include/telnetpp/version.hpp.in"
 )
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/telnetpp/vcpkg.json
+++ b/ports/telnetpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "telnetpp",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "description": "A C++ library for interacting with Telnet streams",
   "homepage": "https://github.com/KazDragon/telnetpp",
   "documentation": "https://kazdragon.github.io/telnetpp/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9909,7 +9909,7 @@
       "port-version": 0
     },
     "telnetpp": {
-      "baseline": "4.0.0",
+      "baseline": "4.0.2",
       "port-version": 0
     },
     "tensorflow": {

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2ee021a75aea055f84470b3932085e6bfd07b71",
+      "version": "4.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "037d34be211605fcad95f52ae99cf45cd7f8cc46",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/KazDragon/telnetpp/releases/tag/v4.0.2
