### PR TITLE
[libdicom] update to 1.2.1

### DIFF
--- a/ports/libdicom/cross-build.diff
+++ b/ports/libdicom/cross-build.diff
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 07fd96f..6cfb436 100644
+index 33ec4f1..fe5516f 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -148,6 +148,9 @@ install_headers(
+@@ -144,6 +144,9 @@ install_headers(
  # src
  library_includes = include_directories('include')
  library_options = ['-DBUILDING_LIBDICOM']
@@ -11,12 +11,12 @@ index 07fd96f..6cfb436 100644
 +else
  dict_build = executable(
    'dicom-dict-build',
-   ['src/dicom-dict-build.c', 'src/dicom-dict-tables.c'],
-@@ -160,6 +163,7 @@ dict_lookup = custom_target(
+   files('src/dicom-dict-build.c', 'src/dicom-dict-tables.c'),
+@@ -156,6 +159,7 @@ dict_lookup = custom_target(
    command : [dict_build, '@OUTPUT@'],
    output : ['dicom-dict-lookup.c', 'dicom-dict-lookup.h'],
  )
 +endif
- library_sources = [
-   dict_lookup,
-   'src/getopt.c',
+ library_sources = [dict_lookup] + files(
+   'src/dicom-data.c',
+   'src/dicom-dict-tables.c',

--- a/ports/libdicom/portfile.cmake
+++ b/ports/libdicom/portfile.cmake
@@ -2,13 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ImagingDataCommons/libdicom
     REF "v${VERSION}"
-    SHA512 dd3145721436eaab80e14750210c1b7528a0d23b77aa2e94acfd1bb24d22e3e3a616133f48244aa1927bf835a5d541c3ca3136518b740cd58114cd753f662917
+    SHA512 7323616a0beee9954f725daeef255215b337ce56d921ea836262fe3a84ee2eb0cce8d6caf6610c88daea2a9b2d0a1deefb70a750268131f82ad48e66a5a29bdd
     HEAD_REF main
     PATCHES
         cross-build.diff
 )
 if(VCPKG_CROSSCOMPILING)
-    file(COPY 
+    file(COPY
         "${CURRENT_HOST_INSTALLED_DIR}/share/${PORT}/${VERSION}/dicom-dict-lookup.c"
         "${CURRENT_HOST_INSTALLED_DIR}/share/${PORT}/${VERSION}/dicom-dict-lookup.h"
         DESTINATION "${SOURCE_PATH}"
@@ -27,7 +27,7 @@ vcpkg_fixup_pkgconfig()
 vcpkg_copy_tools(TOOL_NAMES dcm-dump dcm-getframe AUTO_CLEAN)
 
 if(NOT VCPKG_CROSSCOMPILING)
-    file(COPY 
+    file(COPY
         "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/dicom-dict-lookup.c"
         "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/dicom-dict-lookup.h"
         DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/${VERSION}"

--- a/ports/libdicom/vcpkg.json
+++ b/ports/libdicom/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libdicom",
-  "version": "1.2.0",
-  "port-version": 1,
+  "version": "1.2.1",
   "description": "libdicom is a C library and a set of command-line tools for reading DICOM WSI files",
   "homepage": "https://github.com/ImagingDataCommons/libdicom",
   "documentation": "https://libdicom.readthedocs.io/en/latest/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4837,8 +4837,8 @@
       "port-version": 0
     },
     "libdicom": {
-      "baseline": "1.2.0",
-      "port-version": 1
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/l-/libdicom.json
+++ b/versions/l-/libdicom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fe0d522e302efed181f0e490848585fdb5894e3a",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee95a2f6188e974f3ca1e8135588d00fc5340095",
       "version": "1.2.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ImagingDataCommons/libdicom/releases/tag/v1.2.1
