### PR TITLE
[frugally-deep] update to 0.19.5

### DIFF
--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/frugally-deep
     REF "v${VERSION}"
-    SHA512 6914eca5b4405b97f67f167e0b3cfc09739e80acc19df4f423d7f505ec420d9ce4cb5253531fc7a1c06869f48b3ede7a9b8b25d6d2dbf95c53f2ec48b182d0e5
+    SHA512 bfc632d35c30c209aed87bbd810c2c919609cef07af03fda50c17e8eb5eb735cbda9d49ec1e0685c3f8d322b870471bf02861d53300a22e177ca38639f4cee48
     HEAD_REF master
 )
 

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "frugally-deep",
-  "version-semver": "0.19.2",
+  "version-semver": "0.19.5",
   "description": "Header-only library for using Keras models in C++.",
   "homepage": "https://github.com/Dobiasd/frugally-deep",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3205,7 +3205,7 @@
       "port-version": 0
     },
     "frugally-deep": {
-      "baseline": "0.19.2",
+      "baseline": "0.19.5",
       "port-version": 0
     },
     "fruit": {

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "360b33092299fc382924f767c8dcf4d7bb1975be",
+      "version-semver": "0.19.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "ba9abb43304299066c8039715b96b1bebc5bdd8b",
       "version-semver": "0.19.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Dobiasd/frugally-deep/releases/tag/v0.19.5
