### PR TITLE
[macos] Replace PATs with tokens.

### DIFF
--- a/scripts/azure-pipelines/osx/README.md
+++ b/scripts/azure-pipelines/osx/README.md
@@ -13,6 +13,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
   although you'll need to sign in first: <https://developer.apple.com/downloads>  
   If you are doing this from a local macos box, you can skip to the "update the macos host" step.  
 - [ ] An Xcode Command Line Tools installer
+- [ ] PowerShell 7.x, Azure CLI, and `az login` with your Microsoft corp credentials
 
 ### Instructions (ARM64)
 
@@ -21,20 +22,21 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Go to that machine in the KVM. (Passwords are stored as secrets in the CPP_GITHUB\vcpkg\vcpkgmm-passwords key vault)
 - [ ] Update the macos host
 - [ ] (Once only) install `macosvm` to `~` (this tarball is also backed up in our `vcpkg-image-minting` storage account). For example from a dev workstation:
-    ```sh
+    ```
     ssh vcpkg@HOSTMACHINE
     curl -L -o macosvm-0.2-2-arm64-darwin21.tar.gz https://github.com/s-u/macosvm/releases/download/0.2-2/macosvm-0.2-2-arm64-darwin21.tar.gz
     tar xvf macosvm-0.2-2-arm64-darwin21.tar.gz
     rm macosvm-0.2-2-arm64-darwin21.tar.gz
     exit
     ```
-- [ ] Download the matching `.ipsw` for the macOS copy to install. See https://mrmacintosh.com/apple-silicon-m1-full-macos-restore-ipsw-firmware-files-database/ ; links there to find the .ipsw. Example: https://updates.cdn-apple.com/2025FallFCS/fullrestores/093-37399/E144C918-CF99-4BBC-B1D0-3E739B9A3F2D/UniversalMac_26.2_25C56_Restore.ipsw
+- [ ] Download the matching `.ipsw` for the macOS copy to install. See https://mrmacintosh.com/apple-silicon-m1-full-macos-restore-ipsw-firmware-files-database/ ; links there to find the .ipsw. Example: 
+https://updates.cdn-apple.com/2026WinterFCS/fullrestores/122-28781/DCB2FF13-06CB-44C2-BCA2-DFCAF3521D46/UniversalMac_26.4.1_25E253_Restore.ipsw
 - [ ] Determine the VM name using the form "vcpkg-osx-<date>-arm64", for example "vcpkg-osx-2026-01-12-arm64".
-- [ ] Open a terminal and run the following commands to create the VM with vcpkg-osx-2026-01-12-arm64 and UniversalMac_26.2_25C56_Restore.ipsw replaced as appropriate. This must be run in the KVM as it uses a GUI:
-    ```sh
+- [ ] Open a terminal and run the following commands to create the VM with vcpkg-osx-2026-01-12-arm64 and UniversalMac_26.4.1_25E253_Restore.ipsw replaced as appropriate. This must be run in the KVM as it uses a GUI:
+    ```
     mkdir -p ~/Parallels/vcpkg-osx-2026-01-12-arm64
     cd ~/Parallels/vcpkg-osx-2026-01-12-arm64
-    ~/macosvm --disk disk.img,size=500g --aux aux.img -c 8 -r 12g --restore ~/UniversalMac_26.2_25C56_Restore.ipsw ./vm.json
+    ~/macosvm --disk disk.img,size=500g --aux aux.img -c 8 -r 12g --restore ~/UniversalMac_26.4.1_25E253_Restore.ipsw ./vm.json
     ~/macosvm -g ./vm.json
     ```
 - [ ] Follow prompts as you would on real hardware.
@@ -51,7 +53,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Disable automatic updates in the VM: Settings -> General -> Automatic Updates -> Disable them all
 - [ ] Enable remote login in the VM: Settings -> General -> Sharing -> Remote Login
 - [ ] Set the vcpkg user to be able to use sudo without a password, and install Xcode. For example from a dev workstation:
-    ```sh
+    ```
     scp path/to/Xcode.xip vcpkg@HOSTMACHINE:/Users/vcpkg/Xcode.xip
     ssh vcpkg@HOSTMACHINE
     rm ~/.ssh/known_hosts
@@ -68,7 +70,7 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
 - [ ] Open Xcode from Applications in the guest GUI. Uncheck the "code completion model" and accept the EULA.
 - [ ] Update the Azure Agent URI in setup-box.sh to the current version. You can find this by going to the agent pool, selecting "New agent", picking macOS, and copying the link. For example https://download.agent.dev.azure.com/agent/4.266.2/vsts-agent-osx-arm64-4.266.2.tar.gz
 - [ ] Copy setup-box.sh and the xcode installer renamed to 'clt.dmg' to the host. For example from a dev workstation:
