### PR TITLE
[vcpkg-ci-highway] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-highway/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-highway/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-highway/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-highway/project/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.15)
+project(vcpkg_ci_highway)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(hwy CONFIG REQUIRED)
+
+# Dynamic Dispatch
+add_executable(vcpkg_ci_highway main.cpp scale.cpp scale.hpp)
+target_include_directories(vcpkg_ci_highway PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(vcpkg_ci_highway PRIVATE hwy::hwy)
+
+# Static Dispatch
+add_executable(vcpkg_ci_highway_static main.cpp scale.cpp scale.hpp)
+target_include_directories(vcpkg_ci_highway_static PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(vcpkg_ci_highway_static PRIVATE hwy::hwy)
+target_compile_definitions(vcpkg_ci_highway_static PRIVATE HWY_COMPILE_ONLY_STATIC)

--- a/scripts/test_ports/vcpkg-ci-highway/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-highway/project/main.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <random>
+#include <vector>
+#include "scale.hpp"
+
+std::vector<float> generate_random_floats(size_t n) {
+    std::vector<float> data(n);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    for (auto &x : data) {
+        x = dist(gen);
+    }
+    return data;
+}
+
+int main() {
+    std::vector<float> src = generate_random_floats(1000);
+    std::vector<float> dst(src.size());
+    scale(dst.data(), src.data(), src.size(), 0.75f);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-highway/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-highway/project/main.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <random>
 #include <vector>
 #include "scale.hpp"

--- a/scripts/test_ports/vcpkg-ci-highway/project/scale.cpp
+++ b/scripts/test_ports/vcpkg-ci-highway/project/scale.cpp
@@ -1,0 +1,46 @@
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "scale.cpp"
+#include "hwy/foreach_target.h"
+#include "hwy/highway.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace HWY_NAMESPACE {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+void scale(float *HWY_RESTRICT dst, const float *HWY_RESTRICT src, size_t size, float factor) {
+    auto scale_one = [](auto d, float *HWY_RESTRICT dst, const float *HWY_RESTRICT src, auto s) {
+        const auto x = hn::Load(d, src);
+        const auto o = hn::Mul(x, s);
+        hn::Store(o, d, dst);
+    };
+
+    size_t i = 0;
+
+    constexpr hn::ScalableTag<float> dn;
+    const auto sn = hn::Set(dn, factor);
+    const size_t N = hn::Lanes(dn);
+    for (; i + N <= size; i += N) {
+        scale_one(dn, dst + i, src + i, sn);
+    }
+
+    constexpr hn::CappedTag<float, 1> d1;
+    const auto s1 = hn::Set(d1, factor);
+    for (; i < size; ++i) {
+        scale_one(d1, dst + i, src + i, s1);
+    }
+}
+
+}  // namespace HWY_NAMESPACE
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+#include "scale.hpp"
+
+HWY_EXPORT(scale);
+void scale(float *HWY_RESTRICT dst, const float *HWY_RESTRICT src, size_t size, float factor) {
+    HWY_DYNAMIC_DISPATCH(scale)(dst, src, size, factor);
+}
+
+#endif  // HWY_ONCE

--- a/scripts/test_ports/vcpkg-ci-highway/project/scale.cpp
+++ b/scripts/test_ports/vcpkg-ci-highway/project/scale.cpp
@@ -9,25 +9,30 @@ namespace HWY_NAMESPACE {
 namespace hn = hwy::HWY_NAMESPACE;
 
 void scale(float *HWY_RESTRICT dst, const float *HWY_RESTRICT src, size_t size, float factor) {
-    auto scale_one = [](auto d, float *HWY_RESTRICT dst, const float *HWY_RESTRICT src, auto s) {
-        const auto x = hn::Load(d, src);
-        const auto o = hn::Mul(x, s);
-        hn::Store(o, d, dst);
-    };
-
     size_t i = 0;
 
-    constexpr hn::ScalableTag<float> dn;
-    const auto sn = hn::Set(dn, factor);
-    const size_t N = hn::Lanes(dn);
-    for (; i + N <= size; i += N) {
-        scale_one(dn, dst + i, src + i, sn);
+    constexpr hn::ScalableTag<float> d;
+    const auto vf = hn::Set(d, factor);
+    const size_t N = hn::Lanes(d);
+
+    for (; i + 4 * N <= size; i += 4 * N) {
+        auto x0 = hn::Load(d, src + i + 0 * N);
+        auto x1 = hn::Load(d, src + i + 1 * N);
+        auto x2 = hn::Load(d, src + i + 2 * N);
+        auto x3 = hn::Load(d, src + i + 3 * N);
+        hn::Store(hn::Mul(x0, vf), d, dst + i + 0 * N);
+        hn::Store(hn::Mul(x1, vf), d, dst + i + 1 * N);
+        hn::Store(hn::Mul(x2, vf), d, dst + i + 2 * N);
+        hn::Store(hn::Mul(x3, vf), d, dst + i + 3 * N);
     }
 
-    constexpr hn::CappedTag<float, 1> d1;
-    const auto s1 = hn::Set(d1, factor);
+    for (; i + N <= size; i += N) {
+        auto x = hn::Load(d, src + i);
+        hn::Store(hn::Mul(x, vf), d, dst + i);
+    }
+
     for (; i < size; ++i) {
-        scale_one(d1, dst + i, src + i, s1);
+        dst[i] = src[i] * factor;
     }
 }
 

--- a/scripts/test_ports/vcpkg-ci-highway/project/scale.hpp
+++ b/scripts/test_ports/vcpkg-ci-highway/project/scale.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+
+#if !defined(HWY_RESTRICT)
+#if defined(_MSC_VER)
+#define HWY_RESTRICT __restrict
+#else
+#define HWY_RESTRICT __restrict__
+#endif
+#endif
+
+void scale(float *HWY_RESTRICT dst, const float *HWY_RESTRICT src, size_t size, float factor);

--- a/scripts/test_ports/vcpkg-ci-highway/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-highway/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-highway",
+  "version-string": "ci",
+  "description": "Validates highway",
+  "dependencies": [
+    "highway",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

