### PR TITLE
[vincentlaucsb-csv-parser] update to 4.0.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3ea14d3..22aedc5 100644
+index 7bd1223..4269b41 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,5 +1,8 @@
@@ -11,11 +11,10 @@ index 3ea14d3..22aedc5 100644
 
  if(CSV_CXX_STANDARD)
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
-@@ -83,10 +86,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
-
+@@ -85,9 +88,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  include_directories(${CSV_INCLUDE_DIR})
 
--## Load developer specific CMake settings
+ ## Load developer specific CMake settings
 -if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 -    SET(CSV_DEVELOPER TRUE)
 -endif()
@@ -23,10 +22,10 @@ index 3ea14d3..22aedc5 100644
 
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
-@@ -102,6 +102,22 @@ option(CSV_BUILD_PROGRAMS "Allow to disable building of programs" ON)
- if (CSV_BUILD_PROGRAMS)
-     add_subdirectory("programs")
- endif()
+@@ -106,6 +107,22 @@ endif()
+
+ ## Tests
+ option(CSV_BUILD_TESTS "Allow to disable building of tests" ON)
 +install(TARGETS csv EXPORT unofficial-vincentlaucsb-csv-parser)
 +
 +install(
@@ -47,20 +46,20 @@ index 3ea14d3..22aedc5 100644
  ## Developer settings
  if (CSV_DEVELOPER)
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index e96cfd0..2f95f90 100644
+index 8674389..76f0f1a 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
-@@ -28,7 +28,7 @@ target_sources(csv
+@@ -27,7 +27,7 @@ target_sources(csv
  		thread_safe_deque.hpp
- 		)
+ 	)
 
 -set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX)
 +set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX OUTPUT_NAME "vincentlaucsb-csv-parser-csv")
 
  if(CSV_NO_SIMD)
  	target_compile_definitions(csv PUBLIC CSV_NO_SIMD=1)
-@@ -41,8 +41,6 @@ else()
- 	target_compile_definitions(csv PUBLIC CSV_ENABLE_THREADS=0)
+@@ -44,8 +44,6 @@ if(MSVC AND NOT CSV_NO_SIMD)
+ 	target_compile_options(csv PUBLIC /arch:AVX2)
  endif()
 
 -target_include_directories(csv INTERFACE ../)
@@ -68,7 +67,7 @@ index e96cfd0..2f95f90 100644
  # Scalar-only variant of the library: same sources, CSV_NO_SIMD defined.
  # Used by csv_bench_no_simd to provide a fair apples-to-apples benchmark.
  add_library(csv_no_simd STATIC "")
-@@ -56,4 +54,11 @@ if(CSV_ENABLE_THREADS)
+@@ -59,4 +57,11 @@ if(CSV_ENABLE_THREADS)
  else()
  	target_compile_definitions(csv_no_simd PUBLIC CSV_ENABLE_THREADS=0)
  endif()

--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -1,10 +1,10 @@
 diff --git a/include/internal/basic_csv_parser.hpp b/include/internal/basic_csv_parser.hpp
-index 1fd844c..ee53291 100644
+index 341a154..2d1e70a 100644
 --- a/include/internal/basic_csv_parser.hpp
 +++ b/include/internal/basic_csv_parser.hpp
 @@ -12,7 +12,7 @@
  #include <vector>
- 
+
  #if !defined(__EMSCRIPTEN__)
 -#include "../external/mio.hpp"
 +#include "mio/mmap.hpp"
@@ -12,22 +12,22 @@ index 1fd844c..ee53291 100644
  #include "basic_csv_parser_simd.hpp"
  #include "col_names.hpp"
 diff --git a/include/internal/common.hpp b/include/internal/common.hpp
-index 72c70b8..9ad1dca 100644
+index 97824fd..aa5b484 100644
 --- a/include/internal/common.hpp
 +++ b/include/internal/common.hpp
-@@ -97,7 +97,7 @@
+@@ -105,7 +105,7 @@
  #endif
- 
+
  // Include string_view BEFORE csv namespace to avoid namespace pollution issues
 -#ifdef CSV_HAS_CXX17
 +#if 1
  #include <string_view>
  #else
  #include "../external/string_view.hpp"
-@@ -123,7 +123,7 @@ namespace csv {
- // Allows static assertions without specifying a message
- #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
- 
+@@ -141,7 +141,7 @@ namespace csv {
+     #define CSV_DEBUG_ASSERT(x) assert(x)
+ #endif
+
 -#ifdef CSV_HAS_CXX17
 +#if 1
       /** @typedef string_view

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 ac0fbd1989a55a5a74567a72edd568b4f7050ebe3a7cffbe255c5feaf7c2adf09cce230cc8f14ff8f1d890b8def4ccf6d3a07e7c1ea6cd36e4f57310fccc982c
+    SHA512 f9675ac7f6f0a5060504222580fc1f08de98e79a19631ebe5427d891c99f816d8c5a714b7e34465068b5ec5c84d6ce896014fe5612569419ff217a7b62115dec
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "3.5.1",
+  "version": "4.0.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10597,7 +10597,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "3.5.1",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ce16d083b8893276de2d42bbf8f48bfb09fc9b2",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa8d88e15572fb35f9dc02ff2aa4318cf766f204",
       "version": "3.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/4.0.0
