### PR TITLE
[kguiaddons] Control QML support, fix install locations

### DIFF
--- a/ports/kguiaddons/portfile.cmake
+++ b/ports/kguiaddons/portfile.cmake
@@ -9,11 +9,18 @@ vcpkg_from_github(
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
 
+if(NOT "qml" IN_LIST FEATURES)
+  list(APPEND FEATURE_OPTIONS "-DCMAKE_DISABLE_FIND_PACKAGE_Qt6Qml=ON")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
         -DBUILD_PYTHON_BINDINGS=OFF
+        -DKDE_INSTALL_QMLDIR=qml
+        -DCMAKE_DISABLE_FIND_PACKAGE_Qt6Tools=ON
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/kguiaddons/vcpkg.json
+++ b/ports/kguiaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kguiaddons",
   "version": "6.25.0",
+  "port-version": 1,
   "description": "Addons to QtGui",
   "homepage": "https://invent.kde.org/frameworks/kguiaddons",
   "documentation": "https://api.kde.org/kguiaddons-index.html",
@@ -13,7 +14,10 @@
     },
     {
       "name": "qtbase",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "gui"
+      ]
     },
     {
       "name": "qtwayland",
@@ -28,5 +32,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "qml": {
+      "description": "Build with QML support",
+      "dependencies": [
+        "qtdeclarative"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4482,7 +4482,7 @@
     },
     "kguiaddons": {
       "baseline": "6.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ki18n": {
       "baseline": "6.25.0",

--- a/versions/k-/kguiaddons.json
+++ b/versions/k-/kguiaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09182989299c51a3cecc5f47c31758ac16fa930a",
+      "version": "6.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0766e3d1c73e4d531b05050e7058844db5989fb0",
       "version": "6.25.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
