### PR TITLE
[lastools] Update to 2.0.5

### DIFF
--- a/ports/lastools/portfile.cmake
+++ b/ports/lastools/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO LAStools/LAStools
     REF "v${VERSION}"
-    SHA512 a44e6df02b8f7fe8388420fc7d454b035c38bcfb43a59d15ecb634cb30165c70730258b8ea79f335c4625b482827feb8a3d7afa8e07b369c19d5f7cc7be15001
+    SHA512 d02f376f1597155d65ec23f7dbde21e2fe6f2aabbf67d5813b27657985848aac7e5593427bb0869b243edacc8a1647edc0fa4600840eb054bde7cac0a6bc1b01
     HEAD_REF master
     PATCHES
         fix_install_paths_lastools.patch
@@ -25,7 +25,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/LASlib PACKAGE_NAME laslib)
 
 if(BUILD_TOOLS)
-    vcpkg_copy_tools(TOOL_NAMES las2las64 las2txt64 lascopcindex64 lasdiff64 lasindex64 lasinfo64 lasmerge64 lasprecision64 laszip64 txt2las64 AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES las2las64 las2txt64 lascopcindex64 lasdiff64 lasindex64 lasinfo64 lasmerge64 lasprecision64 lasvalidate64 laszip64 txt2las64 AUTO_CLEAN)
 
     # Copy CSV files that are used as lookup tables by las2las.
     file(COPY "${SOURCE_PATH}/bin/serf/geo" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/serf")

--- a/ports/lastools/vcpkg.json
+++ b/ports/lastools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lastools",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "LAStools: award-winning software for efficient LiDAR processing (with LASzip)",
   "homepage": "https://github.com/LAStools/LAStools",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4577,7 +4577,7 @@
       "port-version": 3
     },
     "lastools": {
-      "baseline": "2.0.4",
+      "baseline": "2.0.5",
       "port-version": 0
     },
     "laszip": {

--- a/versions/l-/lastools.json
+++ b/versions/l-/lastools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "414f61b746b2d9376c0fc2d6c9637f9e421ef128",
+      "version": "2.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "288c8a8e9b4f66a521a19c4cdce917f10c106281",
       "version": "2.0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
