### PR TITLE
[verdict] update to 1.4.5

### DIFF
--- a/ports/verdict/include.patch
+++ b/ports/verdict/include.patch
@@ -1,10 +1,10 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 73c4de3..2cdd102 100644
+index ce06226..1781a1d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -54,7 +54,7 @@ configure_file(
- 
+@@ -77,7 +77,7 @@ configure_file(
  add_library(verdict ${verdict_SOURCES} ${verdict_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/verdict_config.h)
+ target_compile_features(verdict PRIVATE cxx_std_11)
  target_include_directories(verdict PUBLIC
 -  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 +  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)

--- a/ports/verdict/portfile.cmake
+++ b/ports/verdict/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  sandialabs/verdict
     REF ${VERSION}
-    SHA512 e4a38fabcb7b56cbc50b59ee2d97c8a4cc3a2afea6ec22860005b77b79536a8dae16acef48197ae881f5b6dbd20495c16ba5b3eadd57d7d478482e5734a98b1d
+    SHA512 86a67742f52473c9d51b0259201d47a8f46b7a62d4df11f54e85779c7fc8326e8f7e05a59487070901329f7d191068ecb04e15bd03bd17cc9f5d4977192cf9b3
     HEAD_REF master
     PATCHES include.patch
             fix_osx.patch
@@ -21,4 +21,3 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
-

--- a/ports/verdict/vcpkg.json
+++ b/ports/verdict/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "1.4.2",
+  "version": "1.4.5",
   "description": "Compute quality functions of 2 and 3-dimensional regions.",
   "homepage": "https://github.com/sandialabs/verdict",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10545,7 +10545,7 @@
       "port-version": 0
     },
     "verdict": {
-      "baseline": "1.4.2",
+      "baseline": "1.4.5",
       "port-version": 0
     },
     "via-httplib": {

--- a/versions/v-/verdict.json
+++ b/versions/v-/verdict.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf09b68a05464bef2dbc248129c4cd769f925052",
+      "version": "1.4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "5bdd5e0da569597ce5fd1948a7adfbe595da9b75",
       "version": "1.4.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/sandialabs/verdict/releases/tag/1.4.5
