### PR TITLE
[stillwater-universal] update to 4.6.10

### DIFF
--- a/ports/stillwater-universal/portfile.cmake
+++ b/ports/stillwater-universal/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stillwater-sc/universal
     REF "v${VERSION}"
-    SHA512 c4b9d0ed4a46f8ce7b2eb12c2afa3ee3b75f1bda8817568a2fb00a65dfa115b552ddd8863d65eca565f91bb2faa7e808a0d7f4d7a2983beafba8e0e1ba75b937
+    SHA512 45254c31ab606020dd5c1bb21344a638bb92f3d195bc6691b37963254bf23f71f4ace01108cea4f4ed7bfcc8446f6e90a43e15563c556e3251b119a0e0b4d06d
     HEAD_REF master
     PATCHES
         fix-install-path.patch

--- a/ports/stillwater-universal/vcpkg.json
+++ b/ports/stillwater-universal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stillwater-universal",
-  "version": "4.6.9",
+  "version": "4.6.10",
   "description": "A header-only C++ library for plug-in replacement number systems for native types",
   "homepage": "https://github.com/stillwater-sc/universal",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9677,7 +9677,7 @@
       "port-version": 0
     },
     "stillwater-universal": {
-      "baseline": "4.6.9",
+      "baseline": "4.6.10",
       "port-version": 0
     },
     "stlab": {

--- a/versions/s-/stillwater-universal.json
+++ b/versions/s-/stillwater-universal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a88fd6aa6ecff15ce1d7025d7c302f0aecc0057",
+      "version": "4.6.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "aebf952d784d29600a2d27e615ffc451e1a6f059",
       "version": "4.6.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stillwater-sc/universal/releases/tag/v4.6.10
