### PR TITLE
[openexr] update to 3.4.11

### DIFF
--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/openexr
     REF "v${VERSION}"
-    SHA512 c2c14cdfec3c211ee33d8d4706ac2aa8f0e4ad5effe097678aeb7bb87a833dd66c41c50b59d15f26bb08e92f6f703af50cf20baf3d97110c9ac36f75f9fa7442
+    SHA512 1495ca7ae8a9cf865a1ec5e58e78e4136030938b59867e916aa26343693fddb16297faa9d29d6110ad3e97cec594e05d9dee5ffdb47586b44b3800cfc3502d14
     HEAD_REF main
 )
 

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openexr",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7317,7 +7317,7 @@
       "port-version": 0
     },
     "openexr": {
-      "baseline": "3.4.10",
+      "baseline": "3.4.11",
       "port-version": 0
     },
     "openfbx": {

--- a/versions/o-/openexr.json
+++ b/versions/o-/openexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "080bf6839b40d98d179dd53fb7d99bf9e90fad77",
+      "version": "3.4.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc1ae0f12f6c09ebf79028d7d707742dfc860ab9",
       "version": "3.4.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
