### PR TITLE
[md4c] update to 0.5.3

### DIFF
--- a/ports/md4c/cmake.patch
+++ b/ports/md4c/cmake.patch
@@ -1,10 +1,10 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index aec8293..600d51b 100644
+index 3f271ef..5324940 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -51,16 +51,6 @@ elseif(MSVC)
+@@ -40,16 +40,6 @@ elseif(MSVC)
      # Disable warnings about the so-called unsecured functions:
-     add_definitions(/D_CRT_SECURE_NO_WARNINGS)
+     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
      add_compile_options(/W3)
 -
 -    # Specify proper C runtime library:

--- a/ports/md4c/portfile.cmake
+++ b/ports/md4c/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mity/md4c
     REF "release-${VERSION}"
-    SHA512 30607ba39d6c59329f5a56a90cd816ff60b82ea752ac2b9df356d756529cfc49170019fae5df32fa94afc0e2a186c66eaf56fa6373d18436c06ace670675ba85
+    SHA512 213d6b9fbad24b2bfb4fa0a8124cb4c20861da2cb57790882aa0e5ff8c18903450f1d9ffdbcc0547debd103137777059f27a526cd818294f698b5ffdbfe7fbcb
     HEAD_REF master
     PATCHES
         "cmake.patch"

--- a/ports/md4c/vcpkg.json
+++ b/ports/md4c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "md4c",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "MD4C is a C library providing a Markdown parser.",
   "homepage": "https://github.com/mity/md4c",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6397,7 +6397,7 @@
       "port-version": 0
     },
     "md4c": {
-      "baseline": "0.5.2",
+      "baseline": "0.5.3",
       "port-version": 0
     },
     "mdl-sdk": {

--- a/versions/m-/md4c.json
+++ b/versions/m-/md4c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8688206cd03a6c3a66a626208187cb605f770359",
+      "version": "0.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d6a0dd2cd6d89e4c83bebf016a978b82c0733c5",
       "version": "0.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/mity/md4c/releases/tag/release-0.5.3
