### PR TITLE
[vincentlaucsb-csv-parser] update to 3.5.1

### DIFF
--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -1,10 +1,10 @@
 diff --git a/include/internal/basic_csv_parser.hpp b/include/internal/basic_csv_parser.hpp
-index 3b90b14..5460157 100644
+index 1fd844c..ee53291 100644
 --- a/include/internal/basic_csv_parser.hpp
 +++ b/include/internal/basic_csv_parser.hpp
 @@ -12,7 +12,7 @@
  #include <vector>
-
+ 
  #if !defined(__EMSCRIPTEN__)
 -#include "../external/mio.hpp"
 +#include "mio/mmap.hpp"
@@ -12,22 +12,22 @@ index 3b90b14..5460157 100644
  #include "basic_csv_parser_simd.hpp"
  #include "col_names.hpp"
 diff --git a/include/internal/common.hpp b/include/internal/common.hpp
-index 62f27d5..fc4a0a6 100644
+index 72c70b8..9ad1dca 100644
 --- a/include/internal/common.hpp
 +++ b/include/internal/common.hpp
 @@ -97,7 +97,7 @@
  #endif
-
+ 
  // Include string_view BEFORE csv namespace to avoid namespace pollution issues
 -#ifdef CSV_HAS_CXX17
 +#if 1
  #include <string_view>
  #else
  #include "../external/string_view.hpp"
-@@ -122,7 +122,7 @@ namespace csv {
-
+@@ -123,7 +123,7 @@ namespace csv {
+ // Allows static assertions without specifying a message
  #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
-
+ 
 -#ifdef CSV_HAS_CXX17
 +#if 1
       /** @typedef string_view

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 be4e54aa9805675cdbc3424f7dc9ef729871ea81aa983c60276ffea8376fbb37e20681f2576038fb1530ff92df4f66e91b35f3385341bbf080c97a4702e20ec7
+    SHA512 5fa16dd9cdfcfa4938b0d338a7d95f6429d9490d0d28da2829289a0c48da7096a59d658bce6f6d8faf3d352c1a29ef9eb51abeac1ecf9f6db434e295ce392819
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 5fa16dd9cdfcfa4938b0d338a7d95f6429d9490d0d28da2829289a0c48da7096a59d658bce6f6d8faf3d352c1a29ef9eb51abeac1ecf9f6db434e295ce392819
+    SHA512 ac0fbd1989a55a5a74567a72edd568b4f7050ebe3a7cffbe255c5feaf7c2adf09cce230cc8f14ff8f1d890b8def4ccf6d3a07e7c1ea6cd36e4f57310fccc982c
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10573,7 +10573,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "3.4.0",
+      "baseline": "3.5.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10573,7 +10573,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "3.5.0",
+      "baseline": "3.5.1",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71fc05fe21edbf9ae8b4a0f40e5a407550a0f5f7",
+      "version": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e35c6d2c8cad096271389898c3d60a8ca6892dfa",
       "version": "3.4.0",
       "port-version": 0

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "71fc05fe21edbf9ae8b4a0f40e5a407550a0f5f7",
-      "version": "3.5.0",
+      "git-tree": "aa8d88e15572fb35f9dc02ff2aa4318cf766f204",
+      "version": "3.5.1",
       "port-version": 0
     },
     {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/3.5.1
