### PR TITLE
[yalantinglibs] update to 0.6.1

### DIFF
--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
     REF "${VERSION}"
-    SHA512 4431c4fea7af80b81b35989879d47ad09abca31789f8e5bc77aae85824b1bd7c6d3de57c5421820670cbdd2313dbc9ea56ad8bf3f4dc8751d51d9ce7212985b0
+    SHA512 df0aafbda3abf7bd4d2432aa5edede8ce9603f21ad2c1c126759253fcf7394550e74e81b87ed7db4fbc59e6e6e5ba92f552bbce8e772482765cea0a71ecffd89
     HEAD_REF main
     PATCHES
         use-external-libs.patch

--- a/ports/yalantinglibs/use-external-libs.patch
+++ b/ports/yalantinglibs/use-external-libs.patch
@@ -1,11 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8cc8d32..1259d1f 100644
+index 448a80d..c7028a7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -6,6 +6,11 @@ project(yaLanTingLibs
-         LANGUAGES CXX
+@@ -16,6 +16,12 @@ project(yaLanTingLibs
+         HOMEPAGE_URL "https://github.com/alibaba/yalantinglibs"
+         LANGUAGES ${PROJECT_LANGUAGES}
          )
- 
++
 +find_path(IGUANA_INCLUDE_DIRS "iguana/common.hpp")
 +include_directories(${IGUANA_INCLUDE_DIRS})
 +find_path(CINATRA_INCLUDE_DIRS "cinatra.hpp")
@@ -13,7 +14,7 @@ index 8cc8d32..1259d1f 100644
 +
  # load pack finder
  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Find/)
- 
+
 diff --git a/cmake/install.cmake b/cmake/install.cmake
 index 956195f..ad9df4e 100644
 --- a/cmake/install.cmake

--- a/ports/yalantinglibs/vcpkg.json
+++ b/ports/yalantinglibs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yalantinglibs",
-  "version": "0.5.8",
+  "version": "0.6.1",
   "description": "A Collection of C++20 libraries, include struct_pack, struct_json, struct_xml, struct_yaml, struct_pb, easylog, coro_rpc, coro_http and async_simple",
   "homepage": "https://github.com/alibaba/yalantinglibs",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11053,7 +11053,7 @@
       "port-version": 5
     },
     "yalantinglibs": {
-      "baseline": "0.5.8",
+      "baseline": "0.6.1",
       "port-version": 0
     },
     "yaml-cpp": {

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98f5fb6aba261da7233ea4dcd6f88f75887389b2",
+      "version": "0.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b02e50c8a62a395cc44d9988f988761035a6996",
       "version": "0.5.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/alibaba/yalantinglibs/releases/tag/0.6.1
