### PR TITLE
[libscran-umappp] Update to 3.3.1

### DIFF
--- a/ports/libscran-umappp/0002-remove-eigen3-version-constraint.diff
+++ b/ports/libscran-umappp/0002-remove-eigen3-version-constraint.diff
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 942157c..8b4ee79 100644
+index 078d0d0..9649f3d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -24,7 +24,7 @@ if(UMAPPP_FETCH_EXTERN)
  else()
      find_package(ltla_aarand 1.1.0 CONFIG REQUIRED)
-     find_package(ltla_irlba 3.0.0 CONFIG REQUIRED)
+     find_package(ltla_irlba 3.1.0 CONFIG REQUIRED)
 -    find_package(Eigen3 5.0.0 CONFIG REQUIRED)
 +    find_package(Eigen3 CONFIG REQUIRED)
      find_package(ltla_subpar 0.5.0 CONFIG REQUIRED)

--- a/ports/libscran-umappp/portfile.cmake
+++ b/ports/libscran-umappp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libscran/umappp
     REF "v${VERSION}"
-    SHA512 73f4979a0d8b15fc7bc62de04210fba2a95dd8a30480882c3e88a8e2ea3b48e2e9f37d02f39c09648a79ad27a10906b0b1c26600afe573539070d77696ef44f7
+    SHA512 e1eb144b7b3a28b419d2d8645a3b5c8ff003fb9b67bb566a238c692b3d44580712f3dfb57ac3d4ed1cc5244b3e1fefb90d7449e0dfd41ded9401d5d6fe20ef20
     HEAD_REF master
     PATCHES
         0001-make-find-dependency-not-required.diff # https://github.com/libscran/umappp/pull/35

--- a/ports/libscran-umappp/vcpkg.json
+++ b/ports/libscran-umappp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libscran-umappp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "UMAP C++ implementation",
   "homepage": "https://github.com/libscran/umappp",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5545,7 +5545,7 @@
       "port-version": 0
     },
     "libscran-umappp": {
-      "baseline": "3.3.0",
+      "baseline": "3.3.1",
       "port-version": 0
     },
     "libsecret": {

--- a/versions/l-/libscran-umappp.json
+++ b/versions/l-/libscran-umappp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c499893711d1ca6881a11bdb94ac5fa8829f4733",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7ab13a4280e75342a69be6abbb01d8384f793d6d",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.