### PR TITLE
[xmlsec] update to 1.3.11

### DIFF
--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 a13862f4c6278a5719897ec65df5ed31fb01bdb22a29a62f2cd1bf71a1c932eb8d887ce5e7ec2e0492a4a0d7f8b36f6889a708e29bb9d7d0f0bb61ca69a8423a
+    SHA512 23baf617f1bbfe2228ca00df9542a6cc5b4cf9896c448e3154a6e2ef878e6c081e7ee4b74b2101690fd44edbd6e55d3466b86986ca14f11fe556e113434aa33e
     HEAD_REF master
     PATCHES
         pkgconfig_fixes.patch

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11009,7 +11009,7 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.3.10",
+      "baseline": "1.3.11",
       "port-version": 0
     },
     "xnnpack": {

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "375577f17a02b8cd6e7df3bea4ce843d417e1175",
+      "version": "1.3.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "44626ef4c29dcaebec4a9bc33fe435e1eaf07de5",
       "version": "1.3.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/lsh123/xmlsec/releases/tag/1.3.11
