### PR TITLE
[hexl] Update to 1.2.6

### DIFF
--- a/ports/hexl/portfile.cmake
+++ b/ports/hexl/portfile.cmake
@@ -2,9 +2,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO intel/hexl
+    REPO IntelLabs/hexl
     REF "v${VERSION}"
-    SHA512 1a5e42fdeac877f3b4ef87ab75ffa8280697e941d7a8f0f6dc8c5066f2dd405470530dfabdf12d846362bd3e7e6cd30fd1f11d8dd99bee5086d09371ba1da196
+    SHA512 11cfbfbea70d8bb70bb1d5c5d741c18ce87adc9d1904ca30f603cd878eb6b29be0eaf78ca76a05ed2bdacab0370f89494851309cff1e847488d28ca79b891bce
     HEAD_REF development
 )
 

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "hexl",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
-  "homepage": "https://github.com/intel/hexl",
+  "homepage": "https://github.com/IntelLabs/hexl",
   "license": "Apache-2.0",
   "supports": "x64",
   "dependencies": [

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
   "homepage": "https://github.com/IntelLabs/hexl",
   "license": "Apache-2.0",
-  "supports": "x64",
+  "supports": "x64 & !android",
   "dependencies": [
     "cpu-features",
     "easyloggingpp",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -256,7 +256,6 @@ gz-tools:arm-neon-android=fail
 gz-tools:arm64-android=fail
 gz-tools:x64-android=fail
 halide:x64-windows-static=fail
-hexl:x64-android=fail
 hwloc:arm-neon-android=fail
 hwloc:arm64-android=fail
 hwloc:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3785,7 +3785,7 @@
       "port-version": 0
     },
     "hexl": {
-      "baseline": "1.2.5",
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "hffix": {

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f9b90aa4040fe88b72df0996ee04adba8e81aa60",
+      "version": "1.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "507c302772e728f454519b1c7eb2740414b11386",
       "version": "1.2.5",
       "port-version": 0

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f9b90aa4040fe88b72df0996ee04adba8e81aa60",
+      "git-tree": "1a47601a308ef41c32571442efedb97c61bb3db3",
       "version": "1.2.6",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


The upstream repository was changed from Intel/HEXL to IntelLabs/HEXL, because IntelLabs now owns this library and Intel/HEXL redirects to it.

Android build is expected to fail.