### PR TITLE
[vsg] Update to 1.1.14

### DIFF
--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vsg-dev/VulkanSceneGraph
     REF "v${VERSION}"
-    SHA512 d74d5cc889fc9faaac54992e482898fedd2f13a0f136b0ec2b2044ab7b5d3e7f6a26a81dc875fd1cd3eb926031ddf3f428008429bcc8d5cb22cd16f4eb21a5a9
+    SHA512 6b7e400d066cfe5ea26a5739ba0e0cce4eaf34d66e9d5144b9cf4e9909305ac6294af6d25255ece7733bae699ad43f8048a9a5914b4a16253b1ae73d43f3ae51
     HEAD_REF master
 )
 

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vsg",
-  "version": "1.1.13",
-  "port-version": 1,
+  "version": "1.1.14",
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10629,8 +10629,8 @@
       "port-version": 2
     },
     "vsg": {
-      "baseline": "1.1.13",
-      "port-version": 1
+      "baseline": "1.1.14",
+      "port-version": 0
     },
     "vsgimgui": {
       "baseline": "0.7.0",

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f773cc30d6c66a908cfd906693496db07dda94f9",
+      "version": "1.1.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "c51bb8e753b57c5215f46038862f6bdfced53b9f",
       "version": "1.1.13",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.