### PR TITLE
[hazelcast-cpp-client] boost 1.91 compatibility, update SHA512

### DIFF
--- a/ports/hazelcast-cpp-client/fix-boost-optional.patch
+++ b/ports/hazelcast-cpp-client/fix-boost-optional.patch
@@ -1,0 +1,13 @@
+diff --git a/hazelcast/src/hazelcast/client/spi.cpp b/hazelcast/src/hazelcast/client/spi.cpp
+index 0d659f9..9df6553 100644
+--- a/hazelcast/src/hazelcast/client/spi.cpp
++++ b/hazelcast/src/hazelcast/client/spi.cpp
+@@ -941,7 +941,7 @@ ClientClusterServiceImpl::get_member(boost::uuids::uuid uuid) const
+     if (it == members_view_ptr->members.end()) {
+         return boost::none;
+     }
+-    return { it->second };
++    return boost::optional<member>(it->second);
+ }
+
+ std::vector<member>

--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
     REF "v${VERSION}"
-    SHA512 bc37aae5fbd4272b7e3f1c489c05661c1c771e96fc3f0344ee02be8fe705e98a64234772e679e635f10a64788b8d62e069bc5eb119884b7eb9a78ccd66da62c4
+    SHA512 4998b9173f37400515f9bb3a14b0c03755b65f703cc692f8719b0d6c0612a1b10c588ff203daae9ab74853a402ac4560d2874366568cae07f7a7a877b25b073b
     HEAD_REF master
+    PATCHES 
+        fix-boost-optional.patch
 )
 
 vcpkg_check_features(

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hazelcast-cpp-client",
   "version": "5.6.0",
+  "port-version": 1,
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "https://docs.hazelcast.com/hazelcast/latest/clients/cplusplus",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3754,7 +3754,7 @@
     },
     "hazelcast-cpp-client": {
       "baseline": "5.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "hdf5": {
       "baseline": "2.1.1",

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c859908daffd5d501f5f95221b8f42fdce94194a",
+      "version": "5.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "25fdd1f6ac8b5c5a794f887f473184d9ac8bff15",
       "version": "5.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
