### PR TITLE
[hical61-hical] Update to version 2.5.0

### DIFF
--- a/ports/hical61-hical/portfile.cmake
+++ b/ports/hical61-hical/portfile.cmake
@@ -4,8 +4,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Hical61/Hical
     REF "v${VERSION}"
-    SHA512 de7984170b293f685c03ad4e451fe61895e73bc4434a48b5e0bccdf2ea8e7a3f334a6d5159cc468f788ccedeada6ab52a9c92fb3a2f9672588c86b0a7e32a889
+    SHA512 3b1d538a86fecf67a795844c2e51120f42c7c63c25fd3d23c495fb53cb29e283d75cc92dbff54b9d23d634af80d5156162c9b0a53d25592c7830e3db7d536bb6
     HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        database HICAL_WITH_DATABASE
 )
 
 vcpkg_cmake_configure(
@@ -13,6 +19,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DHICAL_BUILD_TESTS=OFF
         -DHICAL_BUILD_EXAMPLES=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/hical61-hical/vcpkg.json
+++ b/ports/hical61-hical/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hical61-hical",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Modern C++20/C++26 high-performance web framework based on Boost.Asio/Beast",
   "homepage": "https://github.com/Hical61/Hical",
   "license": "MIT",
@@ -23,5 +23,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "database": {
+      "description": "Database middleware with MySQL support (requires Boost.MySQL)",
+      "dependencies": [
+        "boost-charconv",
+        "boost-mysql"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3781,7 +3781,7 @@
       "port-version": 0
     },
     "hical61-hical": {
-      "baseline": "2.4.0",
+      "baseline": "2.5.0",
       "port-version": 0
     },
     "hidapi": {

--- a/versions/h-/hical61-hical.json
+++ b/versions/h-/hical61-hical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ae75376bb86779704f65b10106523cb29de991b",
+      "version": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4e3d0f380573172feb85dd16fe3dda95894f3e0a",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
## Changes

Update `hical61-hical` to version 2.5.0.

**Upstream release:** https://github.com/Hical61/Hical/releases/tag/v2.5.0

### Port changes
- Updated `version` to `2.5.0` in `vcpkg.json`
- Updated `SHA512` in `portfile.cmake`
- Added `database` feature with `boost-charconv` and `boost-mysql` dependencies
- Added `vcpkg_check_features()` to forward the `database` feature option to CMake

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.