### PR TITLE
[polkit-qt-1] New port

### DIFF
--- a/ports/polkit-qt-1/portfile.cmake
+++ b/ports/polkit-qt-1/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://invent.kde.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libraries/polkit-qt-1
+    REF "v${VERSION}"
+    SHA512 b0ad001846c149cfc81108894a54bea30efddcf6f34fc115a7874c72bd5079e5c21d2d2c16bbf11c9fabe2443878d9369c311e93afdc810b4bb7c95266f25eef
+    HEAD_REF master
+)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TEST=OFF
+        -DQT_MAJOR_VERSION=6
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME polkitqt6-1
+    CONFIG_PATH lib/cmake/PolkitQt6-1
+)
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/polkit-qt-1/vcpkg.json
+++ b/ports/polkit-qt-1/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "polkit-qt-1",
+  "version": "0.201.1",
+  "description": "Qt6 wrapper around polkit-1",
+  "homepage": "https://invent.kde.org/libraries/polkit-qt-1",
+  "license": "LGPL-2.0-or-later",
+  "supports": "linux",
+  "dependencies": [
+    "glib",
+    "polkit",
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "dbus",
+        "widgets"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7836,6 +7836,10 @@
       "baseline": "124",
       "port-version": 0
     },
+    "polkit-qt-1": {
+      "baseline": "0.201.1",
+      "port-version": 0
+    },
     "polyclipping": {
       "baseline": "6.4.2",
       "port-version": 13

--- a/versions/p-/polkit-qt-1.json
+++ b/versions/p-/polkit-qt-1.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3f5bd16f441c348d08d34f6b34fe5d33f4f95706",
+      "version": "0.201.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/polkit-qt-1/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.