### PR TITLE
[dtc] Add new port

### DIFF
--- a/ports/dtc/0001-enable-static-or-shared.patch
+++ b/ports/dtc/0001-enable-static-or-shared.patch
@@ -1,0 +1,32 @@
+diff --git a/libfdt/meson.build b/libfdt/meson.build
+index bf8343f..c2f4bd6 100644
+--- a/libfdt/meson.build
++++ b/libfdt/meson.build
+@@ -26,7 +26,7 @@ else
+ endif
+ 
+ link_args += version_script
+-libfdt = both_libraries(
++libfdt = library(
+   'fdt', sources,
+   version: meson.project_version(),
+   link_args: link_args,
+@@ -34,17 +34,11 @@ libfdt = both_libraries(
+   install: true,
+ )
+ 
+-if static_build
+-  link_with = libfdt.get_static_lib()
+-else
+-  link_with = libfdt.get_shared_lib()
+-endif
+-
+ libfdt_inc = include_directories('.')
+ 
+ libfdt_dep = declare_dependency(
+   include_directories: libfdt_inc,
+-  link_with: link_with,
++  link_with: libfdt,
+ )
+ 
+ install_headers(

--- a/ports/dtc/portfile.cmake
+++ b/ports/dtc/portfile.cmake
@@ -1,0 +1,40 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY) # library does not explicitely export its symbols.
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dgibson/dtc
+    REF "v${VERSION}"
+    SHA512 5cf48c8bd426919bb8aad6a8866e063305eca830547f8ceb5fe7746bc85a8d6a0a1e13fd29432cb389d3d51337368f217077aabf9436b526e77d425b33167694
+    HEAD_REF main
+    PATCHES
+        0001-enable-static-or-shared.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(STATIC_BUILD true)
+else()
+    set(STATIC_BUILD false)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dtools=false
+        -Dyaml=disabled
+        -Dvalgrind=disabled
+        -Dpython=disabled
+        -Dtests=false
+        "-Dstatic-build=${STATIC_BUILD}"
+)
+
+vcpkg_install_meson()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/README.license"
+    "${SOURCE_PATH}/BSD-2-Clause"
+    "${SOURCE_PATH}/GPL"
+)

--- a/ports/dtc/vcpkg.json
+++ b/ports/dtc/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.7.2",
   "description": "Device Tree Compiler (dtc) toolchain for working with device tree source and binary files and also libfdt, a utility library for reading and manipulating the binary format.",
   "homepage": "https://github.com/dgibson/dtc",
-  "license": "GPL-2.0-or-later AND (GPL-2.0-or-later OR BSD-2-Clause)",
+  "license": "GPL-2.0-or-later OR BSD-2-Clause",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/dtc/vcpkg.json
+++ b/ports/dtc/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "dtc",
+  "version": "1.7.2",
+  "description": "Device Tree Compiler (dtc) toolchain for working with device tree source and binary files and also libfdt, a utility library for reading and manipulating the binary format.",
+  "homepage": "https://github.com/dgibson/dtc",
+  "license": "GPL-2.0-or-later AND (GPL-2.0-or-later OR BSD-2-Clause)",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2620,6 +2620,10 @@
       "baseline": "1.3.0",
       "port-version": 0
     },
+    "dtc": {
+      "baseline": "1.7.2",
+      "port-version": 0
+    },
     "dtl": {
       "baseline": "1.21",
       "port-version": 0

--- a/versions/d-/dtc.json
+++ b/versions/d-/dtc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3c7ee7796ac99681cfc7693cbe33fe1358feedf",
+      "git-tree": "09cf1dc350d443ca61f4374a51069fc2b2b67522",
       "version": "1.7.2",
       "port-version": 0
     }

--- a/versions/d-/dtc.json
+++ b/versions/d-/dtc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f3c7ee7796ac99681cfc7693cbe33fe1358feedf",
+      "version": "1.7.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.