### PR TITLE
[qtmultimedia] Disable ffmpeg for emscripten

### DIFF
--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtmultimedia",
   "version": "6.10.2",
+  "port-version": 1,
   "description": "Qt Multimedia is an add-on module that provides a rich set of QML types and C++ classes to handle multimedia content.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -20,7 +21,10 @@
     }
   ],
   "default-features": [
-    "ffmpeg",
+    {
+      "name": "ffmpeg",
+      "platform": "!emscripten"
+    },
     {
       "name": "pipewire",
       "platform": "linux"
@@ -34,6 +38,7 @@
   "features": {
     "ffmpeg": {
       "description": "Build with ffmpeg",
+      "supports": "!emscripten",
       "dependencies": [
         {
           "name": "ffmpeg",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8390,7 +8390,7 @@
     },
     "qtmultimedia": {
       "baseline": "6.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtnetworkauth": {
       "baseline": "6.10.2",

--- a/versions/q-/qtmultimedia.json
+++ b/versions/q-/qtmultimedia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "083f7229d6a7cc518c025f85f04678b5cddf3174",
+      "version": "6.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "9ee301670ac40e534b0807a991d47c08703facc2",
       "version": "6.10.2",
       "port-version": 0


### PR DESCRIPTION
Ffmpeg is not supported by emscripten

```
  ERROR: Feature "ffmpeg": Forcing to "ON" breaks its condition:
      FFmpeg_FOUND AND ( APPLE OR WIN32 OR ANDROID OR QNX OR QT_FEATURE_pulseaudio OR QT_FEATURE_pipewire ) AND QT_FEATURE_thread
  Condition values dump:
      FFmpeg_FOUND = "TRUE"
      APPLE = ""
      WIN32 = ""
      ANDROID = "0"
      QNX = "0"
      QT_FEATURE_pulseaudio = "OFF"
      QT_FEATURE_pipewire = "OFF"
      QT_FEATURE_thread = "ON"
```