### PR TITLE
[sdl3-image] update to 3.4.4

### DIFF
--- a/ports/sdl3-image/portfile.cmake
+++ b/ports/sdl3-image/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_image
     REF "release-${VERSION}"
-    SHA512 bd2b1c8abdf5b207901fa76f6636830f813b67f3e6854e623af6c7fbd27cf34e0d9f3d62f5eaf8b269fb0e1fbb309adad0e1ce9b55da01db5fbe0f21fb7f93b4
+    SHA512 a20269e064e68dd892084d8d6d6f3d5d44a6a75994808a1579ed7deeedc22c4230ec982d1166a0b85aca0b9a3625ac84e6fe9093dccebb78bf0b7cc01bc6c711
     HEAD_REF main
     PATCHES
         dependencies.diff

--- a/ports/sdl3-image/vcpkg.json
+++ b/ports/sdl3-image/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl3-image",
-  "version": "3.4.2",
-  "port-version": 1,
+  "version": "3.4.4",
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9061,8 +9061,8 @@
       "port-version": 0
     },
     "sdl3-image": {
-      "baseline": "3.4.2",
-      "port-version": 1
+      "baseline": "3.4.4",
+      "port-version": 0
     },
     "sdl3-mixer": {
       "baseline": "3.2.0",

--- a/versions/s-/sdl3-image.json
+++ b/versions/s-/sdl3-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d64d0dd26d1a025b99b83429838551fde4a65cf",
+      "version": "3.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2e97142e6b1a6f51cdf99b8ef743719515c56994",
       "version": "3.4.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libsdl-org/SDL_image/releases/tag/release-3.4.4
