### PR TITLE
[freerdp] update to 3.25.0

### DIFF
--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FreeRDP/FreeRDP
     REF "${VERSION}"
-    SHA512 8e5380ad9772eb28bd8767703bfee05ca60ef77b491c7f695b666d0fbda626365084cca4b48cabc15225088ad2ce88f45d58dff8ee80c102d3e4847f1532a851
+    SHA512 81630bb287adfd200ee7845a9d0c304def6612aa357dd5b5ca7286ff7b3022b1d24c511fc1d88109cba0747c33693e72f687d4665f1a674652c87b5323509b4b
     HEAD_REF master
     PATCHES
         dependencies.patch
@@ -19,6 +19,7 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        av1         WITH_GFX_AV1
         client      WITH_CLIENT
         ffmpeg      WITH_DSP_FFMPEG
         ffmpeg      WITH_FFMPEG

--- a/ports/freerdp/vcpkg.json
+++ b/ports/freerdp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "freerdp",
-  "version": "3.24.1",
+  "version": "3.25.0",
   "description": "A free implementation of the Remote Desktop Protocol (RDP)",
   "homepage": "https://github.com/FreeRDP/FreeRDP",
   "license": "Apache-2.0",
@@ -23,6 +23,9 @@
     "zlib"
   ],
   "features": {
+    "av1": {
+      "description": "Enable AV1 support for GFX channel encoding/decoding"
+    },
     "client": {
       "description": "Build client components"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3185,7 +3185,7 @@
       "port-version": 9
     },
     "freerdp": {
-      "baseline": "3.24.1",
+      "baseline": "3.25.0",
       "port-version": 0
     },
     "freetds": {

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d0f2850bfd7adc3eef4f25717acee991b5c3cc7",
+      "version": "3.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3588efd51783c476d98ae98b8d4d4f04165831fa",
       "version": "3.24.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/FreeRDP/FreeRDP/releases/tag/3.25.0
