### PR TITLE
[ggml] Support CUDA 13.2 on Windows. Fix patch whitespace errors.

### DIFF
--- a/ports/ggml/cmake-config.diff
+++ b/ports/ggml/cmake-config.diff
@@ -1,17 +1,16 @@
 diff --git a/cmake/ggml-config.cmake.in b/cmake/ggml-config.cmake.in
-index fe34cda4..723acac4 100644
+index 91c9d5c..0e0ef78 100644
 --- a/cmake/ggml-config.cmake.in
 +++ b/cmake/ggml-config.cmake.in
-@@ -98,7 +98,7 @@ if (NOT GGML_SHARED_LIB)
+@@ -98,7 +98,6 @@ if (NOT GGML_SHARED_LIB)
  endif()
  
  set_and_check(GGML_INCLUDE_DIR "@PACKAGE_GGML_INCLUDE_INSTALL_DIR@")
 -set_and_check(GGML_LIB_DIR "@PACKAGE_GGML_LIB_INSTALL_DIR@")
-+#set_and_check(GGML_LIB_DIR "@PACKAGE_GGML_LIB_INSTALL_DIR@")
  #set_and_check(GGML_BIN_DIR "@PACKAGE_GGML_BIN_INSTALL_DIR@")
  
  if(NOT TARGET ggml::ggml)
-@@ -112,6 +112,7 @@ if(NOT TARGET ggml::ggml)
+@@ -112,6 +111,7 @@ if(NOT TARGET ggml::ggml)
      add_library(ggml::ggml UNKNOWN IMPORTED)
      set_target_properties(ggml::ggml
          PROPERTIES

--- a/ports/ggml/cuda-13-2.diff
+++ b/ports/ggml/cuda-13-2.diff
@@ -1,0 +1,13 @@
+diff --git a/src/ggml-cuda/CMakeLists.txt b/src/ggml-cuda/CMakeLists.txt
+index 67af1d8..113d0f6 100644
+--- a/src/ggml-cuda/CMakeLists.txt
++++ b/src/ggml-cuda/CMakeLists.txt
+@@ -177,6 +177,8 @@ if (CUDAToolkit_FOUND)
+ 
+     if (NOT MSVC)
+         list(APPEND CUDA_CXX_FLAGS -Wno-pedantic)
++    else()
++        list(APPEND CUDA_CXX_FLAGS /Zc:preprocessor)
+     endif()
+ 
+     list(JOIN   CUDA_CXX_FLAGS " " CUDA_CXX_FLAGS_JOINED)  # pass host compiler flags as a single argument

--- a/ports/ggml/pkgconfig.diff
+++ b/ports/ggml/pkgconfig.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 56420587..98422c5c 100644
+index 0211255..1b1732a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -328,7 +328,7 @@ if (GGML_STANDALONE)
+@@ -333,7 +333,7 @@ if (GGML_STANDALONE)
          @ONLY)
  
      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ggml.pc
@@ -11,7 +11,7 @@ index 56420587..98422c5c 100644
  endif()
  
  #
