### PR TITLE
[gdal] Update to 3.12.4

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -1,19 +1,12 @@
-vcpkg_download_distfile(FIX_UPSTREAM_0ad9529
-    URLS https://github.com/OSGeo/gdal/commit/0ad9529d5fd5e03880147221d56bfee08383d7dc.patch?full_index=1
-    SHA512 0a022e350d9a1a4f0a218bbfbc09dca2e521e42e0af57f8e4797c74b9d96d777f73807b86fa04606c7d2d67e5a75fc0975d9948e2d5e0fdb1ce5a9ea587119c3
-    FILENAME gdal-0ad9529d5fd5e03880147221d56bfee08383d7dc.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/gdal
     REF "v${VERSION}"
-    SHA512 48b74e9446e48e3a16e0c5cdf6ee137aeb343fe431951fc635debe45ed6ac575d25ed453e50832ff7ced00d1c2f6fb716f55272fe347f53647aae4a721cf02f1
+    SHA512 3b915c38cc7c9eb139df9335a90a2f6fd123c54e19ecb1f22670400eac76e317c5334f95dff5875c9c3fde8a0ef0f7aea86fa58ad42afaee823a46c6616e9c17
     HEAD_REF master
     PATCHES
         find-link-libraries.patch
         fix-gdal-target-interfaces.patch
-        "${FIX_UPSTREAM_0ad9529}"
         iconv.diff
         libkml.patch
         sqlite3.diff

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdal",
-  "version-semver": "3.12.3",
-  "port-version": 1,
+  "version-semver": "3.12.4",
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3309,8 +3309,8 @@
       "port-version": 0
     },
     "gdal": {
-      "baseline": "3.12.3",
-      "port-version": 1
+      "baseline": "3.12.4",
+      "port-version": 0
     },
     "gdbm": {
       "baseline": "1.24",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa66d2255b312f5a7541579b6f21507a295bd2c0",
+      "version-semver": "3.12.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d0d81ab4c0422b07ee04fbfbfe36c1ec0dc5d5a",
       "version-semver": "3.12.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.