### PR TITLE
[libfyaml] new port, [appstream] update to 1.1.2

### DIFF
--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ximion/appstream
     REF "v${VERSION}"
-    SHA512 80f3b7b9279152ce271bab61e97a41268d5dc5d977dc9488fc187df90077ac1a81169201d3d1a7a5578d36e962321035bfe34106486c2ac3d684621b40338de6
+    SHA512 2e673af579107603458cf09086ffc8cb488aa4ab24d248c7774b8b6d8e690aac49b2c5ddda56533b179e017f54fa4598ebae5bb7cb3073b3f03149700a7db9ac
     HEAD_REF main
     PATCHES
       remove-uneeded-directories.patch
@@ -17,6 +17,7 @@ vcpkg_configure_meson(
       -Dstemming=false
       -Dsvg-support=false
       -Dgir=false
+      -Dbash-completion=false
     ADDITIONAL_BINARIES
        gperf='${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}'
        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "appstream",
-  "version": "1.0.6",
-  "port-version": 1,
+  "version": "1.1.2",
   "description": "Tools and libraries to work with AppStream metadata",
   "homepage": "https://www.freedesktop.org/software/appstream/docs",
   "license": "LGPL-2.1-or-later",
+  "supports": "!windows | mingw",
   "dependencies": [
     {
       "name": "curl",
@@ -26,12 +26,12 @@
       "name": "gperf",
       "host": true
     },
+    "libfyaml",
     {
       "name": "libxml2",
       "default-features": false
     },
     "libxmlb",
-    "libyaml",
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/ports/libfyaml/math.diff
+++ b/ports/libfyaml/math.diff
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ef0c3ae..624930c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1189,10 +1189,9 @@ endif()
+ 
+ # Link libm where it exists as a separate library (Linux, FreeBSD, etc.).
+ # macOS includes math in libSystem; Windows has no libm.
+-find_library(LIBM m)
+-if(LIBM)
+-    target_link_libraries(fyaml PUBLIC ${LIBM})
+-    target_link_libraries(fyaml_static PUBLIC ${LIBM})
++if(UNIX AND NOT ANDROID AND NOT APPLE)
++    target_link_libraries(fyaml PUBLIC m)
++    target_link_libraries(fyaml_static PUBLIC m)
+ endif()
+ 
+ # Add libclang support if available

--- a/ports/libfyaml/portfile.cmake
+++ b/ports/libfyaml/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_download_distfile(32BIT_PATCH
+    URLS "https://github.com/pantoniou/libfyaml/commit/0982fcefc6a16d4c8cb5b06747d3fc8e630de3ae.patch?full_index=1"
+    FILENAME "fy_skip_size32.patch"
+    SHA512 78071e1e555c531874fec6bd096b9bf8427e6b73436f679a7ef100970ccfdb0fbb0b683242a370b058d1a87f73a008861668b2d81b14a1f9fc77a19b3dbd49ec
+)
+
+vcpkg_download_distfile(ARMNEON_PATCH
+    URLS "https://github.com/pantoniou/libfyaml/commit/9192deaac095f9881cc1e5756dede683f36b09d6.patch?full_index=1"
+    FILENAME "fy_decode_size32.patch"
+    SHA512 f47df2c2300c4e634a0b3a9a95f3e70a3c9c6a71d65d0f0096a47debcaede105634c8bf155632c706cab415d6928fc214883ac14574d6e50967429aeba68a2cf
+)
+
+vcpkg_download_distfile(ARM_PATCH
+    URLS "https://github.com/pantoniou/libfyaml/commit/cd3fd6f666e840051146661969d845f10e31a67c.patch?full_index=1"
+    FILENAME "fy_yield.patch"
+    SHA512 4721636f9a3f78874893afded87309b09a92c7ab01a72ea226632b0330bcfca9f36a3aebff713a740ebe0f3741f49e7e696850e9a9cae3f3a6e78f5c081d9700
+)
+
+vcpkg_download_distfile(ANDROID_PATCH
+    URLS "https://github.com/pantoniou/libfyaml/commit/9eca732bee6f18403e96141fa88ffc57d9f7011a.patch?full_index=1"
+    FILENAME "fy_pthread.patch"
+    SHA512 c2068c3b8ac6101b9821539d5304d412a0a849a9415da8916c5d644d674aafb3c99412309054f1ae327f368bbc9beff4298196c45f447d57b084fdcaff79bf27
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pantoniou/libfyaml
+    REF v${VERSION}
+    SHA512 e38f42b5d3e5e88300fd1c7b59868592afa5f2f88d30f61e778700c35435ebd14ecef7d82ac0213345dabdb3c562dc234ed1b2bfd84e40b47fdc4f84144c79f5
+    PATCHES
+        "${32BIT_PATCH}"
+        "${ARMNEON_PATCH}"
+        "${ARM_PATCH}"
+        "${ANDROID_PATCH}"
+        "math.diff"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(TOOL_NAMES fy-tool AUTO_CLEAN)
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libfyaml/vcpkg.json
+++ b/ports/libfyaml/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libfyaml",
+  "version": "0.9.6",
+  "description": "High-performance YAML parser and emitter library",
+  "homepage": "https://github.com/pantoniou/libfyaml",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af3b94e3fe4100860c7dbccc6758654bc4ee0f5b",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec534369136985b55e67821d956d3c8934ca9035",
       "version": "1.0.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -189,8 +189,8 @@
       "port-version": 0
     },
     "appstream": {
-      "baseline": "1.0.6",
-      "port-version": 1
+      "baseline": "1.1.2",
+      "port-version": 0
     },
     "appstream-glib": {
       "baseline": "0.8.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4996,6 +4996,10 @@
       "baseline": "3.17.3",
       "port-version": 0
     },
+    "libfyaml": {
+      "baseline": "0.9.6",
+      "port-version": 0
+    },
     "libgcrypt": {
       "baseline": "1.12.1",
       "port-version": 0

--- a/versions/l-/libfyaml.json
+++ b/versions/l-/libfyaml.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a24ae7c6f128c669896580ae4bf798e8599d45ef",
+      "version": "0.9.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Supersedes #49474

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
 