### PR TITLE
[dpdk] Disable optional dependencies.

### DIFF
--- a/ports/dpdk/0001-enable-either-static-or-shared-build.patch
+++ b/ports/dpdk/0001-enable-either-static-or-shared-build.patch
@@ -1,5 +1,5 @@
 diff --git a/config/meson.build b/config/meson.build
-index b6b3558e11..34b85f10b5 100644
+index 9ba7b9a..bbdad71 100644
 --- a/config/meson.build
 +++ b/config/meson.build
 @@ -95,7 +95,9 @@ eal_pmd_path = join_paths(get_option('prefix'), driver_install_path)
@@ -14,7 +14,7 @@ index b6b3558e11..34b85f10b5 100644
      if pmd_subdir_opt != '' and pmd_subdir_opt != '.'
          meson.add_install_script('../buildtools/symlink-drivers-solibs.sh',
 diff --git a/drivers/meson.build b/drivers/meson.build
-index 495e21b54a..ff7b5983cb 100644
+index 6ae102e..9a593b7 100644
 --- a/drivers/meson.build
 +++ b/drivers/meson.build
 @@ -322,7 +322,7 @@ foreach subpath:subdirs
@@ -51,10 +51,10 @@ index 495e21b54a..ff7b5983cb 100644
  
          set_variable('shared_@0@'.format(lib_name), shared_dep)
 diff --git a/lib/meson.build b/lib/meson.build
-index ce92cb5537..40880bbf02 100644
+index 8f5cfd2..907a46a 100644
 --- a/lib/meson.build
 +++ b/lib/meson.build
-@@ -274,7 +274,7 @@ foreach l:libraries
+@@ -270,7 +270,7 @@ foreach l:libraries
              c_args: cflags,
              dependencies: static_deps,
              include_directories: includes,
@@ -63,7 +63,7 @@ index ce92cb5537..40880bbf02 100644
      static_dep = declare_dependency(
              include_directories: includes,
              dependencies: static_deps)
-@@ -324,6 +324,7 @@ foreach l:libraries
+@@ -320,6 +320,7 @@ foreach l:libraries
          cflags += '-DRTE_BUILD_SHARED_LIB'
      endif
  
@@ -71,7 +71,7 @@ index ce92cb5537..40880bbf02 100644
      shared_lib = shared_library(libname,
              sources,
              objects: objs,
-@@ -341,6 +342,9 @@ foreach l:libraries
+@@ -336,6 +337,9 @@ foreach l:libraries
              dependencies: shared_deps)
  
      dpdk_libraries = [shared_lib] + dpdk_libraries

--- a/ports/dpdk/0002-fix-dependencies.patch
+++ b/ports/dpdk/0002-fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/config/meson.build b/config/meson.build
-index 34b85f10b5..5ed4625d9e 100644
+index bbdad71..a9c63b5 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -238,12 +238,10 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
+@@ -238,17 +238,15 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
      find_libnuma = false
  endif
  if find_libnuma
@@ -17,11 +17,51 @@ index 34b85f10b5..5ed4625d9e 100644
      endif
  endif
  
+ has_libfdt = false
+-fdt_dep = cc.find_library('fdt', required: false)
++fdt_dep = disabler()
+ if fdt_dep.found() and cc.has_header('fdt.h') and cc.links(min_c_code, dependencies: fdt_dep)
+     dpdk_conf.set10('RTE_HAS_LIBFDT', true)
+     has_libfdt = true
+@@ -269,28 +267,28 @@ if libarchive.found()
+ endif
+ 
+ # check for libbsd
+-libbsd = dependency('libbsd', required: false, method: 'pkg-config')
++libbsd = disabler()
+ if libbsd.found()
+     dpdk_conf.set('RTE_USE_LIBBSD', 1)
+ endif
+ 
+-jansson_dep = dependency('jansson', required: false, method: 'pkg-config')
++jansson_dep = disabler()
+ if jansson_dep.found()
+     dpdk_conf.set('RTE_HAS_JANSSON', 1)
+ endif
+ 
+ # check for OpenSSL
+-openssl_dep = dependency('openssl', required: false, method: 'pkg-config')
++openssl_dep = disabler()
+ if openssl_dep.found()
+     dpdk_conf.set('RTE_HAS_OPENSSL', 1)
+ endif
+ 
+ # check for pcap
+-pcap_dep = dependency('libpcap', required: false, method: 'pkg-config')
++pcap_dep = disabler()
+ pcap_lib = is_windows ? 'wpcap' : 'pcap'
+ if not pcap_dep.found()
+     # pcap got a pkg-config file only in 1.9.0
+-    pcap_dep = cc.find_library(pcap_lib, required: false)
++    pcap_dep = disabler()
+ endif
+ if (pcap_dep.found() and cc.has_header('pcap.h', dependencies: pcap_dep)
+         and cc.links(min_c_code, dependencies: pcap_dep))
 diff --git a/lib/eal/linux/meson.build b/lib/eal/linux/meson.build
-index e99ebed256..672c70547b 100644
+index 29ba313..5a173c4 100644
 --- a/lib/eal/linux/meson.build
 +++ b/lib/eal/linux/meson.build
-@@ -21,5 +21,6 @@ sources += files(
+@@ -25,5 +25,6 @@ endif
  
  deps += ['kvargs', 'telemetry']
  if has_libnuma
@@ -29,7 +69,7 @@ index e99ebed256..672c70547b 100644
      dpdk_conf.set10('RTE_EAL_NUMA_AWARE_HUGEPAGES', true)
  endif
 diff --git a/lib/vhost/meson.build b/lib/vhost/meson.build
-index 51bcf17244..1099a0232f 100644
+index 6a24981..5283e79 100644
 --- a/lib/vhost/meson.build
 +++ b/lib/vhost/meson.build
 @@ -6,6 +6,7 @@ if not is_linux

--- a/ports/dpdk/0002-fix-dependencies.patch
+++ b/ports/dpdk/0002-fix-dependencies.patch
@@ -1,3 +1,17 @@
+diff --git a/buildtools/pkg-config/meson.build b/buildtools/pkg-config/meson.build
+index b36add1..a0a265a 100644
+--- a/buildtools/pkg-config/meson.build
++++ b/buildtools/pkg-config/meson.build
+@@ -47,8 +47,7 @@ pkg.generate(name: 'DPDK', # main DPDK pkgconfig file
+         description: '''The Data Plane Development Kit (DPDK).
+ Note that CFLAGS might contain an -march flag higher than typical baseline.
+ This is required for a number of static inline functions in the public headers.''',
+-        requires: ['libdpdk-libs', libbsd], # may need libbsd for string funcs
+-                      # if libbsd is not enabled, then this is blank
++        requires: ['libdpdk-libs'],
+         libraries_private: ['-Wl,--whole-archive'] +
+             dpdk_drivers + dpdk_static_libraries +
+             ['-Wl,--no-whole-archive'] + platform_flags
 diff --git a/config/meson.build b/config/meson.build
 index bbdad71..a9c63b5 100644
 --- a/config/meson.build

--- a/ports/dpdk/0003-remove-examples-src-from-datadir.patch
+++ b/ports/dpdk/0003-remove-examples-src-from-datadir.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 8436d1dff8..5e704e37d5 100644
+index b01010f..ea800ee 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -89,13 +89,6 @@ subdir('app')
+@@ -99,13 +99,6 @@ subdir('app')
  # build docs
  subdir('doc')
  

--- a/ports/dpdk/0004-stop-building-apps.patch
+++ b/ports/dpdk/0004-stop-building-apps.patch
@@ -1,8 +1,8 @@
 diff --git a/app/meson.build b/app/meson.build
-index e2db888ae1..5e28824780 100644
+index 1798db3..4efbafc 100644
 --- a/app/meson.build
 +++ b/app/meson.build
-@@ -52,7 +52,7 @@ endif
+@@ -48,7 +48,7 @@ endif
  
  foreach app:apps
      name = app

--- a/ports/dpdk/0005-no-absolute-driver-path.patch
+++ b/ports/dpdk/0005-no-absolute-driver-path.patch
@@ -1,8 +1,8 @@
 diff --git a/config/meson.build b/config/meson.build
-index 5ed4625d9e..3f89fd0768 100644
+index a9c63b5..eacbbac 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -461,7 +461,7 @@ Please install libnuma, or set 'max_numa_nodes' option to '1' to build without N
+@@ -473,7 +473,7 @@ Please install libnuma, or set 'max_numa_nodes' option to '1' to build without N
  endif
  
  # set the install path for the drivers

--- a/ports/dpdk/0006-rename-sched.h.patch
+++ b/ports/dpdk/0006-rename-sched.h.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/eal/common/eal_common_thread.c b/lib/eal/common/eal_common_thread.c
-index a53bc63..087ec80 100644
+index dcd81f9..4daa244 100644
 --- a/lib/eal/common/eal_common_thread.c
 +++ b/lib/eal/common/eal_common_thread.c
 @@ -6,7 +6,11 @@
@@ -39,10 +39,10 @@ index e1c3101..f28b37d 100644
  /**
   * This file is required to support the common code in eal_common_proc.c,
 diff --git a/lib/eal/windows/include/rte_os.h b/lib/eal/windows/include/rte_os.h
-index 9d69467..4df82dd 100644
+index 2a43cb1..440fa30 100644
 --- a/lib/eal/windows/include/rte_os.h
 +++ b/lib/eal/windows/include/rte_os.h
-@@ -14,7 +14,7 @@
+@@ -15,7 +15,7 @@
  #include <string.h>
  #include <malloc.h>
  

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -31,7 +31,8 @@ if(VCPKG_TARGET_IS_LINUX AND VCPKG_HOST_IS_LINUX)
 endif()
 
 # Add a leading zero to the minor version if it consists of only one digit, otherwise the regex does nothing
-string(REGEX REPLACE "^([0-9]+)\\.([0-9])(\\..*)$" "\\1.0\\2\\3" VERSION_REF "${VERSION}")
+# Match both `X.Y` and `X.Y.Z...` forms (optional remainder).
+string(REGEX REPLACE "^([0-9]+)\\.([0-9])(\\..*)?$" "\\1.0\\2\\3" VERSION_REF "${VERSION}")
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO DPDK/dpdk

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dpdk",
   "version": "26.3",
+  "port-version": 1,
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2594,7 +2594,7 @@
     },
     "dpdk": {
       "baseline": "26.3",
-      "port-version": 0
+      "port-version": 1
     },
     "dpp": {
       "baseline": "10.1.4",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e76da4e89a5563a0ae4773d265cdfcb8fa53b25f",
+      "version": "26.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "2f0e7f0a8441cfd2b7c64c76f70d599d657df8c1",
       "version": "26.3",
       "port-version": 0

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e76da4e89a5563a0ae4773d265cdfcb8fa53b25f",
+      "git-tree": "bc5eb55c71122f48fd77ac874d09e0cc6b96bda7",
       "version": "26.3",
       "port-version": 1
     },


### PR DESCRIPTION
This fixes the CI failures https://dev.azure.com/vcpkg/public/_build/results?buildId=130806&view=results caused by optionally grabbing jansson which exposes unsupported C99 VLAs to MSVC.

Also regenerated all patches where the line numbers changed.
