### PR TITLE
[xsimd] update to 14.2.0

### DIFF
--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd
     REF "${VERSION}"
-    SHA512 a7030787e49bfb8fd544c94abf5e44ebdf4d922298e7ecbe9a51c473a956f3461d877611b4b0e2f5e962815f513589a124045e3909c864d0ba0d86a96a46ad21
+    SHA512 5a93511719b5460fa27248d7bbfda61a72fd32d67c9dbffee26686d57b54042957e9ed8a7b55923677122e04f0c2f4ba5f92b54028cfb2f4328d45f2858b3bd6
     HEAD_REF master
 )
 
@@ -22,10 +22,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/xsimd/usage
+++ b/ports/xsimd/usage
@@ -1,4 +1,0 @@
-xsimd provides CMake targets:
-
-    find_package(xsimd CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE xsimd)

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xsimd",
-  "version": "14.1.0",
+  "version": "14.2.0",
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11017,7 +11017,7 @@
       "port-version": 5
     },
     "xsimd": {
-      "baseline": "14.1.0",
+      "baseline": "14.2.0",
       "port-version": 0
     },
     "xtensor": {

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e9325c27bb9effaab1c0f5be67c42762508c470",
+      "version": "14.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c85056b96c9f7608b898ca5bab2a6c45e8551f3d",
       "version": "14.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/xtensor-stack/xsimd/releases/tag/14.2.0
