### PR TITLE
DO NOT MERGE Demonstrate version database consistency check again

### DIFF
--- a/ports/hical61-hical/portfile.cmake
+++ b/ports/hical61-hical/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Hical61/Hical
+    REF "v${VERSION}"
+    SHA512 1e7e1adc340e95e8b36c05481da1995269d59453b06ac539ab3e9310a5b051fce0e485339e3b39812cbeb304b0d9b85d117ac4d79e69406b11f9def7c0e0fa2d
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHICAL_BUILD_TESTS=OFF
+        -DHICAL_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME hical
+    CONFIG_PATH lib/cmake/hical
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hical61-hical/vcpkg.json
+++ b/ports/hical61-hical/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "hical61-hical",
+  "version": "1.0.1",
+  "description": "Modern C++20/C++26 high-performance web framework based on Boost.Asio/Beast",
+  "homepage": "https://github.com/Hical61/Hical",
+  "license": "MIT",
+  "supports": "!uwp & !xbox & !android & !emscripten",
+  "dependencies": [
+    "boost-asio",
+    "boost-beast",
+    "boost-json",
+    "boost-system",
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3796,6 +3796,10 @@
       "baseline": "2.11.1",
       "port-version": 0
     },
+	"hical61-hical": {
+	  "baseline": "1.0.1",
+	  "port-version": 0
+	},
     "hidapi": {
       "baseline": "0.15.0",
       "port-version": 1

--- a/versions/h-/hical61-hical.json
+++ b/versions/h-/hical61-hical.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d2048b7690529c305d54a4792217970b3f57b4b2",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This is just https://github.com/microsoft/vcpkg/pull/51110 being applied to the new version database consistency check to demonstrate that it now detects the incorrect tabs that were added in that PR.

This PR exists for the purpose of reviewing https://github.com/microsoft/vcpkg/pull/51374.