### PR TITLE
[kauth] New port

### DIFF
--- a/ports/kauth/portfile.cmake
+++ b/ports/kauth/portfile.cmake
@@ -1,0 +1,52 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kauth
+    REF "v${VERSION}"
+    SHA512 c056a56de2b4019743a1b06ac9f1d647a6adb6750da8cc2912c8645635676089978b9c68f06cda485570bdca87bdcfac8c9ae88d70699f976f00d453e9269c92
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        translations KF_SKIP_PO_PROCESSING
+)
+
+if(VCPKG_TARGET_IS_LINUX)
+    list(APPEND FEATURE_OPTIONS -DKAUTH_BACKEND_NAME=PolkitQt6-1)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6auth
+    CONFIG_PATH lib/cmake/KF6Auth
+)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/kauth/kauth-policy-gen${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+    vcpkg_copy_tools(
+        TOOL_NAMES kauth/kauth-policy-gen
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/kauth"
+        AUTO_CLEAN
+    )
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kauth/vcpkg.json
+++ b/ports/kauth/vcpkg.json
@@ -1,0 +1,58 @@
+{
+  "name": "kauth",
+  "version": "6.25.0",
+  "description": "Execute actions as privileged user",
+  "homepage": "https://invent.kde.org/frameworks/kauth",
+  "documentation": "https://api.kde.org/kauth-index.html",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!android & !windows",
+  "dependencies": [
+    "ecm",
+    "kcoreaddons",
+    {
+      "name": "kwindowsystem",
+      "platform": "linux"
+    },
+    {
+      "name": "polkit-qt-1",
+      "platform": "linux"
+    },
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "gui"
+      ]
+    },
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "dbus"
+      ],
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "translations": {
+      "description": "Build and install translation files",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4248,6 +4248,10 @@
       "baseline": "6.25.0",
       "port-version": 2
     },
+    "kauth": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kbreezeicons": {
       "baseline": "6.25.0",
       "port-version": 1

--- a/versions/k-/kauth.json
+++ b/versions/k-/kauth.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5268fff2819a2a12cbc8986b28eddb3277b4d4ff",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kauth/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

---

Follow up to #50860, that, for some reason, got closed automatically