### PR TITLE
[nameof] update to 0.10.5

### DIFF
--- a/ports/nameof/portfile.cmake
+++ b/ports/nameof/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/nameof
     REF "v${VERSION}"
-    SHA512 88eff4fb9a137c388b39d67eb9e213ed93e6a553dd1295d5db04c6fbc254f6df3da8800de2e0675f574bb3f83ae05141f71efe30ccdd4601a42cf19adaea6e79
+    SHA512 845004c839a865af49b752d6f0689ef6130f348140b22f6f668f8e6ca9fb4bf2eb78cbcccc9e01d14dd526a1c16fa4fa9f8f36b3b7085a302e9b3880cbc45b5e
     HEAD_REF master
 )
 

--- a/ports/nameof/vcpkg.json
+++ b/ports/nameof/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nameof",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Nameof operator for modern C++, simply obtain the name of a variable, type, function, macro, and enum.",
   "homepage": "https://github.com/Neargye/nameof",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6805,7 +6805,7 @@
       "port-version": 0
     },
     "nameof": {
-      "baseline": "0.10.4",
+      "baseline": "0.10.5",
       "port-version": 0
     },
     "nana": {

--- a/versions/n-/nameof.json
+++ b/versions/n-/nameof.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3bbfd4b5a6da11498ce6a4f681807d31797e5c0",
+      "version": "0.10.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "60e906146f2d83899688b0f478dcabaad9aaeace",
       "version": "0.10.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Neargye/nameof/releases/tag/v0.10.5
