### PR TITLE
[openblas] update to 0.3.33

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenMathLib/OpenBLAS
     REF "v${VERSION}"
-    SHA512 046316b4297460bffca09c890ecad17ea39d8b3db92ff445d03b547dd551663d37e40f38bce8ae11e2994374ff01e622b408da27aa8e40f4140185ee8f001a60
+    SHA512 68fa2b90a93a2dfd84dfa586af07d90952fd4f2ad8dfe26061be250e80fec8f1a76ad78977f217c7dbdd26291249f1ac38a07f08ef323eee7a248c4cb67cd670
     HEAD_REF develop
     PATCHES
         disable-testing.diff

--- a/ports/openblas/system-check-msvc.diff
+++ b/ports/openblas/system-check-msvc.diff
@@ -1,8 +1,8 @@
 diff --git a/cmake/system_check.cmake b/cmake/system_check.cmake
-index e94497a..d884727 100644
+index 38a04b7..78defed 100644
 --- a/cmake/system_check.cmake
 +++ b/cmake/system_check.cmake
-@@ -36,6 +36,16 @@ if(CMAKE_CL_64 OR MINGW64)
+@@ -40,6 +40,16 @@ if(CMAKE_CL_64 OR MINGW64)
    else()
      set(X86_64 1)
    endif()
@@ -16,6 +16,6 @@ index e94497a..d884727 100644
 +  else()
 +    set(X86 1)
 +  endif()
+ elseif(OS_EMSCRIPTEN)
+     set(WASM 1)
  elseif(MINGW OR (MSVC AND NOT CMAKE_CROSSCOMPILING))
-   set(X86 1)
- elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc.*|power.*|Power.*" OR (CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc.*"))

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openblas",
-  "version": "0.3.29",
+  "version": "0.3.33",
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/OpenMathLib/OpenBLAS",
   "license": "BSD-3-Clause",

--- a/ports/openblas/win32-uwp.diff
+++ b/ports/openblas/win32-uwp.diff
@@ -21,10 +21,22 @@ index 2effbe0..538ede2 100644
      set(EXTRALIB "${EXTRALIB} -lpthread")
    endif ()
 diff --git a/cmake/system.cmake b/cmake/system.cmake
-index 683c318..eae7436 100644
+index ea56b84..a94e25a 100644
 --- a/cmake/system.cmake
 +++ b/cmake/system.cmake
-@@ -507,7 +507,7 @@ if (USE_SIMPLE_THREADED_LEVEL3)
+@@ -12,9 +12,9 @@
+ #    distribution.
+ # 3. Neither the name of the OpenBLAS project nor the names of
+ #    its contributors may be used to endorse or promote products
+-#    derived from this software without specific prior written permission.
++#    derived from this software without specific prior written permissio5n.
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BU50T NOT LIMITED TO, THE
+ # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ # ARE DISCLAIMED. IN NO EVENT SHALL THE OPENBLAS PROJECT OR CONTRIBUTORS BE
+ # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+@@ -629,7 +629,7 @@ if (USE_SIMPLE_THREADED_LEVEL3)
    set(CCOMMON_OPT "${CCOMMON_OPT} -DUSE_SIMPLE_THREADED_LEVEL3")
  endif ()
  
@@ -33,7 +45,7 @@ index 683c318..eae7436 100644
  if (DEFINED MAX_STACK_ALLOC)
  if (NOT ${MAX_STACK_ALLOC} EQUAL 0)
  set(CCOMMON_OPT "${CCOMMON_OPT} -DMAX_STACK_ALLOC=${MAX_STACK_ALLOC}")
-@@ -516,7 +516,7 @@ else ()
+@@ -638,7 +638,7 @@ else ()
  set(CCOMMON_OPT "${CCOMMON_OPT} -DMAX_STACK_ALLOC=2048")
  endif ()
  endif ()
@@ -42,16 +54,7 @@ index 683c318..eae7436 100644
  if (DEFINED BLAS3_MEM_ALLOC_THRESHOLD)
  if (NOT ${BLAS3_MEM_ALLOC_THRESHOLD} EQUAL 32)
  set(CCOMMON_OPT "${CCOMMON_OPT} -DBLAS3_MEM_ALLOC_THRESHOLD=${BLAS3_MEM_ALLOC_THRESHOLD}")
-@@ -633,7 +633,7 @@ endif()
- set(LAPACK_FPFLAGS "${LAPACK_FPFLAGS} ${FPFLAGS}")
- 
- #Disable -fopenmp for LAPACK Fortran codes on Windows.
--if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-+if (WIN32)
-   set(FILTER_FLAGS "-fopenmp;-mp;-openmp;-xopenmp=parallel")
-   foreach (FILTER_FLAG ${FILTER_FLAGS})
-     string(REPLACE ${FILTER_FLAG} "" LAPACK_FFLAGS ${LAPACK_FFLAGS})
-@@ -665,11 +665,11 @@ if (INTERFACE64)
+@@ -793,14 +793,14 @@ if (INTERFACE64)
    set(LAPACK_CFLAGS "${LAPACK_CFLAGS} -DLAPACK_ILP64")
  endif ()
  
@@ -64,4 +67,8 @@ index 683c318..eae7436 100644
 +if (${CMAKE_C_COMPILER} STREQUAL "LSB" OR WIN32)
    set(LAPACK_CFLAGS "${LAPACK_CFLAGS} -DLAPACK_COMPLEX_STRUCTURE")
  endif ()
- if (${CMAKE_C_COMPILER_ID} MATCHES "IntelLLVM" AND ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+-if (${CMAKE_C_COMPILER_ID} MATCHES "IntelLLVM" AND ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
++if (${CMAKE_C_COMPILER_ID} MATCHES "IntelLLVM" AND WIN32)
+ 	set(LAPACK_CFLAGS "${LAPACK_CFLAGS} -DNOCHANGE")
+ endif ()
+ 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7293,7 +7293,7 @@
       "port-version": 0
     },
     "openblas": {
-      "baseline": "0.3.29",
+      "baseline": "0.3.33",
       "port-version": 0
     },
     "opencascade": {

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96b1c38285b97175d90eb83c7a95862622b81774",
+      "version": "0.3.33",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d3d198cfb372ccd328a36248c4c12fb7c6b3bb6",
       "version": "0.3.29",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/OpenMathLib/OpenBLAS/releases/tag/v0.3.33
