### PR TITLE
[raylib-cpp] update to 6.0.0

### DIFF
--- a/ports/raylib-cpp/portfile.cmake
+++ b/ports/raylib-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RobLoach/raylib-cpp
     REF "v${VERSION}"
-    SHA512 db7e4eef3756b95fdcd583e0485d006311173a96f59c3aed6bda1b07bcae5c6d7c1ab7fda51220edfd1b170c6b1622f3f6bf5de7cececaa172c5f0bdf8fcdf72
+    SHA512 7627e84e56b234f9ada28d0b7c7d39c6a6289d3c2cdbd0e87e71743c2897dfb1e80bb32c60d92fdb5a89e4f09a827fa9919c7f983aa00e9ad0d8e9c03ba49cd5
     HEAD_REF master
 )
 

--- a/ports/raylib-cpp/vcpkg.json
+++ b/ports/raylib-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "raylib-cpp",
-  "version": "5.5.1",
+  "version": "6.0.0",
   "description": "C++ Object Oriented Wrapper for raylib",
   "homepage": "https://github.com/RobLoach/raylib-cpp",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8625,7 +8625,7 @@
       "port-version": 0
     },
     "raylib-cpp": {
-      "baseline": "5.5.1",
+      "baseline": "6.0.0",
       "port-version": 0
     },
     "rbdl": {

--- a/versions/r-/raylib-cpp.json
+++ b/versions/r-/raylib-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2847abb623f6801e98e50e36eb725a0970a3abf9",
+      "version": "6.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "99a4e5f1a955f2bc90521844a5ec4ca5b6337827",
       "version": "5.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/RobLoach/raylib-cpp/releases/tag/v6.0.0
