### PR TITLE
[libxkbcommon] update to 1.13.1.

### DIFF
--- a/ports/libxkbcommon/build.patch
+++ b/ports/libxkbcommon/build.patch
@@ -1,9 +1,24 @@
+diff --git a/src/x11/keymap.c b/src/x11/keymap.c
+index 541ed217..c090ce2b 100644
+--- a/src/x11/keymap.c
++++ b/src/x11/keymap.c
+@@ -8,8 +8,10 @@
+ #include <assert.h>
+ 
+ #include "xkbcommon/xkbcommon.h"
++#ifndef _WIN32
+ #include "atom.h"
+ #include "keymap.h"
++#endif
+ #include "x11-priv.h"
+ 
+ /*
 diff --git a/tools/how-to-type.c b/tools/how-to-type.c
-index 72aea1b..783373a 100644
+index de170ace..9e5194ba 100644
 --- a/tools/how-to-type.c
 +++ b/tools/how-to-type.c
-@@ -26,7 +26,9 @@
- #include <getopt.h>
+@@ -9,7 +9,9 @@
+ #include <locale.h>
  #include <stdbool.h>
  #include <stdlib.h>
 +#ifdef HAVE_UNISTD_H
@@ -12,15 +27,3 @@ index 72aea1b..783373a 100644
  #include <errno.h>
  
  #include "xkbcommon/xkbcommon.h"
-diff --git a/tools/tools-common.c b/tools/tools-common.c
-index 8eb3f4b..8b22307 100644
---- a/tools/tools-common.c
-+++ b/tools/tools-common.c
-@@ -42,6 +42,7 @@
- #ifdef _WIN32
- #include <io.h>
- #include <windows.h>
-+#include <process.h>
- #else
- #include <unistd.h>
- #include <termios.h>

--- a/ports/libxkbcommon/disable-test.patch
+++ b/ports/libxkbcommon/disable-test.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 2de4ee9..bb53561 100644
+index 92483c54..26230102 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -601,6 +601,7 @@ configure_file(input: 'test/xkeyboard-config-test.py.in',
+@@ -853,6 +853,7 @@ configure_file(input: 'test/xkeyboard-config-test.py.in',
                 configuration: xkct_config)
  
  # Tests
@@ -10,7 +10,7 @@ index 2de4ee9..bb53561 100644
  test_env = environment()
  test_env.set('XKB_LOG_LEVEL', 'debug')
  test_env.set('XKB_LOG_VERBOSITY', '10')
-@@ -873,6 +874,7 @@ if get_option('enable-x11')
+@@ -1372,6 +1373,7 @@ if get_option('enable-x11')
        env: bench_env,
    )
  endif
@@ -18,3 +18,13 @@ index 2de4ee9..bb53561 100644
  
  
  # Documentation.
+@@ -1505,7 +1507,9 @@ if meson.version().version_compare('>=0.62.0')
+       'rules': get_option('default-rules'),
+       'variant': get_option('default-variant'),
+     }, section: 'Defaults')
++if false
+     summary({
+       'merge-modes': has_merge_modes_tests,
+     }, section: 'Tests')
+ endif
++endif

--- a/ports/libxkbcommon/portfile.cmake
+++ b/ports/libxkbcommon/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xkbcommon/libxkbcommon
     REF "xkbcommon-${VERSION}"
-    SHA512  454fbb2861405ca957d64035e924c1bbb7d43db7867903963fc053b7ecb64a8fba89a21cc8ac18ebeec9b61ae0789fb88c52521a850dc371857f28b08e80167b
+    SHA512 450c33fe26af6b847cf7516685d0df63c2ba0126887e27595c40fe80e4d0487009aa6cdf38ff1270d595c7900cbf3c11e7aa4f9cff80fa361742b5ebb10d83bd
     HEAD_REF master
     PATCHES
         disable-test.patch
@@ -30,7 +30,11 @@ vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 
 set(OPTIONS "")
 if(VCPKG_TARGET_IS_WINDOWS)
-    set(OPTIONS -Denable-xkbregistry=false)
+    list(APPEND OPTIONS -Denable-xkbregistry=false)
+endif()
+if(VCPKG_TARGET_IS_LINUX)
+    list(APPEND OPTIONS -Dxkb-config-root=/usr/share/X11/xkb)
+    list(APPEND OPTIONS -Dx-locale-root=/usr/share/X11/locale)
 endif()
 
 vcpkg_configure_meson(

--- a/ports/libxkbcommon/vcpkg.json
+++ b/ports/libxkbcommon/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxkbcommon",
-  "version": "1.7.0",
+  "version": "1.13.1",
   "description": "keymap handling library for toolkits and window systems",
   "homepage": "https://xkbcommon.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5909,7 +5909,7 @@
       "port-version": 1
     },
     "libxkbcommon": {
-      "baseline": "1.7.0",
+      "baseline": "1.13.1",
       "port-version": 0
     },
     "libxkbfile": {

--- a/versions/l-/libxkbcommon.json
+++ b/versions/l-/libxkbcommon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7937d36f72b0182c49099433076be11d6e9962fd",
+      "version": "1.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee2872eae95b010c793020412c24e55036421d7b",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
Additionally I have fixed an issue with the wrong config paths. I do understand these paths might be wrong on some devices, but the initial discover of them are made during the build stage (not during runtime that would be more logically correct), and thus it makes it anyway unreliable is the library is used on the device that has different configuration than the build device. However, at least this works, and since this package is not built by default, I doubt there will be issues with the hardcoded paths (also, there are some other ports that hardcode paths, so in this particular case this should be ok as well).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
