### PR TITLE
[simpleble] update to 0.14.0

### DIFF
--- a/ports/simpleble/portfile.cmake
+++ b/ports/simpleble/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO OpenBluetoothToolbox/SimpleBLE
     HEAD_REF main
     REF "v${VERSION}"
-    SHA512 c53c435c53f4829bfe1f1db94a94693958a23174689b798ae32d9518725efbb3173540e150c5a630ee53752d3e49f80f9e412c1c21e9f7a326369592d47cab46
+    SHA512 609bc49c625b5b85b360ccbf09589c752c820685f2108d978daaa3eb5f8ce8d23f4edd02ab03853ae3e313911ad84537a02643af9c81f7f17b9a1ee2b762d930
     PATCHES
         devendor.diff
         use-std-localtime.patch

--- a/ports/simpleble/vcpkg.json
+++ b/ports/simpleble/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "simpleble",
-  "version": "0.12.1",
-  "port-version": 1,
+  "version": "0.14.0",
   "description": "The ultimate fully-fledged cross-platform library and bindings for Bluetooth Low Energy (BLE).",
   "homepage": "https://github.com/OpenBluetoothToolbox/SimpleBLE",
   "license": "BUSL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9253,8 +9253,8 @@
       "port-version": 0
     },
     "simpleble": {
-      "baseline": "0.12.1",
-      "port-version": 1
+      "baseline": "0.14.0",
+      "port-version": 0
     },
     "simpleini": {
       "baseline": "4.25",

--- a/versions/s-/simpleble.json
+++ b/versions/s-/simpleble.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1f1ad70e35a7326faab2eac08e8384342a910ab",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f546eacab0782c85679cae2a7aca20b14a8f6f09",
       "version": "0.12.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/simpleble/simpleble/releases/tag/v0.14.0
