### PR TITLE
[liblsl] update to 1.17.7

### DIFF
--- a/ports/liblsl/portfile.cmake
+++ b/ports/liblsl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sccn/liblsl
     REF v${VERSION}
-    SHA512 5b540c9b7c0b6fb5827dbb8afdc85267d8e36e3b807704af11ed89865754f1d786f28414adf1c3c7df15956143a0bfc82c449c5ff8656d18f1a6e03c4c1e89ce
+    SHA512 bbf19fa15e1286bc47a55ea883faa11187bf148284908e15bc30543b553de666702f41ae9e4606b77505c3facdd72483c01de7fc8e84ca5c04c43b3563177650
     HEAD_REF master
     PATCHES
         use-find-package-asio.patch
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DLSL_BUILD_STATIC=${LSL_BUILD_STATIC}
         -DLSL_BUNDLED_BOOST=OFF # we use the boost vcpkg packages instead
-        -DLSL_BUNDLED_PUGIXML=OFF # we use the pugixml vcpkg package instead
+        -DLSL_FETCH_PUGIXML=OFF # we use the pugixml vcpkg package instead
         -DLSL_FRAMEWORK=OFF
         -Dlslgitrevision=v${VERSION}
         -Dlslgitbranch=master

--- a/ports/liblsl/vcpkg.json
+++ b/ports/liblsl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblsl",
-  "version": "1.17.5",
+  "version": "1.17.7",
   "description": "C++ lsl library for multi-modal time-synched data transmission over the local network",
   "homepage": "https://github.com/sccn/liblsl",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5185,7 +5185,7 @@
       "port-version": 0
     },
     "liblsl": {
-      "baseline": "1.17.5",
+      "baseline": "1.17.7",
       "port-version": 0
     },
     "liblsquic": {

--- a/versions/l-/liblsl.json
+++ b/versions/l-/liblsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03b3f5c2b279ca8b90beb30bc102258a2c994c0c",
+      "version": "1.17.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "650466afe7379871fce32ddc014d7aaf9f09b23d",
       "version": "1.17.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/sccn/liblsl/releases/tag/v1.17.7
