### PR TITLE
[sdbus-cpp] Revise

### DIFF
--- a/ports/sdbus-cpp/dependencies.diff
+++ b/ports/sdbus-cpp/dependencies.diff
@@ -1,0 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a174223..2983cc1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -223,7 +223,12 @@ set_target_properties(sdbus-c++
+                                  VERSION "${SDBUSCPP_VERSION}"
+                                  SOVERSION "${SDBUSCPP_VERSION_MAJOR}"
+                                  OUTPUT_NAME "sdbus-c++")
+-target_link_libraries(sdbus-c++ PRIVATE sdbus-c++-objlib)
++target_link_libraries(sdbus-c++
++    PRIVATE
++        $<BUILD_INTERFACE:sdbus-c++-objlib>
++        $<INSTALL_INTERFACE:Systemd::Libsystemd>
++        $<INSTALL_INTERFACE:Threads::Threads>
++)
+ 
+ #----------------------------------
+ # TESTS
+@@ -287,7 +292,6 @@ configure_file(pkgconfig/sdbus-c++.pc.in pkgconfig/sdbus-c++.pc @ONLY)
+ if(SDBUSCPP_INSTALL)
+     set(EXPORT_SET sdbus-c++)
+     if(NOT BUILD_SHARED_LIBS)
+-        list(APPEND EXPORT_SET "sdbus-c++-objlib")
+     endif()
+     install(TARGETS ${EXPORT_SET}
+             EXPORT sdbus-c++-targets
+diff --git a/cmake/sdbus-c++-config.cmake.in b/cmake/sdbus-c++-config.cmake.in
+index 035dc0f..974ef27 100644
+--- a/cmake/sdbus-c++-config.cmake.in
++++ b/cmake/sdbus-c++-config.cmake.in
+@@ -1,4 +1,11 @@
+ @PACKAGE_INIT@
+ 
++if(NOT "@BUILD_SHARED_LIBS@")
++    include(CMakeFindDependencyMacro)
++    find_dependency(Threads)
++    find_dependency(PkgConfig)
++    pkg_check_modules(Systemd IMPORTED_TARGET)
++endif()
++
+ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+ check_required_components("@PROJECT_NAME@")

--- a/ports/sdbus-cpp/portfile.cmake
+++ b/ports/sdbus-cpp/portfile.cmake
@@ -1,36 +1,42 @@
-message(WARNING "You will need to install sytemd dependencies to build sdbus-cpp:\nsudo apt install libsystemd-dev\n")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Kistler-Group/sdbus-cpp
     REF "v${VERSION}"
     SHA512 bdc628156dc8cc5a1ab0cb08bca8dc58801a233446bc34ce3d10d14b169f8dece16a1204937a674ea80976d9a92da72d72305b8e9ef617a50f7bc5a00c40223a
+    PATCHES
+        dependencies.diff
 )
-
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tool   SDBUSCPP_BUILD_CODEGEN
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSDBUSCPP_BUILD_DOCS=OFF
         -DSDBUSCPP_BUILD_LIBSYSTEMD=OFF
+        -DSDBUSCPP_SDBUS_LIB=systemd
+    OPTIONS_DEBUG
+        -DSDBUSCPP_BUILD_CODEGEN=OFF
 )
-
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME sdbus-c++ CONFIG_PATH lib/cmake/sdbus-c++)
 vcpkg_fixup_pkgconfig()
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/debug/bin"
-)
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING-LGPL-Exception")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 if ("tool" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES sdbus-c++-xml2cpp AUTO_CLEAN)
 endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+#file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING-LGPL-Exception")

--- a/ports/sdbus-cpp/usage
+++ b/ports/sdbus-cpp/usage
@@ -1,3 +1,0 @@
-sdbus-cpp provides CMake targets:
-    find_package(sdbus-c++ REQUIRED)
-    target_link_libraries(main PRIVATE SDBusCpp::sdbus-c++)

--- a/ports/sdbus-cpp/vcpkg.json
+++ b/ports/sdbus-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdbus-cpp",
   "version": "2.2.1",
+  "port-version": 1,
   "description": "High-level C++ D-Bus library for Linux designed to provide easy-to-use yet powerful API in modern C++",
   "homepage": "https://github.com/Kistler-Group/sdbus-cpp",
   "license": "LGPL-2.1-only",
@@ -19,7 +20,7 @@
   ],
   "features": {
     "tool": {
-      "description": "build C++ codegen tool",
+      "description": "Build C++ codegen tool",
       "dependencies": [
         "expat"
       ]

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1310,7 +1310,6 @@ salome-medcoupling(arm | !(linux | windows))=cascade
 saucer:arm64-linux=cascade
 saucer:arm64-osx=fail # std::move_only_function is not supported
 saucer:x64-linux=fail # requires gcc14 or later
-sdbus-cpp:arm64-linux=cascade
 sdformat13:x64-windows-static=cascade
 sdl1:arm64-linux=fail
 sdl1-mixer(android)=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9014,7 +9014,7 @@
     },
     "sdbus-cpp": {
       "baseline": "2.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sdflib": {
       "baseline": "2025-11-03",

--- a/versions/s-/sdbus-cpp.json
+++ b/versions/s-/sdbus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4126b439fc27245277fa446c300240c44555f1b4",
+      "version": "2.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "0590ba651e593ed556ca6bfecd42014cbed8ef9f",
       "version": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
Drop obsolete message. (Resolves #49519.)
Provide PKG_CONFIG.
Use autogenerated usage. (Shows pkgconfig usage.) For proper output, omit obj lib from export.
Add find_dependency.

