### PR TITLE
Restore KF6 CMake package names after port rename

### DIFF
--- a/ports/karchive/portfile.cmake
+++ b/ports/karchive/portfile.cmake
@@ -34,7 +34,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6Archive)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6archive
+    CONFIG_PATH lib/cmake/KF6Archive
+)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE

--- a/ports/karchive/vcpkg.json
+++ b/ports/karchive/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "karchive",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "File compression",
   "homepage": "https://invent.kde.org/frameworks/karchive",
   "documentation": "https://api.kde.org/karchive-index.html",

--- a/ports/kbreezeicons/portfile.cmake
+++ b/ports/kbreezeicons/portfile.cmake
@@ -17,7 +17,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6BreezeIcons)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6breezeicons
+    CONFIG_PATH lib/cmake/KF6BreezeIcons
+)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/kbreezeicons/vcpkg.json
+++ b/ports/kbreezeicons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kbreezeicons",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Breeze icon theme for KDE Frameworks 6",
   "homepage": "https://invent.kde.org/frameworks/breeze-icons",
   "documentation": "https://api.kde.org/breeze-icons-index.html",

--- a/ports/kcodecs/portfile.cmake
+++ b/ports/kcodecs/portfile.cmake
@@ -23,7 +23,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6Codecs)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6codecs
+    CONFIG_PATH lib/cmake/KF6Codecs
+)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/kcodecs/vcpkg.json
+++ b/ports/kcodecs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kcodecs",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "String encoding library",
   "homepage": "https://invent.kde.org/frameworks/kcodecs",
   "documentation": "https://api.kde.org/kcodecs-index.html",

--- a/ports/kcoreaddons/portfile.cmake
+++ b/ports/kcoreaddons/portfile.cmake
@@ -27,7 +27,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6CoreAddons)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6coreaddons
+    CONFIG_PATH lib/cmake/KF6CoreAddons
+)
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig(SKIP_CHECK)
 

--- a/ports/kcoreaddons/vcpkg.json
+++ b/ports/kcoreaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kcoreaddons",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Addons to QtCore",
   "homepage": "https://invent.kde.org/frameworks/kcoreaddons",
   "documentation": "https://api.kde.org/kcoreaddons-index.html",

--- a/ports/kdbusaddons/portfile.cmake
+++ b/ports/kdbusaddons/portfile.cmake
@@ -23,7 +23,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6DBusAddons)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6dbusaddons
+    CONFIG_PATH lib/cmake/KF6DBusAddons
+)
 vcpkg_copy_pdbs()
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/kdbusaddons/vcpkg.json
+++ b/ports/kdbusaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kdbusaddons",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Convenience classes for D-Bus",
   "homepage": "https://invent.kde.org/frameworks/kdbusaddons",
   "documentation": "https://api.kde.org/kdbusaddons-index.html",

--- a/ports/kglobalaccel/portfile.cmake
+++ b/ports/kglobalaccel/portfile.cmake
@@ -27,7 +27,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6GlobalAccel)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6globalaccel
+    CONFIG_PATH lib/cmake/KF6GlobalAccel
+)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/kglobalaccel/vcpkg.json
+++ b/ports/kglobalaccel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kglobalaccel",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Global desktop keyboard shortcuts",
   "homepage": "https://invent.kde.org/frameworks/kglobalaccel",
   "documentation": "https://api.kde.org/kglobalaccel-index.html",

--- a/ports/ki18n/portfile.cmake
+++ b/ports/ki18n/portfile.cmake
@@ -30,7 +30,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6I18n)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6i18n
+    CONFIG_PATH lib/cmake/KF6I18n
+)
 vcpkg_copy_pdbs()
 
 # KF6I18nMacros.cmake embeds the Python executable path used at build time as a

--- a/ports/ki18n/vcpkg.json
+++ b/ports/ki18n/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ki18n",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Advanced internationalization framework",
   "homepage": "https://invent.kde.org/frameworks/ki18n",
   "documentation": "https://api.kde.org/ki18n-index.html",

--- a/ports/kitemmodels/portfile.cmake
+++ b/ports/kitemmodels/portfile.cmake
@@ -17,7 +17,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6ItemModels)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6itemmodels
+    CONFIG_PATH lib/cmake/KF6ItemModels
+)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/kitemmodels/vcpkg.json
+++ b/ports/kitemmodels/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kitemmodels",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Models for Qt Model/View system",
   "homepage": "https://invent.kde.org/frameworks/kitemmodels",
   "documentation": "https://api.kde.org/kitemmodels-index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4230,19 +4230,19 @@
     },
     "karchive": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kbreezeicons": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kcodecs": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kcoreaddons": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kcp": {
       "baseline": "1.7",
@@ -4258,7 +4258,7 @@
     },
     "kdbusaddons": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kddockwidgets": {
       "baseline": "2.4.0",
@@ -4474,11 +4474,11 @@
     },
     "kglobalaccel": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ki18n": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kinectsdk1": {
       "baseline": "1.8",
@@ -4498,7 +4498,7 @@
     },
     "kitemmodels": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kleidiai": {
       "baseline": "1.19.0",

--- a/versions/k-/karchive.json
+++ b/versions/k-/karchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0b3065f564d5f63f48149974f4219303c9eb51f",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf04e51b59672ce1496bec4b25f9ed5251ebef3c",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/kbreezeicons.json
+++ b/versions/k-/kbreezeicons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2128394a21c7256698a9096cbbf8327c94824a0",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3bdeac3470220790a0ffd11af3a0318fb73b5204",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/kcodecs.json
+++ b/versions/k-/kcodecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a7fe1e588b3d83924ee30d633f39f3423d93620",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2386381dd33fe4f31853573153214e9fbbb976ba",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/kcoreaddons.json
+++ b/versions/k-/kcoreaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78ac4e283a5ea376c44bbf9ab916aec753182750",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "859fc10346ca25f6dd6069f88fe79e842a42bece",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/kdbusaddons.json
+++ b/versions/k-/kdbusaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfc37913ae1ea4e2d6f8737079919e2ea9c44da0",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "44624da83ba466e1a4311d8ff0154ee5ad4a065e",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/kglobalaccel.json
+++ b/versions/k-/kglobalaccel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fcc31b64c09a2f96d2f88c5059b092b7694f2fd1",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb227a614c3a0f9dc2e55f8f0ee41db26eab1bd8",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/ki18n.json
+++ b/versions/k-/ki18n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d39f535c99fb95f7ec9b6a2bfe748bae2640cfd0",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "befde47793c07edffdff61ef6382a707acff991c",
       "version": "6.25.0",
       "port-version": 0

--- a/versions/k-/kitemmodels.json
+++ b/versions/k-/kitemmodels.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9b417173e11288c95e13d745bae9b0c22d2b632",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c8119053f9a248f7efcf070bd06bf46cae40bfe9",
       "version": "6.25.0",
       "port-version": 0


### PR DESCRIPTION
Follow up to #51173

After the rename, packages are now in `share/kcoreaddons` instead of `share/kf6coreaddons` and are not found by CMake. This patch restore the original path.

Should fix #50860 and #50861