### PR TITLE
[polkit] New port

### DIFF
--- a/ports/polkit/libs-only-build-polkitagent.patch
+++ b/ports/polkit/libs-only-build-polkitagent.patch
@@ -1,0 +1,15 @@
+diff --git a/src/meson.build b/src/meson.build
+index 35ece7e..8837c5c 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -3,7 +3,9 @@ src_inc = include_directories('.')
+ ldflags = cc.get_supported_link_arguments('-Wl,--version-script,@0@'.format(symbol_map))
+ 
+ subdir('polkit')
+-if not get_option('libs-only')
++if get_option('libs-only')
++  subdir('polkitagent')
++else
+   subdir('polkitbackend')
+   subdir('polkitagent')
+   subdir('programs')

--- a/ports/polkit/portfile.cmake
+++ b/ports/polkit/portfile.cmake
@@ -1,0 +1,42 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO polkit/polkit
+    REF "${VERSION}"
+    SHA512 3c4fe60618cf6e74467dc0efac084a38c93b0a8e4e8c02d36de5ca35634ecff624b6977b54493e9b1ad41aa87693ac3246e14fe6f6b828f57b2012b869af9105
+    HEAD_REF master
+    PATCHES
+        libs-only-build-polkitagent.patch
+)
+
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin")
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dauthfw=shadow
+        -Dexamples=false
+        -Dgtk_doc=false
+        -Dintrospection=false
+        -Dlibs-only=true
+        -Dman=false
+        -Dsession_tracking=ConsoleKit
+        -Dtests=false
+    ADDITIONAL_BINARIES
+        "glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'"
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+)
+vcpkg_install_meson()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/polkit-1"
+    "${CURRENT_PACKAGES_DIR}/lib/polkit-1"
+    "${CURRENT_PACKAGES_DIR}/share/dbus-1"
+    "${CURRENT_PACKAGES_DIR}/share/gettext"
+    "${CURRENT_PACKAGES_DIR}/share/polkit-1"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/polkit/vcpkg.json
+++ b/ports/polkit/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "polkit",
+  "version": "124",
+  "description": "PolicyKit authorization libraries",
+  "homepage": "https://gitlab.freedesktop.org/polkit/polkit",
+  "license": "LGPL-2.0-or-later",
+  "supports": "linux",
+  "dependencies": [
+    "expat",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    "libxcrypt",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7848,6 +7848,10 @@
       "baseline": "2021-09-26",
       "port-version": 0
     },
+    "polkit": {
+      "baseline": "124",
+      "port-version": 0
+    },
     "polyclipping": {
       "baseline": "6.4.2",
       "port-version": 13

--- a/versions/p-/polkit.json
+++ b/versions/p-/polkit.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "00617405495bae3a7c245f7ed74877f7c05e426e",
+      "version": "124",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/polkit/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.