### PR TITLE
[luau] update to 0.718

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1bf58ae..d4419df 100644
+index f215957..b8462b8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -66,41 +66,41 @@ add_library(Luau.VM.Internals INTERFACE)
+@@ -87,45 +87,45 @@ add_library(Luau.VM.Internals INTERFACE)
  include(Sources.cmake)
  
  target_compile_features(Luau.Common PUBLIC cxx_std_17)
@@ -19,10 +19,15 @@ index 1bf58ae..d4419df 100644
 +target_include_directories(Luau.Ast PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Ast/include> $<INSTALL_INTERFACE:include/luau>)
  target_link_libraries(Luau.Ast PUBLIC Luau.Common)
  
+ target_compile_features(Luau.Bytecode PUBLIC cxx_std_17)
+-target_include_directories(Luau.Bytecode PUBLIC Bytecode/include)
++target_include_directories(Luau.Bytecode PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Bytecode/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.Bytecode PUBLIC Luau.Common)
+ 
  target_compile_features(Luau.Compiler PUBLIC cxx_std_17)
 -target_include_directories(Luau.Compiler PUBLIC Compiler/include)
 +target_include_directories(Luau.Compiler PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Compiler/include> $<INSTALL_INTERFACE:include/luau>)
- target_link_libraries(Luau.Compiler PUBLIC Luau.Ast)
+ target_link_libraries(Luau.Compiler PUBLIC Luau.Ast Luau.Bytecode)
  
  target_compile_features(Luau.Config PUBLIC cxx_std_17)
 -target_include_directories(Luau.Config PUBLIC Config/include)
@@ -54,7 +59,7 @@ index 1bf58ae..d4419df 100644
  target_link_libraries(Luau.Require PUBLIC Luau.Config Luau.VM)
  
  target_include_directories(isocline PUBLIC extern/isocline/include)
-@@ -189,22 +189,6 @@ if(MSVC AND LUAU_BUILD_TESTS)
+@@ -230,22 +230,6 @@ if(MSVC AND LUAU_BUILD_TESTS)
      set_target_properties(Luau.CLI.Test PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
  
@@ -77,7 +82,7 @@ index 1bf58ae..d4419df 100644
  # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
  add_library(osthreads INTERFACE)
  if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
-@@ -297,3 +281,56 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
+@@ -338,3 +322,57 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
          endif()
      endif()
  endforeach()
@@ -99,7 +104,7 @@ index 1bf58ae..d4419df 100644
 +)
 +
 +install(
-+  TARGETS Luau.Common Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.Require
++  TARGETS Luau.Common Luau.Ast Luau.Bytecode Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.Require
 +  EXPORT unofficial-luau-targets
 +  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -117,6 +122,7 @@ index 1bf58ae..d4419df 100644
 +install(
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Common/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Ast/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Bytecode/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Compiler/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Config/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Analysis/include/"
@@ -136,8 +142,9 @@ index 1bf58ae..d4419df 100644
 +)
 diff --git b/cmake/unofficial-luau-config.cmake b/cmake/unofficial-luau-config.cmake
 new file mode 100644
-index 0000000..13fd463
+index 0000000..2680ef3
 --- /dev/null
 +++ b/cmake/unofficial-luau-config.cmake
 @@ -0,0 +1 @@
 +include(${CMAKE_CURRENT_LIST_DIR}/unofficial-luau-targets.cmake)
+\ No newline at end of file

--- a/ports/luau/fix-unittest.patch
+++ b/ports/luau/fix-unittest.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 08af371..df60595 100644
+index b8462b8..4a794ba 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -216,11 +216,11 @@ if(MSVC AND LUAU_BUILD_CLI)
+@@ -222,11 +222,11 @@ if(MSVC AND LUAU_BUILD_CLI)
      # the default stack size that MSVC linker uses is 1 MB; we need more stack space in Debug because stack frames are larger
      set_target_properties(Luau.Analyze.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 172a576107aff5e9acc9e7ae7e7f6d058174207f184259b7ad4c39df16bfd032b64b7398065ea334ba89abc7e2cf4b180b19b1bda4c3241fb2db5b7ec7f74238
+    SHA512 3f9eeceeff3a010b2fef3425622aef15e8a5fe036badbe991c98f7c90aefe96c4419035064f7a902c1a160406dcd8a2c4532a1b4f412036337be3d3db9f5265d
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.717",
+  "version": "0.718",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6205,7 +6205,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.717",
+      "baseline": "0.718",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ffcc67c7e4da86192e36a8f80b7e3afae6a9756f",
+      "version": "0.718",
+      "port-version": 0
+    },
+    {
       "git-tree": "6a11ca188d90823b27b4ca531556f4aa27141b21",
       "version": "0.717",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/luau-lang/luau/releases/tag/0.718

Luau.Bytecode has been added.