### PR TITLE
[libxfont] Update to 2.0.7

### DIFF
--- a/ports/libxfont/configure.patch
+++ b/ports/libxfont/configure.patch
@@ -1,16 +1,8 @@
 diff --git a/configure.ac b/configure.ac
-index f507c285a..a821e7311 100644
---- a/configure.ac	
+index 43cd3bb..240864a 100644
+--- a/configure.ac
 +++ b/configure.ac
-@@ -122,14 +122,14 @@ AC_SUBST(FREETYPE_REQUIRES)
- AC_DEFINE(X_GZIP_FONT_COMPRESSION,1,[Support gzip for bitmap fonts])
- X_GZIP_FONT_COMPRESSION=1
- AC_SUBST(X_GZIP_FONT_COMPRESSION)
--AC_CHECK_LIB(z, gzopen, [Z_LIBS=-lz], AC_MSG_ERROR([*** zlib is required]))
-+AC_SEARCH_LIBS(gzopen, [z zs zlib zd zsd zlibd] , [Z_LIBS="$ac_cv_search_gzopen"], AC_MSG_ERROR([*** zlib is required]))
- 
- AC_ARG_WITH(bzip2,
- 	AS_HELP_STRING([--with-bzip2],
+@@ -147,7 +147,7 @@ AC_ARG_WITH(bzip2,
  	  [Use libbz2 to support bzip2 compressed bitmap fonts (default: no)]),
  	[], [with_bzip2=no])
  if test "x$with_bzip2" = xyes; then
@@ -19,15 +11,15 @@ index f507c285a..a821e7311 100644
  		AC_MSG_ERROR([*** libbz2 is required for bzip2 support]))
  	AC_DEFINE(X_BZIP2_FONT_COMPRESSION,1,[Support bzip2 for bitmap fonts])
  fi
-@@ -204,8 +204,13 @@ if test "x$XFONT_FC" = xyes; then
+@@ -222,8 +222,13 @@ if test "x$XFONT_FC" = xyes; then
  fi
  
  
 -AC_CHECK_LIB(m, hypot, [MATH_LIBS=-lm
 -AC_SUBST(MATH_LIBS)], AC_MSG_ERROR([*** libm is required]))
-+AC_SEARCH_LIBS([hypot], [m], [MATH_LIBS=-lm AC_SUBST(MATH_LIBS)], 
++AC_SEARCH_LIBS([hypot], [m], [MATH_LIBS=-lm AC_SUBST(MATH_LIBS)],
 +[if test "x$ac_cv_search_hypot" != "xnone required"; then
-+	AC_MSG_ERROR([*** libm is required])	
++	AC_MSG_ERROR([*** libm is required])
 +else
 +	AC_MSG_ERROR([*** libm is not required])
 +fi]

--- a/ports/libxfont/portfile.cmake
+++ b/ports/libxfont/portfile.cmake
@@ -1,19 +1,24 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxfont
-    REF 3a4f68284c5aeea77789af1fe395cac35efc8562 # 2.0.5
-    SHA512  d9731b50a55c3bceadb0abb4530a673940432467402829559229cfa946105270970db0b7663b72e64279b4b6f8a82b594549d8987205e581de19e55710fec15f
-    HEAD_REF master
-    PATCHES build.patch
-            build2.patch
-            configure.patch
-) 
+vcpkg_download_distfile(
+    LIBXFONT2_ARCHIVE
+    URLS "https://www.x.org/archive/individual/lib/libXfont2-${VERSION}.tar.xz"
+    FILENAME "libXfont2-${VERSION}.tar.xz"
+    SHA512 f703127df5d5b1093c9b73e019153ed7799523573d52e61d344209f0acfd4df42e11be12bdd1880479c47c2b70de581a4f2ef74e199e9b1ac438f426593d56b0
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXFONT2_ARCHIVE}"
+    PATCHES
+        build.patch
+        build2.patch
+        configure.patch
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 if(VCPKG_TARGET_IS_WINDOWS)
@@ -23,10 +28,8 @@ endif()
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
-    OPTIONS ${OPTIONS}
-      --with-bzip2=yes
-    OPTIONS_DEBUG ${DEPS_DEBUG}
-    OPTIONS_RELEASE ${DEPS_RELEASE}
+    OPTIONS
+        --with-bzip2=yes
 )
 
 vcpkg_make_install()
@@ -44,9 +47,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxfont/vcpkg.json
+++ b/ports/libxfont/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxfont",
-  "version": "2.0.5",
-  "port-version": 3,
+  "version": "2.0.7",
   "description": "X font handling library for server & utilities",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxfont",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5893,8 +5893,8 @@
       "port-version": 1
     },
     "libxfont": {
-      "baseline": "2.0.5",
-      "port-version": 3
+      "baseline": "2.0.7",
+      "port-version": 0
     },
     "libxft": {
       "baseline": "2.3.9",

--- a/versions/l-/libxfont.json
+++ b/versions/l-/libxfont.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f2ba49916df62b4408426e3bd2846549bb8083f",
+      "version": "2.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "626b0f9af32ec7e9243a8367ae56289661eff54c",
       "version": "2.0.5",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.