### PR TITLE
[usearch] update to 2.25.2

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unum-cloud/usearch
     REF "v${VERSION}"
-    SHA512 bbddcc500032c71e8e7563454baddf798cb8eb7bb96f4c6cab1137c86a8e0849701eb70d6e3b1329575d90faffa91656844a2a0205132f447ac9c2ffabc87e3c
+    SHA512 d1b48601671cb5220caa2603e8e7d58538e0085636618777fce9e574be4853e1f4157a8d4d7f0de37b95e734a3ed7834c7a6b4907ea99d1aa6b267726299727c
     HEAD_REF main
     PATCHES
         use-vcpkg-ports.patch

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usearch",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "Fastest Search & Clustering engine × for Vectors & Strings",
   "homepage": "https://github.com/unum-cloud/usearch",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10357,7 +10357,7 @@
       "port-version": 0
     },
     "usearch": {
-      "baseline": "2.25.1",
+      "baseline": "2.25.2",
       "port-version": 0
     },
     "usockets": {

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "351fe3f80326a5394de1ee0c9ba0252abf83fe8d",
+      "version": "2.25.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "348825085ebe0a1d25c26191f1a94fa92e628b5f",
       "version": "2.25.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/unum-cloud/USearch/releases/tag/v2.25.2
