### PR TITLE
[frei0r] update to 3.1.1

### DIFF
--- a/ports/frei0r/portfile.cmake
+++ b/ports/frei0r/portfile.cmake
@@ -2,17 +2,11 @@
 # hence they don't have import libs
 set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
 
-vcpkg_download_distfile(FIX_UPSTREAM_PR_252
-    URLS https://github.com/dyne/frei0r/pull/252.patch?full_index=1
-    SHA512 bdf8c6e64d73495a843c76d08204217002f1108363674633a70574ba05f0f33efafc567b73f604c7c76fd9a9614a64ccadd62c3709454b52efbb8b8d61055532
-    FILENAME fix-sleid0r-symbol-export.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dyne/frei0r
     REF "v${VERSION}"
-    SHA512 81831ede1d76d0ad8811f6b8116eb71a74e5af47a3249954f2c6f327e71e618d92c31f19566963bd9952363b22c5a6606df3ef8592f97c3bb1cd8ed9abe94c14
+    SHA512 cd4eebf1fa77e24e5ea1cec98b0eddab0e6d0ecca5daf5b06cf293c8ac17b4f57bfb320f49ed209835062d4faed6b119c732a7ff5d114dda68eba36f4ecd144e
     HEAD_REF master
     PATCHES
         "${FIX_UPSTREAM_PR_252}"

--- a/ports/frei0r/vcpkg.json
+++ b/ports/frei0r/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "frei0r",
-  "version": "2.5.4",
+  "version": "3.1.1",
   "description": "A large collection of free and portable video plugins",
   "homepage": "https://frei0r.dyne.org/",
-  "license": "GPL-2.0",
+  "license": "GPL-2.0-or-later",
   "supports": "!(static & windows)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3193,7 +3193,7 @@
       "port-version": 2
     },
     "frei0r": {
-      "baseline": "2.5.4",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "fribidi": {

--- a/versions/f-/frei0r.json
+++ b/versions/f-/frei0r.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab9d2e6f1c6359e192cc45122516ee8bc6802e3d",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ddfa0c31ead64f21a195cc53c5b5c437f73f9142",
       "version": "2.5.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or~ no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
