### PR TITLE
[gtk3] fix when building with wayland support

### DIFF
--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -38,8 +38,13 @@ else()
     list(APPEND OPTIONS_RELEASE -Dintrospection=false)
 endif()
 
+set(BINARIES "")
+
 if("wayland" IN_LIST FEATURES)
     list(APPEND OPTIONS -Dwayland_backend=true)
+    if(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES)
+        list(APPEND BINARIES "wayland-scanner='${CURRENT_HOST_INSTALLED_DIR}/tools/wayland/wayland-scanner${VCPKG_HOST_EXECUTABLE_SUFFIX}'")
+    endif()
 else()
     list(APPEND OPTIONS -Dwayland_backend=false)
 endif()
@@ -70,6 +75,7 @@ vcpkg_configure_meson(
         "glib-compile-schemas='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-schemas${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
         "g-ir-compiler='${GIR_COMPILER}'"
         "g-ir-scanner='${GIR_SCANNER}'"
+        ${BINARIES}
 )
 
 # Reduce command line lengths, in particular for static windows builds.

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.52",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -94,6 +94,7 @@
       "description": "Build with Wayland support",
       "supports": "linux | freebsd | openbsd",
       "dependencies": [
+        "libxkbcommon",
         "wayland",
         "wayland-protocols"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3606,7 +3606,7 @@
     },
     "gtk3": {
       "baseline": "3.24.52",
-      "port-version": 1
+      "port-version": 2
     },
     "gtkmm": {
       "baseline": "4.22.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdaacc5cc7324e2e33d4d5453cae2bdf4358b326",
+      "version": "3.24.52",
+      "port-version": 2
+    },
+    {
       "git-tree": "afdd4189312de678e0fe7da05ffa6277847205a2",
       "version": "3.24.52",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
