### PR TITLE
[steamhelper] Add new port

### DIFF
--- a/ports/steamhelper/portfile.cmake
+++ b/ports/steamhelper/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tomh500/SteamHelper
+    REF 1.0.1
+    SHA512  e689df4340cd5d80f277109eabb33a6ecc5541be7525361ba7ed93f37b14f76cd8c4faee790937d8403eb4af81f50182aad3aa5643b4f5c1e6adec836c886000
+    HEAD_REF main
+)
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA # 提高编译速度
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(GLOB_RECURSE LICENSE_FILE "${SOURCE_PATH}/LICENSE*")
+
+if(LICENSE_FILE)
+    file(INSTALL "${LICENSE_FILE}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+else()
+    message(FATAL_ERROR "Could not find LICENSE file in ${SOURCE_PATH}")
+endif()

--- a/ports/steamhelper/vcpkg.json
+++ b/ports/steamhelper/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "steamhelper",
+  "version": "1.0.0",
+  "description": "A C++ library for Steam path discovery and ID conversion (32-bit to 64-bit).",
+  "homepage": "https://github.com/tomh500/SteamHelper",
+  "license": "MIT",
+  "supports": "windows"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9628,6 +9628,10 @@
       "baseline": "4.8.1",
       "port-version": 0
     },
+    "steamhelper": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "stella-cv-fbow": {
       "baseline": "0.0.1",
       "port-version": 1

--- a/versions/s-/steamhelper.json
+++ b/versions/s-/steamhelper.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9150938a0078eebf95c9501af658f5fc415cbcc7",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add new port: steamhelper

This PR adds the `steamhelper` port, a C++ utility library for Steam-related auxiliary functions.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. 
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.