-    ```sh
+    ```
     scp ./setup-guest.sh vcpkg@HOSTMACHINE:/Users/vcpkg
     scp ./setup-box.sh vcpkg@HOSTMACHINE:/Users/vcpkg
     scp path/to/console/tools.dmg vcpkg@HOSTMACHINE:/Users/vcpkg/clt.dmg
@@ -81,14 +83,28 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
     exit
     ```
 - [ ] Shut down the VM cleanly.
-- [ ] Mint a SAS token to vcpkgimageminting/pvms with read, add, create, write, and list permissions.
-- [ ] Package the VM into a tarball. For example from a dev workstation:
-    ```sh
+- [ ] Package the VM into a tarball and upload it to blob storage. From a dev workstation, get the azcopy command to do the upload with:
+    ```powershell
+    function Get-AzCopyWriteCommand {
+        Param([Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$FileName)
+        $accountName = 'vcpkgimageminting'
+        $containerName = 'pvms'
+        $uNow = (Get-Date).ToUniversalTime()
+        $start = $uNow.ToString('s') + 'Z'
+        $expiry = $uNow.AddHours(1).ToString('s') + 'Z'
+        $sas = az storage blob generate-sas --as-user --auth-mode login --account-name $accountName --container-name $containerName --name $FileName --permissions cw --start $start --expiry $expiry --https-only --output tsv
+        return "azcopy copy  --check-length=false `"$($FileName)`" `"https://vcpkgimageminting.blob.core.windows.net/pvms/$($FileName)?$($sas)`""
+    }
+
+    Get-AzCopyWriteCommand -FileName vcpkg-osx-2026-01-12-arm64.aar
+    ```
+    Then:
+    ```
     ssh vcpkg@HOSTMACHINE
     cd ~/Parallels
     aa archive -d vcpkg-osx-<date>-arm64 -o vcpkg-osx-<date>-arm64.aar -enable-holes
     brew install azcopy
-    azcopy copy vcpkg-osx-<date>-arm64.aar "https://vcpkgimageminting.blob.core.windows.net/pvms?<SAS>"
+    # (The azcopy command line generated above)
     exit
     ```
 - [ ] Go to https://dev.azure.com/vcpkg/public/_settings/agentqueues and create a new self hosted Agent pool named `PrOsx-YYYY-MM-DD-arm64` based on the current date. Grant microsoft.vcpkg.ci and microsoft.vcpkg.pr access.
@@ -111,13 +127,28 @@ Run these steps on each machine to add to the fleet. Skip steps that were done i
     rm macosvm-0.2-2-arm64-darwin21.tar.gz
     exit
     ```
-- [ ] Skip if this is the image building machine. Mint a SAS token URI to the box to use from the Azure portal if you don't already have one, and download the VM. (Recommend running this via SSH from domain joined machine due to containing SAS tokens). From a developer machine:
+- [ ] Skip if this is the image building machine. Mint a SAS token URI to the box to use from the Azure portal if you don't already have one, and download the VM. (Recommend running this via SSH from domain joined machine due to containing SAS tokens). From a developer machine, get the azcopy command with:
+    ```powershell
+    function Get-AzCopyReadCommand {
+        Param([Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$FileName)
+        $accountName = 'vcpkgimageminting'
+        $containerName = 'pvms'
+        $uNow = (Get-Date).ToUniversalTime()
+        $start = $uNow.ToString('s') + 'Z'
+        $expiry = $uNow.AddHours(1).ToString('s') + 'Z'
+        $sas = az storage blob generate-sas --as-user --auth-mode login --account-name $accountName --container-name $containerName --name $FileName --permissions r --start $start --expiry $expiry --https-only --output tsv
+        return "azcopy copy `"https://vcpkgimageminting.blob.core.windows.net/pvms/$($FileName)?$($sas)`" `"$($FileName)`""
+    }
+
+    Get-AzCopyReadCommand -FileName vcpkg-osx-2026-01-12-arm64.aar
+    ```
+    Then run:
     ```sh
     ssh vcpkg@HOSTMACHINE
     brew install azcopy
     mkdir -p ~/Parallels
     cd ~/Parallels
-    azcopy copy "https://vcpkgimageminting.blob.core.windows.net/pvms/vcpkg-osx-<DATE>-arm64.aar?<SAS>" vcpkg-osx-<DATE>-arm64.aar
+    # (The azcopy command line generated above)
     aa extract -d vcpkg-osx-<DATE>-arm64 -i ./vcpkg-osx-<DATE>-arm64.aar -enable-holes
     exit
     ```
@@ -126,14 +157,17 @@ Run these steps on each machine to add to the fleet. Skip steps that were done i
     cd ~/Parallels/vcpkg-osx-<DATE>-arm64
     ~/macosvm ./vm.json
     ```
