### PR TITLE
[args] update to 6.4.12

### DIFF
--- a/ports/args/portfile.cmake
+++ b/ports/args/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Taywee/args
     REF "${VERSION}"
-    SHA512 0cb0b3bbb54ec4a8a5dc110b50e51e20cbe97ffefdaa726bd69d72ccfc726603b9df82f5f2a76bb53efbcff9d0de877a2679470fcdde13cdc985408c0a25c862
+    SHA512 acddaacfd458601250c687c582dc0657d7d2d41ce22f56d9d9431838c1e7a30fdf02bf65ff3b8708858cd8e7368d1885a56b03c7bfd5c854795e8207e5a4d5b3
     HEAD_REF master
 )
 

--- a/ports/args/vcpkg.json
+++ b/ports/args/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "args",
-  "version": "6.4.11",
+  "version": "6.4.12",
   "description": "A simple header-only C++ argument parser library.",
   "homepage": "https://github.com/Taywee/args",
   "license": "MIT",

--- a/versions/a-/args.json
+++ b/versions/a-/args.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "21e8104fbb7ea8c68a9673f0ddbf87d981a562c3",
+      "version": "6.4.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "6eb53905a4edf97bda03a0c3ee23170f026e7c6e",
       "version": "6.4.11",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -249,7 +249,7 @@
       "port-version": 0
     },
     "args": {
-      "baseline": "6.4.11",
+      "baseline": "6.4.12",
       "port-version": 0
     },
     "argtable2": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Taywee/args/releases/tag/6.4.12
