### PR TITLE
[geo-utils] new port

### DIFF
--- a/ports/geo-utils/portfile.cmake
+++ b/ports/geo-utils/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gistrec/geo-utils
+    REF "v${VERSION}"
+    SHA512 9955a991c52634ff9c98b69ed2e7b55eb15e8ece0eff059a0dd8173c3e4e2b51044ea637365722a532de62309aa68109abda1aa1018561d3596944b8cf760ede
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DGEO_UTILS_BUILD_TESTS=OFF
+        -DGEO_UTILS_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/GeoUtils PACKAGE_NAME GeoUtils)
+
+# Header-only — no compiled artifacts to keep
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/geo-utils/vcpkg.json
+++ b/ports/geo-utils/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "geo-utils",
+  "version": "1.0.0",
+  "description": "Header-only C++17 library for spherical (lat/lng) geometry: distance, bearing, area, point-in-polygon",
+  "homepage": "https://github.com/gistrec/geo-utils",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3320,6 +3320,10 @@
       "baseline": "2019-07-10",
       "port-version": 3
     },
+    "geo-utils": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "geogram": {
       "baseline": "1.9.3",
       "port-version": 0

--- a/versions/g-/geo-utils.json
+++ b/versions/g-/geo-utils.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "41701e9e67f022c7009af3c07fcc8c9b32edf514",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

  Adds a new port for [geo-utils](https://github.com/gistrec/geo-utils) — a header-only C++17 library for spherical (lat/lng) geometry: distance, bearing, polygon area, point-in-polygon, path proximity.
  License: Apache-2.0. No runtime dependencies.

- Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

  Header-only, builds and installs cleanly on `arm64-osx` locally. Should work on all triplets the upstream CMake supports (Linux gcc/clang, macOS AppleClang, Windows MSVC — verified by upstream CI). No `ci.baseline.txt` changes needed.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

  Yes — license expression, homepage, version, vcpkg-cmake / vcpkg-cmake-config dependencies, copyright via `vcpkg_install_copyright`, no debug/lib leakage (header-only).

- If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

  Yes — `versions/g-/geo-utils.json` and `versions/baseline.json` updated.

- If you have added/updated a port: Have you added/updated a Versioning info?

  Yes.

**Test plan**

- [x] Local install `./vcpkg install geo-utils` succeeds on arm64-osx
- [x] Post-build validation passes
- [x] Heuristic CMake target detection: `find_package(GeoUtils CONFIG REQUIRED)` + `geo::utils`
- [ ] vcpkg CI on Linux/macOS/Windows