### PR TITLE
[flint] DISABLE_PARALLEL_CONFIGURE

### DIFF
--- a/ports/flint/portfile.cmake
+++ b/ports/flint/portfile.cmake
@@ -11,6 +11,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_find_acquire_program(PYTHON3)
     vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"
+        DISABLE_PARALLEL_CONFIGURE # see configure_file(${CMAKE_CURRENT_SOURCE_DIR} ...
         OPTIONS
             "-DPython_EXECUTABLE=${PYTHON3}"
             -DVCPKG_LOCK_FIND_PACKAGE_CBLAS=OFF

--- a/ports/flint/vcpkg.json
+++ b/ports/flint/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "flint",
   "version-semver": "3.5.0",
+  "port-version": 1,
   "description": "Fast Library for Number Theory",
   "homepage": "https://www.flintlib.org/",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3090,7 +3090,7 @@
     },
     "flint": {
       "baseline": "3.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "fltk": {
       "baseline": "1.3.11",

--- a/versions/f-/flint.json
+++ b/versions/f-/flint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86d123e4d68a7250d926df718461f4a45c39499e",
+      "version-semver": "3.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c692b2a3562c15c162011b6298fb6cc70146c69a",
       "version-semver": "3.5.0",
       "port-version": 0


### PR DESCRIPTION
Writes to the source tree, for instance https://github.com/flintlib/flint/blob/741b017a41d55189e6d0dbcfd158cdfcbf3f6033/CMakeLists.txt#L344

Related: https://github.com/microsoft/vcpkg/pull/51210
