### PR TITLE
ethindp-prism: update to 0.11.6

### DIFF
--- a/ports/ethindp-prism/portfile.cmake
+++ b/ports/ethindp-prism/portfile.cmake
@@ -4,8 +4,8 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO ethindp/prism
-  REF v0.11.4
-  SHA512 dcb1d66542196c48144d38ddd783e7387f3f37d2ad5558cfcb133d33d9c9372fab8d235686b68a9c257dd84b8bdf832fb2779f7ad8b4e93aa5acc023ecdf8455
+  REF v0.11.6
+  SHA512 c374371352081bc25ca908bf93ec2f217223b5471f94b997c6ac00ac6820be1dfe691ada41faf605e90a8e9213abbd79758aa8f7a0a178954c4663c3b4c5aada
   HEAD_REF master
 )
 vcpkg_check_features(

--- a/ports/ethindp-prism/vcpkg.json
+++ b/ports/ethindp-prism/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ethindp-prism",
-  "version": "0.11.4",
+  "version": "0.11.6",
   "description": "The Platform-agnostic Reader Interface for Speech and Messages",
   "license": "MPL-2.0",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2837,7 +2837,7 @@
       "port-version": 3
     },
     "ethindp-prism": {
-      "baseline": "0.11.4",
+      "baseline": "0.11.6",
       "port-version": 0
     },
     "etl": {

--- a/versions/e-/ethindp-prism.json
+++ b/versions/e-/ethindp-prism.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1225978e1420dc787a71430e04e147edb210aae1",
+      "version": "0.11.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "a668e41ec015f9a255b701e95d78a60bd65b7bfd",
       "version": "0.11.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
