### PR TITLE
[harfbuzz] Disable gpu_demo

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -101,6 +101,7 @@ vcpkg_configure_meson(
         -Ddocs=disabled          # Generate documentation with gtk-doc
         -Dtests=disabled
         -Dbenchmark=disabled
+        -Dgpu_demo=disabled
         ${OPTIONS}
     OPTIONS_DEBUG
         ${OPTIONS_DEBUG}

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "14.2.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3722,7 +3722,7 @@
     },
     "harfbuzz": {
       "baseline": "14.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a13874241340ff2488f3ed018cdc70b0c581679",
+      "version": "14.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1a0355d3c0f6be4f7e44747052609235a7377bda",
       "version": "14.2.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Fixes #51463 

Failure mechanism:

* The gpu_demo executable is built based on detecting dependencies (OpenGL, GLEW, GLFW), hence the non-failure in previous builds.
* The gpu_demo source code uses `std::max` in a file which also contains `#include <windows.h>`
* The upstream build system does not define `NOMINMAX`
* The `min` and `max` macros defined in `<windows.h>` wreak their typical havoc.

Simplest solution is to just disable the generation of the gpu_demo tool, it's probably not so useful for the vcpkg use case. In any case, the build of this component should be explicitly controlled rather than depend on whatever's been previously installed.