### PR TITLE
[magic-enum] update to 0.9.8

### DIFF
--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
     REF "v${VERSION}"
-    SHA512 8b61c621ff2a6981b4ff89f7df577091ffc9382d443c061db612fb61822dbf6ef8aba69ea35d1c435dcffbd7434cb4ccc5d12bbe2deba1cf0a5316c979ee6a4b
+    SHA512 ba20ecefd3bf01c44e0b321bdff55b1f39067d416e9c1afb0b3661289ce26b455ca8736baf4782c19c8f737c0763fa8eb3cf235527cc2f1dbf5b924a767a8ed7
     HEAD_REF master
 )
 

--- a/ports/magic-enum/vcpkg.json
+++ b/ports/magic-enum/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "magic-enum",
-  "version": "0.9.7",
-  "port-version": 1,
+  "version": "0.9.8",
   "description": "Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.",
   "homepage": "https://github.com/Neargye/magic_enum",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6253,8 +6253,8 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.9.7",
-      "port-version": 1
+      "baseline": "0.9.8",
+      "port-version": 0
     },
     "magma": {
       "baseline": "2.9.0",

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1efc0107896faa5eb40f2a398c61ad2b8ca2dc65",
+      "version": "0.9.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ab95f56c0327e8b6c0190fae3d975439161ffaa",
       "version": "0.9.7",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Neargye/magic_enum/releases/tag/v0.9.8
