### PR TITLE
[libxt] Remove debugging code

### DIFF
--- a/ports/libxt/portfile.cmake
+++ b/ports/libxt/portfile.cmake
@@ -85,7 +85,7 @@ if(VCPKG_CROSSCOMPILING)
     endif()
 endif()
 
-vcpkg_install_make(DISABLE_PARALLEL)
+vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)

--- a/ports/libxt/vcpkg.json
+++ b/ports/libxt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxt",
   "version": "1.3.1",
+  "port-version": 1,
   "description": "X Toolkit Intrinsics library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5982,7 +5982,7 @@
     },
     "libxt": {
       "baseline": "1.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libxtst": {
       "baseline": "1.2.5",

--- a/versions/l-/libxt.json
+++ b/versions/l-/libxt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fc9fc4b933e7c54f94d7055dc1ee6f9ddf1d7c8",
+      "version": "1.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "828043b8ce0be3ffb7f321e4785e506f94a6d5ca",
       "version": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
Missed to remove this in #51439 (as the logs were not readable without it)