### PR TITLE
[vcpkg-ci-ffmpeg] Fix x64-android

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1479,3 +1479,4 @@ vcpkg-ci-wxwidgets:x86-windows=pass
 zookeeper:arm-neon-android=pass
 zookeeper:arm64-android=pass
 zookeeper:x64-android=pass
+

--- a/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
@@ -179,7 +179,7 @@
           "features": [
             "qsv"
           ],
-          "platform": "!arm & (android | linux | windows) & !uwp"
+          "platform": "(x64 | x86) & (windows | linux) & !uwp"
         },
         {
           "name": "ffmpeg",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
