### PR TITLE
[sdl3] Update to version 3.4.8

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
     REF "release-${VERSION}"
-    SHA512 0ef3b561bef20b6b442fd0d7ed6c295f47f76787dfe3cfb6eb978ecb85ea285bcbbd8cbd70a85d52431be0d03e8e8632d8ee2413395e1bd944dd6feeb0c3c6d3
+    SHA512 df5a323af7ac366661a3c0e887969c72584d232f3cc211419d59b0487b620b6b2859d4549c9e8df002ee489290062e466fcfddf7edc0872a37b1f2845e81c0f3
     HEAD_REF main
     PATCHES
         fix-freebsd.patch

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3",
-  "version": "3.4.6",
+  "version": "3.4.8",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9053,7 +9053,7 @@
       "port-version": 0
     },
     "sdl3": {
-      "baseline": "3.4.6",
+      "baseline": "3.4.8",
       "port-version": 0
     },
     "sdl3-image": {

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3a9eeaee64a945a280bd3eeda988129400a8e63",
+      "version": "3.4.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec7dde0624c261f49e0ce7ac8732bb87f39c49ce",
       "version": "3.4.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.