### PR TITLE
[ms-gdk] Updated port CMake targets for missing lib

### DIFF
--- a/ports/ms-gdk/gdk-config.cmake.in
+++ b/ports/ms-gdk/gdk-config.cmake.in
@@ -87,6 +87,15 @@ if (@BUILD_PLAYFAB_SERVICES@ AND (EXISTS "${_msgdk_root}/lib/PlayFabCore.lib"))
 
     target_link_libraries(Xbox::PlayFabServices INTERFACE Xbox::PlayFabCore Xbox::XCurl)
 
+    # PlayFab Game Save
+    add_library(Xbox::PlayFabGameSave SHARED IMPORTED)
+    set_target_properties(Xbox::PlayFabGameSave PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/PlayFabGameSave.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/PlayFabGameSave.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
     # PlayFab Party
     add_library(Xbox::PlayFabParty SHARED IMPORTED)
     set_target_properties(Xbox::PlayFabParty PROPERTIES

--- a/ports/ms-gdk/pfusage
+++ b/ports/ms-gdk/pfusage
@@ -1,4 +1,6 @@
   target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+  target_link_libraries(main PRIVATE Xbox::PlayFabGameSave)
   target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
   target_link_libraries(main PRIVATE Xbox::PlayFabParty)
   target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)
+

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ms-gdk",
   "version": "2510.2.6247",
+  "port-version": 1,
   "description": "Microsoft Game Development Kit (GDK)",
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6694,7 +6694,7 @@
     },
     "ms-gdk": {
       "baseline": "2510.2.6247",
-      "port-version": 0
+      "port-version": 1
     },
     "ms-gdkx": {
       "baseline": "1.0.0",

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d1c639a844b5fb9dec5b95da7de37d1db2a3471",
+      "version": "2510.2.6247",
+      "port-version": 1
+    },
+    {
       "git-tree": "202dad72a32a2b498d962f8e4f32f1daf5e51afa",
       "version": "2510.2.6247",
       "port-version": 0


### PR DESCRIPTION
There was a new PlayFab library added in October 2025 PlayFabGameSave.lib. This adds that library to the supported CMake targets list.