### PR TITLE
[numkong] Update to 7.6.0

### DIFF
--- a/ports/numkong/export-target.patch
+++ b/ports/numkong/export-target.patch
@@ -1,36 +1,36 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 01a7c60..70f8ce7 100644
+index b7c15176..24bfe6c3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -266,7 +266,7 @@ if (MSVC)
+@@ -290,7 +290,7 @@ if (MSVC)
  endif ()
-
+ 
  # Enable Clang C modules for incremental compilation
 -if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 +if (FALSE)
      target_compile_options(
          numkong INTERFACE $<$<COMPILE_LANGUAGE:C>:-fmodules> $<$<COMPILE_LANGUAGE:C>:-fimplicit-module-maps>
                            $<$<COMPILE_LANGUAGE:C>:-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache>
-@@ -601,7 +601,7 @@ if (NK_BUILD_SHARED)
+@@ -625,7 +625,7 @@ if (NK_BUILD_SHARED)
          )
-
+ 
          add_executable(nk_shared ${NK_SOURCES} "${CMAKE_BINARY_DIR}/emscripten_stub.c")
 -        target_include_directories(nk_shared PUBLIC "${PROJECT_SOURCE_DIR}/include")
 +        target_include_directories(nk_shared PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
-
+ 
          if (NK_WASM64_)
              set_target_properties(
-@@ -647,7 +647,7 @@ if (NK_BUILD_SHARED)
-         endif ()
+@@ -677,7 +677,7 @@ if (NK_BUILD_SHARED)
+         set_target_properties(nk_shared PROPERTIES ENABLE_EXPORTS ON)
      else ()
          add_library(nk_shared SHARED ${NK_SOURCES})
 -        target_include_directories(nk_shared PUBLIC "${PROJECT_SOURCE_DIR}/include")
 +        target_include_directories(nk_shared PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
          set_target_properties(nk_shared PROPERTIES OUTPUT_NAME numkong)
-
+ 
          # Hide all symbols by default; only NK_DYNAMIC-annotated API functions are exported.
-@@ -705,15 +705,21 @@ if (NK_BUILD_SHARED)
-
+@@ -735,15 +735,21 @@ if (NK_BUILD_SHARED)
+ 
      install(
          TARGETS nk_shared
 -        ARCHIVE
@@ -53,11 +53,11 @@ index 01a7c60..70f8ce7 100644
 +        DESTINATION share/unofficial-numkong
      )
  endif ()
-
-@@ -756,5 +762,4 @@ if (NK_BUILD_SHARED_TEST)
-     add_test(NAME nk_shared_test COMMAND nk_shared_test)
+ 
+@@ -827,5 +833,4 @@ if (NK_BUILD_CUDA_TEST)
+     add_test(NAME nk_cuda_test COMMAND nk_cuda_test)
  endif ()
-
+ 
 -install(DIRECTORY include/ DESTINATION include)
 -install(DIRECTORY c/ DESTINATION share/doc/${PROJECT_NAME}/src)
 +install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN *.h)

--- a/ports/numkong/portfile.cmake
+++ b/ports/numkong/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/NumKong
     REF "v${VERSION}"
-    SHA512 fdb0d0190890fdf802c5ec9b3164d52b5721efcdff98e33eb1cf06558b6e3c00ecfba44d22492dd9619749b77237e0d94ba366c39ee543f9ae744552faf6e2bc
+    SHA512 0454cc0168d3cd3a3d176cdfc879bfa2b4752b036248f7a7445a22dd1bd0c1f1c78a68e50fd15c8d0f0c10d234de28cc3cea906c37d01850e8939aecddd86b91
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/numkong/vcpkg.json
+++ b/ports/numkong/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "numkong",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "description": "NumKong (previously SimSIMD) delivers mixed-precision numerics that are often faster and more accurate than standard BLAS libraries",
   "homepage": "https://github.com/ashvardanian/NumKong",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3796,10 +3796,10 @@
       "baseline": "2.11.1",
       "port-version": 0
     },
-	"hical61-hical": {
-	  "baseline": "1.0.1",
-	  "port-version": 0
-	},
+    "hical61-hical": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "hidapi": {
       "baseline": "0.15.0",
       "port-version": 1
@@ -7093,7 +7093,7 @@
       "port-version": 0
     },
     "numkong": {
-      "baseline": "7.5.0",
+      "baseline": "7.6.0",
       "port-version": 0
     },
     "nuraft": {

--- a/versions/n-/numkong.json
+++ b/versions/n-/numkong.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e80b3d4e584e487b26051726e473813384194cc1",
+      "version": "7.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "60c65c4d7561b9aaaab0d8db75b9c3e0350df50e",
       "version": "7.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.