### PR TITLE
[kuku] Update to v3.0.0

### DIFF
--- a/ports/apsi/fix-find-kuku.patch
+++ b/ports/apsi/fix-find-kuku.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 55e2d77..8fd7e41 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -133,7 +133,7 @@ if(NOT APSI_USE_CXX17 AND SEAL_USE_CXX17)
+ endif()
+ 
+ # Microsoft Kuku
+-find_package(Kuku 2.1 QUIET REQUIRED)
++find_package(Kuku QUIET REQUIRED)
+ if(NOT Kuku_FOUND)
+     message(FATAL_ERROR "Microsoft Kuku: not found")
+ else()

--- a/ports/apsi/portfile.cmake
+++ b/ports/apsi/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         fix-find-seal.patch
         fix-c2398.patch
+        fix-find-kuku.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/apsi/vcpkg.json
+++ b/ports/apsi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "apsi",
   "version-semver": "0.11.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "APSI is a research library for asymmetric private set intersection.",
   "homepage": "https://github.com/microsoft/APSI",
   "license": "MIT",

--- a/ports/kuku/portfile.cmake
+++ b/ports/kuku/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/Kuku
     REF "v${VERSION}"
-    SHA512 4b0f0cae191c70d20337fb1581fa06a8fe363a942cf3a3b6be59fbef551b70446405fb1e4e5e7ec917d5519e8d2ad0ea59bd59c36dbf917e838fc1a1cd6a3bef
+    SHA512 c5c79d0ca94e4a02786934ac419311ce2a46090b8846b885ec11f24205977a02270a14bbd7178b82eb9284e3345c89a421b710171bac5946491a61c9661775b8
     HEAD_REF main
 )
 
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Kuku-2.1)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Kuku)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/kuku/vcpkg.json
+++ b/ports/kuku/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kuku",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Kuku is a compact and convenient cuckoo hashing library written in C++.",
   "homepage": "https://github.com/microsoft/Kuku",
   "license": "MIT",

--- a/versions/a-/apsi.json
+++ b/versions/a-/apsi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b55029ec6a1e04c5f69c534871c998f2c63d066",
+      "version-semver": "0.11.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "154dfb78740cc2acc90c4190af5f5598062c94c1",
       "version-semver": "0.11.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -210,7 +210,7 @@
     },
     "apsi": {
       "baseline": "0.11.0",
-      "port-version": 1
+      "port-version": 2
     },
     "aravis": {
       "baseline": "0.8.36",
@@ -4545,7 +4545,7 @@
       "port-version": 1
     },
     "kuku": {
-      "baseline": "2.1.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "kvasir-mpl": {

--- a/versions/k-/kuku.json
+++ b/versions/k-/kuku.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3e5a5a120cae618458803ff7c6b4590bd2ea8ed",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "55d5b6509ad53b413c0f4bd71a15f71ab79d8c8b",
       "version": "2.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


This is a major (3.0.0) API-breaking update to the Kuku library. To prevent the downstream`apsi` port from failing, I'm also providing a patch for that. I also tested that the `apsi` unit tests pass with this.