### PR TITLE
[fluidsynth] update to 2.5.4

### DIFF
--- a/ports/fluidsynth/fix-gcem.patch
+++ b/ports/fluidsynth/fix-gcem.patch
@@ -1,21 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2bb396ba..25d3557b 100644
+index 2bc2531..07047ac 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -364,7 +364,7 @@ if ( WIN32 )
+@@ -367,7 +367,7 @@ if ( WIN32 )
    endif  ( MINGW )
  endif ( WIN32 )
  
 -find_package ( GCEM REQUIRED )
 +find_package ( gcem CONFIG REQUIRED )
  
- set ( LIBFLUID_LIBS ${MATH_LIBRARY} )
- if (NOT ((CMAKE_SYSTEM_NAME MATCHES "SunOS") OR (osal STREQUAL "embedded")))
+ find_library ( HAS_LIBM NAMES "m" )
+ if ( HAS_LIBM )
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index cc43d691..3021d54f 100644
+index 388e848..48d5377 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -295,7 +295,7 @@ target_include_directories ( libfluidsynth-OBJ PRIVATE
+@@ -299,7 +299,7 @@ target_include_directories ( libfluidsynth-OBJ PRIVATE
      ${FluidSynth_SOURCE_DIR}/src/sfloader
      ${FluidSynth_SOURCE_DIR}/src/bindings
      ${FluidSynth_SOURCE_DIR}/include

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
     REF "v${VERSION}"
-    SHA512 5c376d9bf6388f04e5d48375a70682f9d7edcd65809383afc0190c77140b086492abc17a8d3a2aa07e59dde681ab17a919e9b8b7e174a91a2951c30b262c10e4
+    SHA512 7539e32a56309ce61c4178dad38ac8aae82ebab37398e1a7b6d1e2d5abd0af73ae7af35358e655a935666c7e6fde30885a0d6e4b7ad8b129ab02f6aad8f18dd0
     HEAD_REF master
     PATCHES
         fix-gcem.patch

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fluidsynth",
-  "version": "2.5.2",
-  "port-version": 1,
+  "version": "2.5.4",
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -329,7 +329,6 @@ flashlight-sequence[cuda]:x86-windows=cascade
 flashlight-sequence[openmp]:arm64-osx=feature-fails # No openmp on osx
 flashlight-text[kenlm]:arm64-windows=cascade
 fltk:arm64-linux=fail
-fluidsynth[pulseaudio]:arm64-linux=cascade
 fluidsynth[pulseaudio](android | osx | windows)=cascade
 forge:arm64-linux=cascade
 forge:x86-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3109,8 +3109,8 @@
       "port-version": 0
     },
     "fluidsynth": {
-      "baseline": "2.5.2",
-      "port-version": 1
+      "baseline": "2.5.4",
+      "port-version": 0
     },
     "flux": {
       "baseline": "0.4.0",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48798e344d7d76993660993d776bfbaeb2e08b66",
+      "version": "2.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "b73b0b49b786f73c4d2257e72125ec595466ca3a",
       "version": "2.5.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/FluidSynth/fluidsynth/releases/tag/v2.5.4
