### PR TITLE
[cpp-httplib] update to 0.43.3

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 265355b86a798f628932b76402cba108f17402f573c79b00dbe54fa93e8b8ce4bb03adbc090b773c77fd175b6d108cd84481b10bb31f4fe60171d5d4bc3b74af
+    SHA512 2b4884eb4bedd359e93e33584e7c712630d1ec9e05f49690f3f7d001611a3fb8e25a0c76fad4e4983df121643e04ce8ae90aeee4d40eacabf02f3b63b627bc2b
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2009,7 +2009,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.43.2",
+      "baseline": "0.43.3",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71f61ca60d111d119aee96665c0fa4944f9bb0bb",
+      "version": "0.43.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "bb04ce798e4667fae9eae7265d2caf2b60e463eb",
       "version": "0.43.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/yhirose/cpp-httplib/releases/tag/v0.43.3
