### PR TITLE
[usearch] update to 2.25.1

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unum-cloud/usearch
     REF "v${VERSION}"
-    SHA512 d2ba01c86a102b23aa2827392bc4759d33cf6bcd7e7a1baa35cff9c2100721726c7bff854d8d06065095d480dc2a8c2245fe7afe404d53b577b7a9c9446fb8c0
+    SHA512 bbddcc500032c71e8e7563454baddf798cb8eb7bb96f4c6cab1137c86a8e0849701eb70d6e3b1329575d90faffa91656844a2a0205132f447ac9c2ffabc87e3c
     HEAD_REF main
     PATCHES
         use-vcpkg-ports.patch
@@ -12,7 +12,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         fp16     USEARCH_USE_FP16LIB
         jemalloc USEARCH_USE_JEMALLOC
-        simsimd  USEARCH_USE_SIMSIMD
+        numkong  USEARCH_USE_NUMKONG
 )
 
 vcpkg_cmake_configure(

--- a/ports/usearch/use-vcpkg-ports.patch
+++ b/ports/usearch/use-vcpkg-ports.patch
@@ -1,33 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1f6b036..abfca67 100644
+index 58f31ff..d8ae930 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -149,18 +149,6 @@ target_include_directories(
-     ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${USEARCH_INCLUDE_BUILD_DIR}>
+@@ -149,9 +149,10 @@ target_include_directories(
                                                                 $<INSTALL_INTERFACE:include>
  )
--if (USEARCH_USE_FP16LIB)
--    target_include_directories(
--        ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/fp16/include>
--                                                                   $<INSTALL_INTERFACE:fp16/include>
--    )
--endif ()
--if (USEARCH_USE_SIMSIMD)
--    target_include_directories(
--        ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE}
--        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/simsimd/include> $<INSTALL_INTERFACE:simsimd/include>
--    )
--endif ()
- 
+ if (USEARCH_USE_NUMKONG)
++    find_path(NUMKONG_INCLUDE_DIRS "numkong/attention.h")
+     target_include_directories(
+         ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE}
+-        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/numkong/include> $<INSTALL_INTERFACE:numkong/include>
++        INTERFACE $<BUILD_INTERFACE:${NUMKONG_INCLUDE_DIRS}> $<INSTALL_INTERFACE:include>
+     )
+ endif ()
  # Install a pkg-config file, so other tools can find this
- configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkg-config.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc")
-@@ -220,8 +208,7 @@ if (NOT CMAKE_BUILD_TYPE)
+@@ -212,7 +213,7 @@ if (NOT CMAKE_BUILD_TYPE)
  endif ()
  
  # Include directories
--set(USEARCH_HEADER_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/fp16/include"
--                            "${CMAKE_CURRENT_SOURCE_DIR}/simsimd/include"
-+set(USEARCH_HEADER_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/include"
- )
+-set(USEARCH_HEADER_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/numkong/include")
++set(USEARCH_HEADER_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/include")
  
  # Function to setup target
+ function (setup_target TARGET_NAME)
+@@ -385,7 +386,7 @@ endfunction ()
+ 
+ # Delegate NumKong compilation to its own CMakeLists.txt — it handles ISA detection, NK_TARGET_* flags, and SIMD
+ # dispatch backends internally.
+-if (USEARCH_USE_NUMKONG)
++if (0)
+     set(NK_BUILD_SHARED
+         ON
+         CACHE BOOL "" FORCE

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usearch",
-  "version": "2.24.0",
+  "version": "2.25.1",
   "description": "Fastest Search & Clustering engine × for Vectors & Strings",
   "homepage": "https://github.com/unum-cloud/usearch",
   "license": "Apache-2.0",
@@ -27,10 +27,10 @@
         "jemalloc"
       ]
     },
-    "simsimd": {
-      "description": "Use SimSIMD hardware-accelerated metrics",
+    "numkong": {
+      "description": "Use NumKong hardware-accelerated metrics",
       "dependencies": [
-        "simsimd"
+        "numkong"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10365,7 +10365,7 @@
       "port-version": 0
     },
     "usearch": {
-      "baseline": "2.24.0",
+      "baseline": "2.25.1",
       "port-version": 0
     },
     "usockets": {

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "348825085ebe0a1d25c26191f1a94fa92e628b5f",
+      "version": "2.25.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f91e30e3275f8bdebb7b5a6bcc6dcadebcac257",
       "version": "2.24.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/unum-cloud/USearch/releases/tag/v2.25.1
