### PR TITLE
[magma] Fix with CUDA 13.2.

### DIFF
--- a/ports/magma/fix-cmake4.patch
+++ b/ports/magma/fix-cmake4.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fc61af7..a3c9606 100644
+index 0d5d83d..fd463c5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -654,7 +654,7 @@ endif()
+@@ -661,7 +661,7 @@ endif()
  
  
  set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SPARSE_TEST_DIR}" )

--- a/ports/magma/fix-cuda13-clockrate.patch
+++ b/ports/magma/fix-cuda13-clockrate.patch
@@ -1,5 +1,5 @@
 diff --git a/interface_cuda/interface.cpp b/interface_cuda/interface.cpp
-index c4544f9..4800536 100644
+index c4544f9..4dab052 100644
 --- a/interface_cuda/interface.cpp
 +++ b/interface_cuda/interface.cpp
 @@ -451,10 +451,12 @@ magma_print_environment()
@@ -7,7 +7,7 @@ index c4544f9..4800536 100644
  
          #ifdef MAGMA_HAVE_CUDA
 +        int clockRateKHz = 0;
-+        cudaDeviceGetAttribute( &clockRateKHz, cudaDevAttrClockRate, dev );        
++        cudaDeviceGetAttribute( &clockRateKHz, cudaDevAttrClockRate, dev );
          printf( "%% device %d: %s, %.1f MHz clock, %.1f MiB memory, capability %d.%d\n",
                  dev,
                  prop.name,

--- a/ports/magma/fix-cuda13-cpp17.patch
+++ b/ports/magma/fix-cuda13-cpp17.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a59abcd..1c8fe87 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -603,7 +603,6 @@ include_directories( testing )
+ 
+ if (MAGMA_ENABLE_CUDA)
+   add_library( magma_sparse ${libsparse_all} )
+-  set_property(TARGET magma_sparse PROPERTY CUDA_STANDARD 14)
+   target_link_libraries( magma_sparse
+     magma
+     ${blas_fix}

--- a/ports/magma/fix-cuda13-preprocessor.patch
+++ b/ports/magma/fix-cuda13-preprocessor.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fd463c5..a59abcd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,6 +219,10 @@ if (MAGMA_ENABLE_CUDA)
+             )
+         endif()
+ 
++        if(MSVC)
++            target_compile_options(magma_nvcc_flags INTERFACE -Zc:preprocessor)
++        endif()
++
+         set( MAGMA_HAVE_CUDA "1" )
+ 
+         message( STATUS "Define -DMAGMA_HAVE_CUDA -DMAGMA_CUDA_ARCH_MIN=${MAGMA_CUDA_ARCH_MIN}" )

--- a/ports/magma/no-tests.patch
+++ b/ports/magma/no-tests.patch
@@ -1,40 +1,36 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3c9606..a783c57 100644
+index 56a3c84..0d5d83d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -569,6 +569,7 @@ target_link_libraries( lapacktest
+@@ -571,6 +571,7 @@ target_link_libraries( lapacktest
+ )
  
+ 
++if(FALSE)
  # ----------------------------------------
  # compile tester library
-+if(FALSE)
  add_library( tester ${libtest_all} )
- target_link_libraries( tester
-     magma
-@@ -576,8 +577,7 @@ target_link_libraries( tester
+@@ -580,6 +581,7 @@ target_link_libraries( tester
      ${blas_fix}
      ${LAPACK_LIBRARIES}
  )
--
--
 +endif()
+ 
+ 
  # ----------------------------------------
- # compile MAGMA sparse library
+@@ -621,6 +623,7 @@ endif()
+ add_custom_target( sparse-lib DEPENDS magma_sparse )
  
-@@ -619,7 +619,7 @@ add_custom_target( sparse-lib DEPENDS magma_sparse )
  
++if(FALSE)
  # ----------------------------------------
  # compile each tester
--
-+if(FALSE)
- # save testers to testing/
- # save tester lib files to testing_lib/ to avoid cluttering lib/
- set( CMAKE_RUNTIME_OUTPUT_DIRECTORY testing )
-@@ -664,7 +664,7 @@ foreach( TEST ${sparse_testing_all} )
+ 
+@@ -668,6 +671,7 @@ foreach( TEST ${sparse_testing_all} )
      list( APPEND sparse-testing ${EXE} )
  endforeach()
  add_custom_target( sparse-testing DEPENDS ${sparse-testing} )
--
 +endif()
  
+ 
  # ----------------------------------------
- # what to install

--- a/ports/magma/portfile.cmake
+++ b/ports/magma/portfile.cmake
@@ -1,4 +1,3 @@
-
 set(opts "")
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
   set(opts
@@ -23,6 +22,8 @@ vcpkg_extract_source_archive(
     clang-cuda.patch
     fix-cmake4.patch
     fix-cuda13-clockrate.patch
+    fix-cuda13-preprocessor.patch
+    fix-cuda13-cpp17.patch
 )
 
 vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT cuda_toolkit_root) 
@@ -33,10 +34,12 @@ vcpkg_cmake_configure(
     -DMAGMA_ENABLE_CUDA=ON
     -DMAGMA_ENABLE_HIP=OFF # HIP is backend and seems additive?!
     -DUSE_FORTRAN=OFF
+    -DCMAKE_CUDA_STANDARD=17
     "-DCMAKE_CUDA_COMPILER:FILEPATH=${NVCC}"
     "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
     ${opts}
 )
+
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/magma/vcpkg.json
+++ b/ports/magma/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magma",
   "version": "2.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Matrix Algebra on GPU and Multi-core Architectures (MAGMA) is a collection of next-generation linear algebra libraries for heterogeneous computing",
   "homepage": "https://icl.utk.edu/magma/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6266,7 +6266,7 @@
     },
     "magma": {
       "baseline": "2.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "magnum": {
       "baseline": "2020.06",

--- a/versions/m-/magma.json
+++ b/versions/m-/magma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "414326930320964f1c6392e3f0aeaeadd6932b1a",
+      "version": "2.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "12c188bca44f164b2ecdd896e559c1256bd34b4e",
       "version": "2.9.0",
       "port-version": 1


### PR DESCRIPTION
CUDA 13.2 requires C++17.

Also fixed patches with trailing whitespace, incorrect line endings, minimized in some cases.

Related to https://github.com/microsoft/vcpkg/pull/51210