### PR TITLE
[dpdk] Update to 26.03

### DIFF
--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -30,11 +30,13 @@ if(VCPKG_TARGET_IS_LINUX AND VCPKG_HOST_IS_LINUX)
   endif()
 endif()
 
+# Add a leading zero to the minor version if it consists of only one digit, otherwise the regex does nothing
+string(REGEX REPLACE "^([0-9]+)\\.([0-9])(\\..*)$" "\\1.0\\2\\3" VERSION_REF "${VERSION}")
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO DPDK/dpdk
-  REF "v${VERSION}"
-  SHA512 21b1fd1b87797a61c3480e9b049a38ea5be2fb174b8d1d397db25a0d6c04281f1951e402276299fd605763ef6aa867f1285b2321f03214aa6122553cfb53771e
+  REF "v${VERSION_REF}"
+  SHA512 37b49b5b5481036e0d563794222fc37c358f3c81b449e4252adb3bb1365e5dde14d7310a1ace810ee2443902a1cc7b177dca76666dd324241142062532a7509d
   HEAD_REF main
   PATCHES
       0001-enable-either-static-or-shared-build.patch

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "dpdk",
-  "version": "25.11",
-  "port-version": 1,
+  "version": "26.3",
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/",
   "license": "BSD-3-Clause",
-  "supports": "freebsd | linux",
+  "supports": "freebsd | linux | (windows & x64)",
   "dependencies": [
     {
       "name": "libarchive",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2585,8 +2585,8 @@
       "port-version": 1
     },
     "dpdk": {
-      "baseline": "25.11",
-      "port-version": 1
+      "baseline": "26.3",
+      "port-version": 0
     },
     "dpp": {
       "baseline": "10.1.4",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f0e7f0a8441cfd2b7c64c76f70d599d657df8c1",
+      "version": "26.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ae5ab5a636f2c9dc7972c69a9c554bfe16823b5",
       "version": "25.11",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Windows support was removed here: https://github.com/microsoft/vcpkg/pull/49284/changes#r2697410410. As it compiles on my local machine, added again and we will see, if the CI is fine.