### PR TITLE
Fix the "check for common mistakes" check when ports are deindexed.

### DIFF
--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -61,13 +61,14 @@ jobs:
           # reset the version database to the state of the merge base, so that we can check that the PR only adds one version and doesn't modify any existing versions
           git restore --source=$merge_base --staged --worktree -- versions
           git clean -fd -- versions
-          rm versions/baseline.json
+          rm versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
           # check for version format errors separately by running x-add-version --all, recording problems it generates
           ./vcpkg x-add-version --all | grep -E '^warning:|instead of "version-string"' | tee .github-pr.version-string.out || true
           # reset the version database again
+          git reset --hard
           git restore --source=$merge_base --staged --worktree -- versions
           git clean -fd -- versions
-          rm versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
+          rm versions/baseline.json
           # check that the PR only adds one version and doesn't modify any existing versions, ignoring any of the warnings recorded into .github-pr.version-string.out
           ./vcpkg x-add-version --all --skip-version-format-check | tee .github-pr.x-add-version.out || true
           git add -A -- versions

--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -61,11 +61,13 @@ jobs:
           # reset the version database to the state of the merge base, so that we can check that the PR only adds one version and doesn't modify any existing versions
           git restore --source=$merge_base --staged --worktree -- versions
           git clean -fd -- versions
+          rm versions/baseline.json
           # check for version format errors separately by running x-add-version --all, recording problems it generates
           ./vcpkg x-add-version --all | grep -E '^warning:|instead of "version-string"' | tee .github-pr.version-string.out || true
           # reset the version database again
           git restore --source=$merge_base --staged --worktree -- versions
           git clean -fd -- versions
+          rm versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
           # check that the PR only adds one version and doesn't modify any existing versions, ignoring any of the warnings recorded into .github-pr.version-string.out
           ./vcpkg x-add-version --all --skip-version-format-check | tee .github-pr.x-add-version.out || true
           git add -A -- versions

--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -61,14 +61,13 @@ jobs:
           # reset the version database to the state of the merge base, so that we can check that the PR only adds one version and doesn't modify any existing versions
           git restore --source=$merge_base --staged --worktree -- versions
           git clean -fd -- versions
-          rm versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
+          echo '{"default": {}}' > versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
           # check for version format errors separately by running x-add-version --all, recording problems it generates
           ./vcpkg x-add-version --all | grep -E '^warning:|instead of "version-string"' | tee .github-pr.version-string.out || true
           # reset the version database again
-          git reset --hard
           git restore --source=$merge_base --staged --worktree -- versions
           git clean -fd -- versions
-          rm versions/baseline.json
+          echo '{"default": {}}' > versions/baseline.json
           # check that the PR only adds one version and doesn't modify any existing versions, ignoring any of the warnings recorded into .github-pr.version-string.out
           ./vcpkg x-add-version --all --skip-version-format-check | tee .github-pr.x-add-version.out || true
           git add -A -- versions

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -416,10 +416,6 @@
       "baseline": "0.5.1",
       "port-version": 0
     },
-    "autobahn": {
-      "baseline": "20.8.1",
-      "port-version": 2
-    },
     "autodock-vina": {
       "baseline": "1.2.7",
       "port-version": 0
@@ -895,10 +891,6 @@
     "boost-compat": {
       "baseline": "1.90.0",
       "port-version": 1
-    },
-    "boost-compatibility": {
-      "baseline": "1.86.0",
-      "port-version": 0
     },
     "boost-compute": {
       "baseline": "1.90.0",
@@ -1435,10 +1427,6 @@
     "boost-variant2": {
       "baseline": "1.90.0",
       "port-version": 1
-    },
-    "boost-vcpkg-helpers": {
-      "baseline": "1.84.0",
-      "port-version": 0
     },
     "boost-vmd": {
       "baseline": "1.90.0",
@@ -2039,10 +2027,6 @@
     "cpp-lazy": {
       "baseline": "9.0.1",
       "port-version": 0
-    },
-    "cpp-netlib": {
-      "baseline": "0.13.0",
-      "port-version": 10
     },
     "cpp-peglib": {
       "baseline": "1.10.2",
@@ -2832,10 +2816,6 @@
       "baseline": "ca7cb332011ec37",
       "port-version": 1
     },
-    "etcd-cpp-apiv3": {
-      "baseline": "0.15.4",
-      "port-version": 3
-    },
     "ethindp-prism": {
       "baseline": "0.11.6",
       "port-version": 0
@@ -3180,10 +3160,6 @@
       "baseline": "3.18.0",
       "port-version": 27
     },
-    "freeopcua": {
-      "baseline": "20190125",
-      "port-version": 9
-    },
     "freerdp": {
       "baseline": "3.25.0",
       "port-version": 0
@@ -3298,10 +3274,6 @@
     },
     "gaussianlib": {
       "baseline": "2024-11-03",
-      "port-version": 0
-    },
-    "gazebo": {
-      "baseline": "11.15.1",
       "port-version": 0
     },
     "gcem": {
@@ -6500,10 +6472,6 @@
       "baseline": "7.0.3",
       "port-version": 0
     },
-    "microsoft-signalr": {
-      "baseline": "0.1.0-alpha4",
-      "port-version": 12
-    },
     "microsoft-windows-devices-midi2": {
       "baseline": "1.0.13-preview.13.192",
       "port-version": 0
@@ -6987,10 +6955,6 @@
     "nghttp2": {
       "baseline": "1.69.0",
       "port-version": 0
-    },
-    "nghttp2-asio": {
-      "baseline": "2022-08-11",
-      "port-version": 2
     },
     "nghttp3": {
       "baseline": "1.15.0",
@@ -8520,10 +8484,6 @@
       "baseline": "1.5",
       "port-version": 0
     },
-    "quickfast": {
-      "baseline": "1.5",
-      "port-version": 5
-    },
     "quickfix": {
       "baseline": "1.15.1",
       "port-version": 9
@@ -9399,10 +9359,6 @@
     "soci": {
       "baseline": "4.0.3",
       "port-version": 3
-    },
-    "socket-io-client": {
-      "baseline": "2023-11-11",
-      "port-version": 0
     },
     "sockpp": {
       "baseline": "1.0.0",


### PR DESCRIPTION
Bug is currently appearing in https://github.com/microsoft/vcpkg/pull/51394

The `git restore` operation re-added the removed entries from `baseline.json`, which `x-add-version` preserved. Avoid this problem by having x-add-version recreate the whole file from scratch.