### PR TITLE
[tree-sitter-c] Update to 0.24.2

### DIFF
--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -19,11 +19,9 @@ find_program(NODEJS
         "${CURRENT_HOST_INSTALLED_DIR}/tools/node/bin"
         ENV PATH
     NO_DEFAULT_PATH
+    REQUIRED
 )
-if(NOT NODEJS)
-    message(FATAL_ERROR "node not found! Please install it via your system package manager!")
-endif()
-get_filename_component(NODEJS_DIR "${NODEJS}" DIRECTORY )
+get_filename_component(NODEJS_DIR "${NODEJS}" DIRECTORY)
 vcpkg_add_to_path(PREPEND "${NODEJS_DIR}")
 
 vcpkg_cmake_configure(

--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter-c
     REF "v${VERSION}"
-    SHA512 51cf052230ee835d4ae5e6c5adb24aeaeba3b4f106aceefaf4000bd0e57321946f1b3e3b0f9ea71d1c17a618604c6c7269c80c3ecc5ca17e22c883ff5ce4c304
+    SHA512 daa56178adfc4cc7931fb2810367e531113e07ebadcf51cdf7645281627cb86c028c5bb32a1306d294e79d314ef19ce185dfd8786732d5c81a9f3c870396249c
     HEAD_REF master
     PATCHES
         pkgconfig.diff

--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -12,6 +12,20 @@ vcpkg_from_github(
         pkgconfig.diff
 )
 
+find_program(NODEJS
+    NAMES node
+    PATHS
+        "${CURRENT_HOST_INSTALLED_DIR}/tools/node"
+        "${CURRENT_HOST_INSTALLED_DIR}/tools/node/bin"
+        ENV PATH
+    NO_DEFAULT_PATH
+)
+if(NOT NODEJS)
+    message(FATAL_ERROR "node not found! Please install it via your system package manager!")
+endif()
+get_filename_component(NODEJS_DIR "${NODEJS}" DIRECTORY )
+vcpkg_add_to_path(PREPEND "${NODEJS_DIR}")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/tree-sitter-c/vcpkg.json
+++ b/ports/tree-sitter-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-c",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "C grammar for tree-sitter",
   "homepage": "https://github.com/tree-sitter/tree-sitter-c",
   "license": "MIT",

--- a/ports/tree-sitter-c/vcpkg.json
+++ b/ports/tree-sitter-c/vcpkg.json
@@ -13,6 +13,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-tool-nodejs",
+      "host": true
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10209,7 +10209,7 @@
       "port-version": 0
     },
     "tree-sitter-c": {
-      "baseline": "0.24.1",
+      "baseline": "0.24.2",
       "port-version": 0
     },
     "tree-sitter-cli": {

--- a/versions/t-/tree-sitter-c.json
+++ b/versions/t-/tree-sitter-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3002fd2f56bc8ae149a30933299471f9a6a7420",
+      "version": "0.24.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b13d01b8c0207ecdb7ffdf988a4d6956dd7eeda5",
       "version": "0.24.1",
       "port-version": 0

--- a/versions/t-/tree-sitter-c.json
+++ b/versions/t-/tree-sitter-c.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c3002fd2f56bc8ae149a30933299471f9a6a7420",
+      "git-tree": "5f68e7b941f7bff23ca94d4dca84ff4e7d4a7359",
       "version": "0.24.2",
       "port-version": 0
     },

--- a/versions/t-/tree-sitter-c.json
+++ b/versions/t-/tree-sitter-c.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5f68e7b941f7bff23ca94d4dca84ff4e7d4a7359",
+      "git-tree": "d687342b4b5ae27bd5a5b8ce843a6318593d6e8c",
       "version": "0.24.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