-- [ ] [grab a PAT][] if you don't already have one
-- [ ] Copy the guest deploy script to the host, and run it with a first parameter of your PAT. From a developer machine:
-    ```sh
+- [ ] Generate an access token to add the agent to the pool:
+    ```pwsh
+    az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken --output tsv
+    ```
+- [ ] Copy the guest deploy script to the host, and run it with a first parameter of your PAT. From a developer machine pwsh:
+    ```pwsh
     scp register-guest.sh vcpkg@HOSTMACHINE:/Users/vcpkg/register-guest.sh
     ssh vcpkg@HOSTMACHINE
     rm .ssh/known_hosts
     chmod +x register-guest.sh
-    ./register-guest.sh PAT-GOES-HERE AGENT-NUMBER-GOES-HERE
+    ./register-guest.sh TOKEN-GOES-HERE AGENT-NUMBER-GOES-HERE
     rm register-guest.sh
     ```
 - [ ] That will cleanly shut down the VM. In the KVM's terminal, relaunch the VM in ephemeral mode with:
@@ -148,19 +182,3 @@ Run these steps on each machine to add to the fleet. Skip steps that were done i
 - [ ] Check that the machine shows up in the pool, and lock the vcpkg user on the host.
 - [ ] Lock the screen on the host.
 - [ ] Update the "vcpkg Macs" spreadsheet line for the machine with the new pool.
-
-[grab a PAT]: #getting-an-azure-pipelines-pat
-
-## Getting an Azure Pipelines PAT
-
-Personal Access Tokens are an important part of this process,
-and they are fairly easy to generate.
-On ADO, under the correct project (in vcpkg's case, "vcpkg"),
-click on the "User Settings" icon, then go to "Personal access tokens".
-It is the icon to the left of your user icon, in the top right corner.
-
-Then, create a new token, give it a name, make sure it expires quickly,
-and give it a custom defined scope that includes the
-"Agent pools: Read & manage" permission (you'll need to "Show all scopes"
-to access this).
-You can now copy this token and use it to allow machines to join.

--- a/scripts/azure-pipelines/osx/README.md
+++ b/scripts/azure-pipelines/osx/README.md
@@ -161,7 +161,7 @@ Run these steps on each machine to add to the fleet. Skip steps that were done i
     ```pwsh
     az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken --output tsv
     ```
-- [ ] Copy the guest deploy script to the host, and run it with a first parameter of your PAT. From a developer machine pwsh:
+- [ ] Copy the guest deploy script to the host, and run it with the access token/OAuth token from the `az account get-access-token` command above as the first parameter. From a developer machine pwsh:
     ```pwsh
     scp register-guest.sh vcpkg@HOSTMACHINE:/Users/vcpkg/register-guest.sh
     ssh vcpkg@HOSTMACHINE

--- a/scripts/azure-pipelines/osx/README.md
+++ b/scripts/azure-pipelines/osx/README.md
@@ -29,8 +29,8 @@ This is the checklist for what the vcpkg team does when updating the macOS machi
     rm macosvm-0.2-2-arm64-darwin21.tar.gz
     exit
     ```
-- [ ] Download the matching `.ipsw` for the macOS copy to install. See https://mrmacintosh.com/apple-silicon-m1-full-macos-restore-ipsw-firmware-files-database/ ; links there to find the .ipsw. Example: 
-https://updates.cdn-apple.com/2026WinterFCS/fullrestores/122-28781/DCB2FF13-06CB-44C2-BCA2-DFCAF3521D46/UniversalMac_26.4.1_25E253_Restore.ipsw
+- [ ] Download the matching `.ipsw` for the macOS copy to install. See https://mrmacintosh.com/apple-silicon-m1-full-macos-restore-ipsw-firmware-files-database/ ; links there to find the .ipsw. Example:
+    https://updates.cdn-apple.com/2026WinterFCS/fullrestores/122-28781/DCB2FF13-06CB-44C2-BCA2-DFCAF3521D46/UniversalMac_26.4.1_25E253_Restore.ipsw
 - [ ] Determine the VM name using the form "vcpkg-osx-<date>-arm64", for example "vcpkg-osx-2026-01-12-arm64".
 - [ ] Open a terminal and run the following commands to create the VM with vcpkg-osx-2026-01-12-arm64 and UniversalMac_26.4.1_25E253_Restore.ipsw replaced as appropriate. This must be run in the KVM as it uses a GUI:
     ```

--- a/scripts/azure-pipelines/osx/register-guest.sh
+++ b/scripts/azure-pipelines/osx/register-guest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ -z "$1" ]; then
-    echo "PAT missing"
+    echo "Token missing"
     exit 1
 fi
 if [ -z "$2" ]; then


### PR DESCRIPTION
We are being required to disable all use of Personal Access Tokens. However, we can use oauth tokens in much the same way.

Thanks to Grant Holiday for the suggestion in https://dev.azure.com/mseng/1ES/_git/1ES-on-EngHub/pullrequest/914424