-@@ -349,6 +349,7 @@ set(variable_set_statements
+@@ -354,6 +354,7 @@ set(variable_set_statements
  set(GGML_SHARED_LIB ${BUILD_SHARED_LIBS})
  
  get_cmake_property(all_variables VARIABLES)
@@ -20,7 +20,7 @@ index 56420587..98422c5c 100644
      if(variable_name MATCHES "^GGML_")
          string(REPLACE ";" "\\;"
 diff --git a/ggml.pc.in b/ggml.pc.in
-index 3e0291e0..a7627339 100644
+index 3e0291e..a762733 100644
 --- a/ggml.pc.in
 +++ b/ggml.pc.in
 @@ -6,5 +6,7 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
@@ -34,10 +34,10 @@ index 3e0291e0..a7627339 100644
 +Libs.private: @GGML_PKGCONFIG_LIBS_PRIVATE@
 +Requires.private: @GGML_PKGCONFIG_REQUIRES_PRIVATE@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index c8f3d859..d7c15992 100644
+index 628db3f..af611bb 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -186,6 +186,10 @@ endif()
+@@ -189,6 +189,10 @@ endif()
  
  # ggml
  
@@ -48,7 +48,7 @@ index c8f3d859..d7c15992 100644
  if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
      message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
  endif()
-@@ -228,6 +232,7 @@ target_link_libraries(ggml PUBLIC ggml-base)
+@@ -241,6 +245,7 @@ target_link_libraries(ggml PUBLIC ggml-base)
  
  if (CMAKE_SYSTEM_NAME MATCHES "Linux")
      target_link_libraries(ggml PRIVATE dl)
@@ -56,12 +56,12 @@ index c8f3d859..d7c15992 100644
  endif()
  
  function(ggml_add_backend_library backend)
-@@ -272,12 +277,20 @@ function(ggml_add_backend backend)
+@@ -291,12 +296,20 @@ function(ggml_add_backend backend)
      string(TOUPPER "GGML_${backend}" backend_id)
      if (${backend_id})
          string(TOLOWER "ggml-${backend}" backend_target)
 +        if (NOT GGML_BACKEND_DL)
-+            # Mirrors ggml_add_backend_library but avoids cmake scoping 
++            # Mirrors ggml_add_backend_library but avoids cmake scoping
 +            set(GGML_PKGCONFIG_LIBS_BACKEND "${GGML_PKGCONFIG_LIBS_BACKEND} -l${backend_target}")
 +        endif()
          add_subdirectory(${backend_target})
@@ -77,7 +77,7 @@ index c8f3d859..d7c15992 100644
      endif()
  endfunction()
  
-@@ -399,11 +412,15 @@ find_library(MATH_LIBRARY m)
+@@ -434,11 +447,15 @@ find_library(MATH_LIBRARY m)
  if (MATH_LIBRARY)
      if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
          target_link_libraries(ggml-base PRIVATE m)
@@ -93,7 +93,7 @@ index c8f3d859..d7c15992 100644
  endif()
  
  if(CMAKE_SYSTEM_NAME MATCHES "visionOS")
-@@ -416,4 +433,10 @@ if (BUILD_SHARED_LIBS)
+@@ -451,4 +468,10 @@ if (BUILD_SHARED_LIBS)
          target_compile_definitions(${target} PRIVATE GGML_BUILD)
          target_compile_definitions(${target} PUBLIC  GGML_SHARED)
      endforeach()
@@ -105,7 +105,7 @@ index c8f3d859..d7c15992 100644
 +set(GGML_PKGCONFIG_LIBS_PRIVATE "${GGML_PKGCONFIG_LIBS_PRIVATE}" PARENT_SCOPE)
 +set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE}" PARENT_SCOPE)
 diff --git a/src/ggml-blas/CMakeLists.txt b/src/ggml-blas/CMakeLists.txt
-index 60ce4b1e..058f65cd 100644
+index 60ce4b1..058f65c 100644
 --- a/src/ggml-blas/CMakeLists.txt
 +++ b/src/ggml-blas/CMakeLists.txt
 @@ -79,6 +79,7 @@ if (BLAS_FOUND)
@@ -117,7 +117,7 @@ index 60ce4b1e..058f65cd 100644
  else()
      message(FATAL_ERROR "BLAS not found, please refer to "
 diff --git a/src/ggml-cpu/CMakeLists.txt b/src/ggml-cpu/CMakeLists.txt
-index 42041b71..b17aca1a 100644
+index e52e050..107cbf5 100644
 --- a/src/ggml-cpu/CMakeLists.txt
 +++ b/src/ggml-cpu/CMakeLists.txt
 @@ -52,6 +52,9 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
@@ -171,7 +171,7 @@ index 42041b71..b17aca1a 100644
          message(STATUS "ARM detected")
          list(APPEND GGML_CPU_SOURCES
 diff --git a/src/ggml-metal/CMakeLists.txt b/src/ggml-metal/CMakeLists.txt
-index 63418fe1..138996a1 100644
+index 63418fe..138996a 100644
 --- a/src/ggml-metal/CMakeLists.txt
 +++ b/src/ggml-metal/CMakeLists.txt
 @@ -19,6 +19,11 @@ target_link_libraries(ggml-metal PRIVATE
@@ -187,7 +187,7 @@ index 63418fe1..138996a1 100644
      add_compile_definitions(GGML_METAL_NDEBUG)
  endif()
 diff --git a/src/ggml-opencl/CMakeLists.txt b/src/ggml-opencl/CMakeLists.txt
-index 7e6c8438..de676a79 100644
+index 681c81b..bac7067 100644
 --- a/src/ggml-opencl/CMakeLists.txt
 +++ b/src/ggml-opencl/CMakeLists.txt
 @@ -7,6 +7,7 @@ ggml_add_backend_library(${TARGET_NAME}
@@ -199,10 +199,10 @@ index 7e6c8438..de676a79 100644
  
  if (GGML_OPENCL_PROFILING)
 diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
-index b97e7bf9..ec194126 100644
+index de01336..3f9524c 100644
 --- a/src/ggml-vulkan/CMakeLists.txt
 +++ b/src/ggml-vulkan/CMakeLists.txt
-@@ -77,6 +77,11 @@ if (Vulkan_FOUND)
+@@ -87,6 +87,11 @@ if (Vulkan_FOUND)
      )
  
      target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)

--- a/ports/ggml/portfile.cmake
+++ b/ports/ggml/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         relax-link-options.diff
         vulkan-shaders-gen.diff
         fix-dequant_funcs.diff
+        cuda-13-2.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/ggml/vcpkg.json
+++ b/ports/ggml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ggml",
   "version-date": "2025-11-17",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Tensor library for machine learning",
   "homepage": "https://github.com/ggml-org/ggml",
   "license": "MIT",

--- a/ports/ggml/vulkan-shaders-gen.diff
+++ b/ports/ggml/vulkan-shaders-gen.diff
@@ -1,8 +1,8 @@
 diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
-index b97e7bf9..0ba5fcdd 100644
+index 3f9524c..556e39e 100644
 --- a/src/ggml-vulkan/CMakeLists.txt
 +++ b/src/ggml-vulkan/CMakeLists.txt
-@@ -110,6 +110,12 @@ if (Vulkan_FOUND)
+@@ -125,6 +125,12 @@ if (Vulkan_FOUND)
          add_compile_definitions(GGML_VULKAN_RUN_TESTS)
      endif()
  
@@ -15,7 +15,7 @@ index b97e7bf9..0ba5fcdd 100644
      # Set up toolchain for host compilation whether cross-compiling or not
      if (CMAKE_CROSSCOMPILING)
          if (GGML_VULKAN_SHADERS_GEN_TOOLCHAIN)
-@@ -159,6 +165,8 @@ if (Vulkan_FOUND)
+@@ -174,6 +180,8 @@ if (Vulkan_FOUND)
      set (_ggml_vk_host_suffix $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,.exe,>)
      set (_ggml_vk_genshaders_dir "${CMAKE_BINARY_DIR}/$<CONFIG>")
      set (_ggml_vk_genshaders_cmd "${_ggml_vk_genshaders_dir}/vulkan-shaders-gen${_ggml_vk_host_suffix}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3370,7 +3370,7 @@
     },
     "ggml": {
       "baseline": "2025-11-17",
-      "port-version": 1
+      "port-version": 2
     },
     "ghc-filesystem": {
       "baseline": "1.5.14",

--- a/versions/g-/ggml.json
+++ b/versions/g-/ggml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "befbc0e2ba5c226a789bd5ed9f3f515182b53ef1",
+      "version-date": "2025-11-17",
+      "port-version": 2
+    },
+    {
       "git-tree": "56adeee23aaed103cd81d95b0f40f47ed308c761",
       "version-date": "2025-11-17",
       "port-version": 1


### PR DESCRIPTION
Related: https://github.com/microsoft/vcpkg/pull/51210

The main meaningful change is adding `/Zc:preprocessor` but I regenerated all patches and kept them if the line endings changed.