### PR TITLE
[aeron] update to 1.51.0

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aeron-io/aeron
     REF "${VERSION}"
-    SHA512 aacd14611acfff3f4890541fbd1f3cdb8b396d86a4e9fb2eb1f4f1a72c9fbe546d2b479ee86b4fe5900b5f3acf6e29d9916364efbe98255baa9cd6c429b057cb
+    SHA512 07416031e022e668dc236971637ecadb62f90ce31ea008da3d30a67553b5dc6079c2ac2cf631a14d3331fbda09ca1fd70ae9890ca6e1b965e27a802b9be1e9e4
     HEAD_REF master
     PATCHES
         patches/add-libuuid-vcpkg-support.patch

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
-  "version": "1.50.4",
+  "version": "1.51.0",
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0cf4732e51e3304f2ba951cc81e31d13e8464fb",
+      "version": "1.51.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4841039173fdd756d73cb7cc0b095bebe0bfb5ba",
       "version": "1.50.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -61,7 +61,7 @@
       "port-version": 0
     },
     "aeron": {
-      "baseline": "1.50.4",
+      "baseline": "1.51.0",
       "port-version": 0
     },
     "air-ctl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/aeron-io/aeron/releases/tag/1.51.0
