### PR TITLE
[podofo] update to 1.1.0

### DIFF
--- a/ports/podofo/dependencies.diff
+++ b/ports/podofo/dependencies.diff
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0441083c..ff19fe8e 100644
+index 54a90f1..e40c529 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -246,6 +246,7 @@ if(JPEG_FOUND)
+@@ -301,6 +301,7 @@ if(JPEG_FOUND)
      string(APPEND PODOFO_PKGCONFIG_REQUIRES_PRIVATE " libjpeg")
  endif()
  list(APPEND PODOFO_LIB_DEPENDS ZLIB::ZLIB)
 +string(APPEND PODOFO_PKGCONFIG_REQUIRES_PRIVATE " libutf8proc")
  string(APPEND PODOFO_PKGCONFIG_REQUIRES_PRIVATE " zlib")
- list(APPEND PODOFO_LIB_DEPENDS ${PLATFORM_SYSTEM_LIBRARIES})
- 
-@@ -276,6 +277,25 @@ add_subdirectory(3rdparty)
+ if (PODOFO_DEVENDOR_TCBSPAN)
+     list(APPEND PODOFO_LIB_DEPENDS $<COMPILE_ONLY:tcbspan::tcbspan>)
+@@ -354,6 +355,25 @@ add_subdirectory(3rdparty)
  add_subdirectory(src/podofo)
  include_directories(${PODOFO_INCLUDE_DIRS})
  
@@ -37,7 +37,7 @@ index 0441083c..ff19fe8e 100644
      enable_testing()
      add_subdirectory(test)
 diff --git a/src/podofo/podofo-config.cmake.in b/src/podofo/podofo-config.cmake.in
-index 700619bb..3ab4afce 100644
+index 700619b..b2d75f6 100644
 --- a/src/podofo/podofo-config.cmake.in
 +++ b/src/podofo/podofo-config.cmake.in
 @@ -2,6 +2,7 @@
@@ -48,29 +48,3 @@ index 700619bb..3ab4afce 100644
      if("@Fontconfig_FOUND@")
          find_dependency(Fontconfig)
      endif()
-diff --git a/src/podofo/private/SASLprep.cpp b/src/podofo/private/SASLprep.cpp
-index a9c8a672..6899b9f0 100644
---- a/src/podofo/private/SASLprep.cpp
-+++ b/src/podofo/private/SASLprep.cpp
-@@ -8,7 +8,7 @@
- #include <cassert>
- #include <vector>
- 
--#include <utf8proc/utf8proc.h>
-+#include <utf8proc.h>
- #include <utf8cpp/utf8.h>
- 
- #include "SASLprepPrivate.h"
-diff --git a/src/podofo/private/charconv_compat.h b/src/podofo/private/charconv_compat.h
-index 1f72d9d9..b20c860b 100644
---- a/src/podofo/private/charconv_compat.h
-+++ b/src/podofo/private/charconv_compat.h
-@@ -15,7 +15,7 @@
- #endif
- 
- #if defined(WANT_CHARS_FORMAT) || defined(WANT_FROM_CHARS)
--#include <fast_float.h>
-+#include <fast_float/fast_float.h>
- #endif
- 
- #ifdef WANT_TO_CHARS

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO podofo/podofo
     REF "${VERSION}"
-    SHA512 ddc33e1265eac4650c1cd4f8c04dabae206bd8ca3eadefa310cd87066ce5e262ee1a5dbf395797e01cb4de05e390db2f1d54dffa26e8659b084a57fac97de03b
+    SHA512 cb5608f7496974c0d546c73000d2551913e18a13319b991a7532a46dd04ee7305e0df4a1233156d0171cd965d0af1cf99a27b2400fcc6117a5d1f04c0ad8b364
     PATCHES
         dependencies.diff
 )
@@ -41,4 +41,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LGPL" "${SOURCE_PATH}/COPYING.MPL")

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "podofo",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://github.com/podofo/podofo",
-  "license": "LGPL-2.0-or-later",
+  "license": "LGPL-2.0-or-later OR MPL-2.0",
   "supports": "!uwp & !xbox",
   "dependencies": [
     "date",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7821,7 +7821,7 @@
       "port-version": 2
     },
     "podofo": {
-      "baseline": "1.0.3",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "poissonrecon": {

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9647a08fffc0ba477c87819ab0a1a4e4e1abd452",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "40f8266395d0d068efb32dce0053782660ff58dc",
       "version": "1.0.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/podofo/podofo/releases/tag/1.1.0
