### PR TITLE
[logme] update to 2.4.16

### DIFF
--- a/ports/logme/portfile.cmake
+++ b/ports/logme/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO efmsoft/logme
   REF "v${VERSION}"
-  SHA512 f3bfead1357d917d03a23b7eae318f49a65ff401e7cdb971adee7938c2dae0ab6fabea66bbf71a6832aacd057f5abd56868e30a4c0333ccf78a4d67aefbca050
+  SHA512 4debf121f997bddbd62e749b7cbc237142d9fd052cb7b2099d359cfb563cd43458ad452135dbe9eba1d37b8b139cf2f793ab61b379382b7e54a1a651fb50e793
   HEAD_REF master
 )
 

--- a/ports/logme/vcpkg.json
+++ b/ports/logme/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "logme",
-  "version": "2.4.15",
-  "port-version": 1,
+  "version": "2.4.16",
   "description": "Cross-platform C/C++ logging framework: channels and routing, multiple backends, colored output, and runtime dynamic control.",
   "homepage": "https://github.com/efmsoft/logme",
   "documentation": "https://github.com/efmsoft/logme/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6133,8 +6133,8 @@
       "port-version": 0
     },
     "logme": {
-      "baseline": "2.4.15",
-      "port-version": 1
+      "baseline": "2.4.16",
+      "port-version": 0
     },
     "loguru": {
       "baseline": "2.1.0",

--- a/versions/l-/logme.json
+++ b/versions/l-/logme.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff686e788934d5335b8d03d4bf4ae0f40ccc7391",
+      "version": "2.4.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "88d16c135245825fd0f85a5dbb5287cc0813553b",
       "version": "2.4.15",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/efmsoft/logme/releases/tag/v2.4.16
