### PR TITLE
[frugally-deep] update to0.20.0

### DIFF
--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/frugally-deep
     REF "v${VERSION}"
-    SHA512 bfc632d35c30c209aed87bbd810c2c919609cef07af03fda50c17e8eb5eb735cbda9d49ec1e0685c3f8d322b870471bf02861d53300a22e177ca38639f4cee48
+    SHA512 74ad9e26c4e5937afdd2603f9d1389b5303250c6bac34aeabf13cfeaf6fd64fa2bf275a02f58b31ca449c2bf31c1db728dd96d0b085d8d6cc7d93719b1778530
     HEAD_REF master
 )
 

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "frugally-deep",
-  "version-semver": "0.19.5",
+  "version-semver": "0.20.0",
   "description": "Header-only library for using Keras models in C++.",
   "homepage": "https://github.com/Dobiasd/frugally-deep",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3209,7 +3209,7 @@
       "port-version": 0
     },
     "frugally-deep": {
-      "baseline": "0.19.5",
+      "baseline": "0.20.0",
       "port-version": 0
     },
     "fruit": {

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aaf69511b69ee9f1d783f95008ce07846ad9da6a",
+      "version-semver": "0.20.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "360b33092299fc382924f767c8dcf4d7bb1975be",
       "version-semver": "0.19.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Dobiasd/frugally-deep/releases/tag/v0.20.0
