### PR TITLE
[cpprestsdk] patch to fix clang error with unique_ptr to incomplete type

### DIFF
--- a/ports/cpprestsdk/fix-incomplete-json-value.patch
+++ b/ports/cpprestsdk/fix-incomplete-json-value.patch
@@ -1,0 +1,42 @@
+diff --git a/Release/include/cpprest/json.h b/Release/include/cpprest/json.h
+index 9549f9b8..bf8e1c03 100644
+--- a/Release/include/cpprest/json.h
++++ b/Release/include/cpprest/json.h
+@@ -737,12 +737,13 @@ private:
+     _ASYNCRTIMP void format(std::basic_string<char>& string) const;
+ 
+ #ifdef ENABLE_JSON_VALUE_VISUALIZER
+-    explicit value(std::unique_ptr<details::_Value> v, value_type kind) : m_value(std::move(v)), m_kind(kind)
++    explicit value(std::unique_ptr<details::_Value> v, value_type kind);
+ #else
+-    explicit value(std::unique_ptr<details::_Value> v) : m_value(std::move(v))
++    explicit value(std::unique_ptr<details::_Value> v);
+ #endif
+-    {
+-    }
++public:
++    ~value() noexcept;
++private:
+ 
+     std::unique_ptr<details::_Value> m_value;
+ #ifdef ENABLE_JSON_VALUE_VISUALIZER
+diff --git a/Release/src/json/json.cpp b/Release/src/json/json.cpp
+index 079ccae4..aa4598e9 100644
+--- a/Release/src/json/json.cpp
++++ b/Release/src/json/json.cpp
+@@ -495,3 +495,15 @@ const web::json::details::json_error_category_impl& web::json::details::json_err
+ #endif
+     return instance;
+ }
++
++#ifdef ENABLE_JSON_VALUE_VISUALIZER
++web::json::value::value(std::unique_ptr<details::_Value> v, value_type kind) : m_value(std::move(v)), m_kind(kind)
++#else
++web::json::value::value(std::unique_ptr<details::_Value> v) : m_value(std::move(v))
++#endif
++{
++}
++
++web::json::value::~value() noexcept
++{
++}

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         fix-clang-dllimport.patch # workaround for https://github.com/microsoft/cpprestsdk/issues/1710
         silence-stdext-checked-array-iterators-warning.patch
         fix-asio-error.patch
+        fix-incomplete-json-value.patch
 )
 
 vcpkg_check_features(

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.19",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2122,7 +2122,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.19",
-      "port-version": 3
+      "port-version": 4
     },
     "cppslippi": {
       "baseline": "1.4.3.18",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf1204a8c7367efc227e922b9aad22ce9ebc2695",
+      "version": "2.10.19",
+      "port-version": 4
+    },
+    {
       "git-tree": "9f5e160191038cbbd2470e534c43f051c80e7d44",
       "version": "2.10.19",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

Clang versions 18 and above with standard version C++23 using libstdc++ fails to compile cpprestsdk due to [llvm issue 111185](https://github.com/llvm/llvm-project/issues/111185).

Defining the json::value destructor in the .cpp file where the full definition is visible fixes the issue and allows compiling with C++23.

Cpprestsdk upstream is no longer being updated.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
