### PR TITLE
[libxt] Update to 1.3.1

### DIFF
--- a/ports/libxt/globals.patch
+++ b/ports/libxt/globals.patch
@@ -1,5 +1,5 @@
 diff --git a/util/StrDefs.ct b/util/StrDefs.ct
-index b597b2051..b682255ad 100644
+index b597b20..2e5198b 100644
 --- a/util/StrDefs.ct
 +++ b/util/StrDefs.ct
 @@ -46,6 +46,8 @@ SOFTWARE.
@@ -12,7 +12,7 @@ index b597b2051..b682255ad 100644
  <<<STRING_TABLE_GOES_HERE>>>
  
 diff --git a/util/StrDefs.ht b/util/StrDefs.ht
-index 2ce20562f..ceab2610f 100644
+index 2ce2056..ceab261 100644
 --- a/util/StrDefs.ht
 +++ b/util/StrDefs.ht
 @@ -52,6 +52,18 @@ SOFTWARE.
@@ -35,7 +35,7 @@ index 2ce20562f..ceab2610f 100644
  
  #ifndef XTSTRINGDEFINES
 diff --git a/util/string.list b/util/string.list
-index 49ba7476e..753c592b3 100644
+index 49ba747..753c592 100644
 --- a/util/string.list
 +++ b/util/string.list
 @@ -6,7 +6,7 @@
@@ -48,7 +48,7 @@ index 49ba7476e..753c592b3 100644
  ! note that the trailing space is required in the #externdef line.
  #ctmpl util/StrDefs.ct
 diff --git a/util/Shell.ht b/util/Shell.ht
-index 500e0fd75..ac8fc2a2e 100644
+index 500e0fd..ac8fc2a 100644
 --- a/util/Shell.ht
 +++ b/util/Shell.ht
 @@ -64,6 +64,18 @@ SOFTWARE.
@@ -71,13 +71,13 @@ index 500e0fd75..ac8fc2a2e 100644
  
  #ifndef XTSTRINGDEFINES
 diff --git a/include/X11/Intrinsic.h b/include/X11/Intrinsic.h
-index 559697aa0..d11eb0955 100644
+index d47bfab..6453635 100644
 --- a/include/X11/Intrinsic.h
 +++ b/include/X11/Intrinsic.h
-@@ -106,7 +106,18 @@ typedef char *String;
- #define externalref globalref
- #define externaldef(psect) globaldef {"psect"} noshare
- #else
+@@ -98,7 +98,18 @@ typedef char *String;
+ 
+ #include <stddef.h>
+ 
 -#define externalref extern
 +#ifndef XT_EXTERN_API
 +# if defined(_MSC_VER) && defined(XT_DLL_EXPORTS)
@@ -92,5 +92,5 @@ index 559697aa0..d11eb0955 100644
 +#endif
 +#define externalref XT_EXTERN_API
  #define externaldef(psect)
- #endif /* VMS */
  
+ #ifndef FALSE

--- a/ports/libxt/portfile.cmake
+++ b/ports/libxt/portfile.cmake
@@ -1,7 +1,8 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
@@ -13,20 +14,23 @@ if(VCPKG_CROSSCOMPILING)
     set(PATCHES cc_for_build.patch)
 endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxt
-    REF "libXt-${VERSION}"
-    SHA512 7cb22be9706bd7d089e84c09a99597f730ca858a9f8134d2741916b28cd4786e236beaad568c8b7ab8cdcfdea1c49140cefac528244bab8c94d48dc4729267e8
-    HEAD_REF master
+vcpkg_download_distfile(
+    LIBXT_ARCHIVE
+    URLS "https://www.x.org/archive/individual/lib/libXt-${VERSION}.tar.xz"
+    FILENAME "libXt-${VERSION}.tar.xz"
+    SHA512 c220292f60b0f53134cf9364831a32bbaa9fa6bbb3a7143e917920957b7a48c616e946042747089f29ea9d8a18ecd64de620bcaf56d82462e7107de906f5db38
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXT_ARCHIVE}"
     PATCHES
         windows_build.patch
         globals.patch
         getcwd.patch
         add-missing-process-h.patch
         ${PATCHES}
-) 
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -81,7 +85,7 @@ if(VCPKG_CROSSCOMPILING)
     endif()
 endif()
 
-vcpkg_install_make()
+vcpkg_install_make(DISABLE_PARALLEL)
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
@@ -100,7 +104,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endif()
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 if(NOT VCPKG_CROSSCOMPILING)
@@ -108,6 +111,4 @@ if(NOT VCPKG_CROSSCOMPILING)
             DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 endif()
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxt/vcpkg.json
+++ b/ports/libxt/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "libxt",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "X Toolkit Intrinsics library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxt",
   "license": null,
+  "supports": "!(arm64 & windows)",
   "dependencies": [
-    "bzip2",
     "glib",
     "libice",
     "libsm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5973,7 +5973,7 @@
       "port-version": 0
     },
     "libxt": {
-      "baseline": "1.3.0",
+      "baseline": "1.3.1",
       "port-version": 0
     },
     "libxtst": {

--- a/versions/l-/libxt.json
+++ b/versions/l-/libxt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "828043b8ce0be3ffb7f321e4785e506f94a6d5ca",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0bb02545da1d28c209ba8d237070b61239f3a6cb",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

ARM64-Windows patch is updated via Sonnet 4.6, as I have no experience in ASM code for ARM. Issue was:
```
<inline asm>(4,12): error: unknown token in expression
    4 |     jmp *_y(%rip)         
      |         
```
Alternate would be to don't build this on ARM64-Windows