### PR TITLE
[cfitsio] update to 4.6.4

### DIFF
--- a/ports/cfitsio/portfile.cmake
+++ b/ports/cfitsio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HEASARC/cfitsio
     REF "cfitsio-${VERSION}"
-    SHA512 5db1b0c881169d2718cecff53c2de2ef2c93b933d48996025a0559ecff903f4aea0a0727aec0863b5eedafba4022325fcebd9092d50c427b3c1bab9a5c3fde6f
+    SHA512 52471b20c762b8041bd245fb938af3a31628c4a161799b2b6e17c08c32c74fb8b18de79dbd3d9938bd35c7b713665f1d8190f6f89ff1a1e4be960c23123c2b4e
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/cfitsio/vcpkg.json
+++ b/ports/cfitsio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cfitsio",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Library of C and Fortran subroutines for reading and writing data files in FITS (Flexible Image Transport System) data format",
   "homepage": "https://heasarc.gsfc.nasa.gov/fitsio/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1665,7 +1665,7 @@
       "port-version": 6
     },
     "cfitsio": {
-      "baseline": "4.6.3",
+      "baseline": "4.6.4",
       "port-version": 0
     },
     "cgal": {

--- a/versions/c-/cfitsio.json
+++ b/versions/c-/cfitsio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3251d06b987734d21f847d1b026b10f2042ac83f",
+      "version": "4.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "80cb506fd853d5dbe20d5ecf1d7bf25262d4f4c0",
       "version": "4.6.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
