### PR TITLE
[mimalloc] Update to 3.3.1

### DIFF
--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/mimalloc
     REF "v${VERSION}"
-    SHA512 601bdf622d0bc7521edf0cc73d1caec9d976bcd1faa689ff48cc18a9a6a3b2294b571fc71d3266b38907bc5aad10a41d92d03d2cdde139a30b08357ee7bc25c5
+    SHA512 c829e402ad9b8784cb30c6d42186627e779936d90c952474785e0da77a31699e8532f64d8a0e68d4559c759a0c1c6910391ba4423191bfbc8a92876b95abe8a7
     HEAD_REF dev3
     PATCHES
         pkgconfig-cxx.diff

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mimalloc",
-  "version": "3.3.0",
-  "port-version": 1,
+  "version": "3.3.1",
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6497,8 +6497,8 @@
       "port-version": 3
     },
     "mimalloc": {
-      "baseline": "3.3.0",
-      "port-version": 1
+      "baseline": "3.3.1",
+      "port-version": 0
     },
     "mimicpp": {
       "baseline": "9.3.0",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0b2abb3f0c610f3cb3174c8196b15ec11c9b0cf0",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc6fc14cf9c98de519520ff49c0504422266681a",
       "version": "3.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.