### PR TITLE
[vcpkg-ci-ffmpeg] Fix x64-android

### DIFF
--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "8.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
@@ -179,7 +179,7 @@
           "features": [
             "qsv"
           ],
-          "platform": "!arm & (android | linux | windows) & !uwp"
+          "platform": "(x64 | x86) & (windows | linux) & !uwp"
         },
         {
           "name": "ffmpeg",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2998,7 +2998,7 @@
     },
     "ffmpeg": {
       "baseline": "8.1",
-      "port-version": 4
+      "port-version": 5
     },
     "ffmpeg-bin2c": {
       "baseline": "8.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97bc7b3347b2f6f719bae248fd1a06d32d941d8a",
+      "version": "8.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "3c613502bfbafe7fc10b7504e5bea2e8fb37775e",
       "version": "8.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
