### PR TITLE
[libuuid] Replace usleep() with nanosleep() for Linux toolchain compatibility

### DIFF
--- a/ports/libuuid/fix-usleep-with-nanosleep.patch
+++ b/ports/libuuid/fix-usleep-with-nanosleep.patch
@@ -1,0 +1,40 @@
+diff --git a/all-io.h b/all-io.h
+index d8a3e6d..6a9d9e0 100644
+--- a/all-io.h
++++ b/all-io.h
+@@ -9,6 +9,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <time.h>
+ 
+ #include "c.h"
+ 
+@@ -29,8 +30,11 @@ static inline int write_all(int fd, const void *buf, size_t count)
+ 				buf = (void *) ((char *) buf + tmp);
+ 		} else if (errno != EINTR && errno != EAGAIN)
+ 			return -1;
+-		if (errno == EAGAIN)	/* Try later, *sigh* */
+-			usleep(10000);
++		if (errno == EAGAIN) {	/* Try later, *sigh* */
++			struct timespec ts = { .tv_sec = 0, .tv_nsec = 10000000 };
++
++			nanosleep(&ts, NULL);
++		}
+ 	}
+ 	return 0;
+ }
+@@ -46,8 +50,11 @@ static inline int fwrite_all(const void *ptr, size_t size,
+ 				ptr = (void *) ((char *) ptr + (tmp * size));
+ 		} else if (errno != EINTR && errno != EAGAIN)
+ 			return -1;
+-		if (errno == EAGAIN)	/* Try later, *sigh* */
+-			usleep(10000);
++		if (errno == EAGAIN) {	/* Try later, *sigh* */
++			struct timespec ts = { .tv_sec = 0, .tv_nsec = 10000000 };
++
++			nanosleep(&ts, NULL);
++		}
+ 	}
+ 	return 0;
+ }

--- a/ports/libuuid/portfile.cmake
+++ b/ports/libuuid/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_sourceforge(
     REPO libuuid
     FILENAME "libuuid-${LIBUUID_VERSION}.tar.gz"
     SHA512 77488caccc66503f6f2ded7bdfc4d3bc2c20b24a8dc95b2051633c695e99ec27876ffbafe38269b939826e1fdb06eea328f07b796c9e0aaca12331a787175507
+    PATCHES
+        fix-usleep-with-nanosleep.patch
 )
 
 file(COPY

--- a/ports/libuuid/vcpkg.json
+++ b/ports/libuuid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libuuid",
   "version": "1.0.3",
-  "port-version": 16,
+  "port-version": 17,
   "description": "Universally unique id library",
   "homepage": "https://sourceforge.net/projects/libuuid/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5786,7 +5786,7 @@
     },
     "libuuid": {
       "baseline": "1.0.3",
-      "port-version": 16
+      "port-version": 17
     },
     "libuv": {
       "baseline": "1.52.1",

--- a/versions/l-/libuuid.json
+++ b/versions/l-/libuuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecdb458cf474347a983e5ffb199fbd6f82de708a",
+      "version": "1.0.3",
+      "port-version": 17
+    },
+    {
       "git-tree": "7955bebb26eaac1bb6a893211f6f33a6966efba3",
       "version": "1.0.3",
       "port-version": 16


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

## Problem

The current `libuuid` 1.0.3 source used by this port calls `usleep()` from `all-io.h`.

On some Linux toolchains, especially Conda/Pixi environments using `x86_64-conda-linux-gnu-*`, this fails with:

```text
error: implicit declaration of function 'usleep'; did you mean 'sleep'?
```

Although `usleep(3)` may still be exposed by glibc under certain feature-test macro combinations, it is an obsolete interface and its declaration is sensitive to libc/header macro configuration.

## Root cause

The bundled upstream source is relatively old and still relies on `usleep()`. In the affected environments, that declaration is not exposed during the `libuuid` build, which causes compilation of `gen_uuid.c` to fail through `all-io.h`.

## Solution

Replace the two `usleep(10000)` calls in `all-io.h` with `nanosleep()` and include `<time.h>`.

This avoids reliance on obsolete `usleep()` declarations and makes the build more robust across Linux libc/toolchain configurations.

## Validation

Reproduced with:

- `vcpkg install libuuid --triplet x64-linux-dynamic`
- Conda/Pixi toolchain:
  - `x86_64-conda-linux-gnu-cc`
  - GCC 14.3.0

Before this patch, the build failed in `gen_uuid.c` with an implicit declaration error for `usleep`.
After this patch, the `usleep`-related compilation failure is resolved.
