### PR TITLE
[openssl] Set the CC variable to fix cross compilation

### DIFF
--- a/ports/openssl/unix/portfile.cmake
+++ b/ports/openssl/unix/portfile.cmake
@@ -41,6 +41,8 @@ elseif(NOT compiler_in_path STREQUAL VCPKG_DETECTED_CMAKE_C_COMPILER)
     vcpkg_host_path_list(PREPEND ENV{PATH} "${compiler_path}")
 endif()
 
+set(ENV{CC} ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+
 vcpkg_list(SET MAKEFILE_OPTIONS)
 if(VCPKG_TARGET_IS_ANDROID)
     set(ENV{ANDROID_NDK_ROOT} "${VCPKG_DETECTED_CMAKE_ANDROID_NDK}")

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.6.2",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7410,7 +7410,7 @@
     },
     "openssl": {
       "baseline": "3.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "616d8ec407771eb9fd096e1753823c3c2b6ad94b",
+      "version": "3.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "131700c32d3bdaa8b4862deb3113a8053793833f",
       "version": "3.6.2",
       "port-version": 0


### PR DESCRIPTION
This change fixes cross compiling to arm64 from x64 in my case.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.