### PR TITLE
[thrift] update to 0.23.0

### DIFF
--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_find_acquire_program(BISON)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/thrift/${VERSION}/thrift-${VERSION}.tar.gz"
     FILENAME "thrift-${VERSION}.tar.gz"
-    SHA512 beb37ee2a295fae7df12cce6449c92799076771bae515fafcc790a62ac6e76ac5584f102315d466b8f5f98e236c9dc4a244695bdcd9f1392d6e9a13d365ddadc
+    SHA512 a57c6fa645852f22ca10380621facc193393b19d1d760e113baa0f964365839043f2b527bd8cd3c03808380e9f09e9a8f707f8abbd931c51632e9d5181a459cf
 )
 
 vcpkg_extract_source_archive(
@@ -70,7 +70,6 @@ vcpkg_cmake_configure(
         CMAKE_REQUIRE_FIND_PACKAGE_Libevent
         CMAKE_REQUIRE_FIND_PACKAGE_OpenSSL
         CMAKE_REQUIRE_FIND_PACKAGE_ZLIB
-    
 )
 
 vcpkg_cmake_install()

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "thrift",
-  "version": "0.22.0",
-  "port-version": 2,
+  "version": "0.23.0",
   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
   "homepage": "https://github.com/apache/thrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10001,8 +10001,8 @@
       "port-version": 4
     },
     "thrift": {
-      "baseline": "0.22.0",
-      "port-version": 2
+      "baseline": "0.23.0",
+      "port-version": 0
     },
     "tidy-html5": {
       "baseline": "5.8.0",

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "088c3581c3b7ffdedffca7029fc303e16f6b7594",
+      "version": "0.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c69712275b12812b2464254884257cd47673d2c",
       "version": "0.22.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/apache/thrift/releases/tag/v0.23.0
