### PR TITLE
Add new port cpp-unicodelib

### DIFF
--- a/ports/cpp-unicodelib/portfile.cmake
+++ b/ports/cpp-unicodelib/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO yhirose/cpp-unicodelib
+    REF f18fbc3ac3108f132fa25eea0ad130fb10d80da0 # committed on 2025-12-05
+    SHA512 606ac1f6ea36aaf0133190ae0d2f8d2745c2c7ffdcf1461900960e4e0bc0bc8eaf8653f47e4b7656516d3d25c5b0912e84e98f9e578e20f0c8df8d68296e95cc
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/unicode.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cpp-unicodelib/vcpkg.json
+++ b/ports/cpp-unicodelib/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "cpp-unicodelib",
+  "version-date": "2025-12-05",
+  "description": "A C++17 single-file header-only Unicode library. (Unicode 17.0.0)",
+  "homepage": "https://github.com/yhirose/cpp-unicodelib",
+  "license": "MIT"
+}


### PR DESCRIPTION
Add cpp-unicodelib as new port: https://github.com/yhirose/cpp-unicodelib

Closes #51318 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.