### PR TITLE
Update slick net 2.0.2

### DIFF
--- a/ports/slick-net/portfile.cmake
+++ b/ports/slick-net/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-net
     REF "v${VERSION}"
-    SHA512 fa0ab34370b55e3c1c020fa657ff2c5b2ef020867aa12ebe778394d1e89641b17bc3d19578c238ddc8e36df306394b33ff6fdc8258a88913b4cadf4db772d9b1
+    SHA512 9779ae452e26f8a60c94eddd8102e1f134b3d9699e2645c6e4dff2edc7c488fda0482e9abdcd79472db77ac6cdcb994103c8e05d4f5cd74af088c3f9b5d031e3
     HEAD_REF main
     PATCHES
         slick-queue.patch

--- a/ports/slick-net/portfile.cmake
+++ b/ports/slick-net/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-net
     REF "v${VERSION}"
-    SHA512 15ce0b13645fe48750083583b1881aff0c3730ee837d8df7f54cee75025a1039dfd2a9e75a8aa30484dbca578102f35a7b9d4c8e5b9fd4802a24538585278e6e
+    SHA512 fa0ab34370b55e3c1c020fa657ff2c5b2ef020867aa12ebe778394d1e89641b17bc3d19578c238ddc8e36df306394b33ff6fdc8258a88913b4cadf4db772d9b1
     HEAD_REF main
     PATCHES
         slick-queue.patch

--- a/ports/slick-net/vcpkg.json
+++ b/ports/slick-net/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-net",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A modern C++20 networking library providing HTTP/HTTPS client, WebSocket/WebSocket Secure client, and HTTP streaming support built on Boost.Beast and Boost.Asio",
   "homepage": "https://github.com/SlickQuant/slick-net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9297,7 +9297,7 @@
       "port-version": 0
     },
     "slick-net": {
-      "baseline": "2.0.1",
+      "baseline": "2.0.2",
       "port-version": 0
     },
     "slick-object-pool": {

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c17633f5f090779667e98b1153667417962e1e81",
+      "version": "2.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e490210238df7656c4df264bef346fe22faf5bb1",
       "version": "2.0.1",
       "port-version": 0

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c17633f5f090779667e98b1153667417962e1e81",
+      "git-tree": "6657c9bf37e16bf30f5c5cfb6568c8fe91267ac7",
       "version": "2.0.2",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

 If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
