### PR TITLE
[sintra] update to 1.2.0

### DIFF
--- a/ports/sintra/portfile.cmake
+++ b/ports/sintra/portfile.cmake
@@ -1,10 +1,24 @@
+set(VCPKG_BUILD_TYPE release) # header only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO imakris/sintra
     REF "v${VERSION}"
-    SHA512 52494fd9dcb6c32f546c362210ad37687001d62387057b39be218dc2aa405e701a534386b8591e81c8505c595aa1dcc1fa19f8872203a5db570b4d6494def234
+    SHA512 6cc28c4281566b3c9b0d1364d6f930f9fe13dcd7018262bedceb77cc212d4e1459b0b2920a75d854faefa12fddef0ee23b01942e4eb4d4015d60e1ba9f9f00f5
     HEAD_REF master
 )
 
-file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSINTRA_INSTALL=ON
+        -DSINTRA_BUILD_EXAMPLES=OFF
+        -DSINTRA_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sintra")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sintra/vcpkg.json
+++ b/ports/sintra/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Header-only C++20 IPC library using shared-memory ring buffers.",
   "homepage": "https://github.com/imakris/sintra",
   "license": "BSD-2-Clause",
-  "supports": "!android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/sintra/vcpkg.json
+++ b/ports/sintra/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "sintra",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Header-only C++20 IPC library using shared-memory ring buffers.",
   "homepage": "https://github.com/imakris/sintra",
   "license": "BSD-2-Clause",
-  "supports": "!android"
+  "supports": "!android",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9257,7 +9257,7 @@
       "port-version": 1
     },
     "sintra": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "sjpeg": {

--- a/versions/s-/sintra.json
+++ b/versions/s-/sintra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e242db89b631b4217cf4bd250746e1eb0b806041",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "509d02ca7cb88c971833c0b80bb8b32698803ac2",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/s-/sintra.json
+++ b/versions/s-/sintra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e242db89b631b4217cf4bd250746e1eb0b806041",
+      "git-tree": "165558e805d0743907c4ff6d3f5ea3daa5bb9b15",
       "version": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/imakris/sintra/releases/tag/v1.2.0

CMake targets has been installed.