### PR TITLE
[libsystemd] Fix build on 26.04 ubuntu systems

### DIFF
--- a/ports/libsystemd/fix-2604-build.patch
+++ b/ports/libsystemd/fix-2604-build.patch
@@ -1,12 +1,46 @@
 diff --git a/meson.build b/meson.build
-index a4730f0570..57af84f147 100644
+index a4730f0570..1034ce5fbc 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -363,6 +363,7 @@ basic_disabled_warnings = [
-         '-Wno-unknown-warning-option',
-         '-Wno-unused-parameter',
-         '-Wno-nonnull-compare',
-+        '-Wno-override-init'
- ]
+@@ -370,21 +370,6 @@ possible_common_cc_flags = [
+         '-Warray-bounds=2',
+         '-Wdate-time',
+         '-Wendif-labels',
+-        '-Werror=format=2',
+-        '-Werror=format-signedness',
+-        '-Werror=implicit-function-declaration',
+-        '-Werror=implicit-int',
+-        '-Werror=incompatible-pointer-types',
+-        '-Werror=int-conversion',
+-        '-Werror=missing-declarations',
+-        '-Werror=missing-prototypes',
+-        '-Werror=overflow',
+-        '-Werror=override-init',
+-        '-Werror=return-type',
+-        '-Werror=shift-count-overflow',
+-        '-Werror=shift-overflow=2',
+-        '-Werror=strict-flex-arrays',
+-        '-Werror=undef',
+         '-Wfloat-equal',
+         # gperf prevents us from enabling this because it does not emit fallthrough
+         # attribute with clang.
+@@ -511,19 +496,6 @@ userspace_c_ld_args += cc.get_supported_link_arguments(possible_link_flags)
+ have = cc.has_argument('-Wzero-length-bounds')
+ conf.set10('HAVE_ZERO_LENGTH_BOUNDS', have)
  
- possible_common_cc_flags = [
+-if cc.compiles('''
+-   #include <time.h>
+-   #include <inttypes.h>
+-   typedef uint64_t usec_t;
+-   usec_t now(clockid_t clock);
+-   int main(void) {
+-           struct timespec now;
+-           return 0;
+-   }
+-''', args: '-Werror=shadow', name : '-Werror=shadow with local shadowing')
+-        add_project_arguments('-Werror=shadow', language : 'c')
+-endif
+-
+ if cxx_cmd != ''
+         add_project_arguments(cxx.get_supported_arguments(basic_disabled_warnings), language : 'cpp')
+ endif

--- a/ports/libsystemd/fix-2604-build.patch
+++ b/ports/libsystemd/fix-2604-build.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index a4730f0570..57af84f147 100644
+--- a/meson.build
++++ b/meson.build
+@@ -363,6 +363,7 @@ basic_disabled_warnings = [
+         '-Wno-unknown-warning-option',
+         '-Wno-unused-parameter',
+         '-Wno-nonnull-compare',
++        '-Wno-override-init'
+ ]
+ 
+ possible_common_cc_flags = [

--- a/ports/libsystemd/portfile.cmake
+++ b/ports/libsystemd/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     disable-warning-nonnull.patch
     only-libsystemd.patch
     pkgconfig.patch
+    fix-2604-build.patch
 )
 
 set(static false)

--- a/ports/libsystemd/vcpkg.json
+++ b/ports/libsystemd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsystemd",
   "version": "257.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libsystemd",
   "homepage": "https://github.com/systemd/systemd",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5678,7 +5678,7 @@
     },
     "libsystemd": {
       "baseline": "257.8",
-      "port-version": 1
+      "port-version": 2
     },
     "libtar": {
       "baseline": "1.2.20",

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dcebf08a65646e710e4d1d63be8fab12d5e4e96a",
+      "version": "257.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "9a7380e250b16232a48738c3e0798f07006c24c8",
       "version": "257.8",
       "port-version": 1

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dcebf08a65646e710e4d1d63be8fab12d5e4e96a",
+      "git-tree": "2c321fd60481e2ac3996b56c88cd1e6bec5b051e",
       "version": "257.8",
       "port-version": 2
     },


### PR DESCRIPTION
This PR removes some Werror arguments in the building of libsystemd that caused the build to fail when using a docker container of ubuntu 26.04. I tested using the following:
```bash
docker run -it ubuntu:26.04
apt install -y ca-certificates curl gnupg lsb-release openjdk-17-jre-headless git sudo vim openssh-client build-essential ninja-build openjdk-21-jre fontconfig \
    zip unzip tar autoconf autoconf-archive automake libtool \
    linux-libc-dev pkg-config software-properties-common \
    nasm bison flex \
    libx11-dev libxext-dev libxrender-dev libxtst-dev libxrandr-dev \
    libltdl-dev libxi-dev libxcursor-dev libxinerama-dev \
    libgl1-mesa-dev libglu1-mesa-dev libasound2-dev \
    libvulkan-dev libwayland-dev libxkbcommon-dev \
    libssl-dev libbz2-dev liblzma-dev libudev-dev libdrm-dev \
    libglfw3-dev libgtk-3-dev \
    libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
    libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
    libx11-xcb-dev libxkbcommon-x11-dev libegl1-mesa-dev \
    python3 python3-venv openjdk-21-jdk openjdk-25-jdk openjdk-17-jdk \
    '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev \
    libxkbcommon-x11-dev libegl1-mesa-dev clang-tidy clang-tools clang-format codespell cppcheck
curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc \
    -o /usr/share/keyrings/kitware-archive-keyring.asc && \
    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.asc] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
    > /etc/apt/sources.list.d/kitware.list && \
    apt-get update && apt-get install -y cmake
git clone https://github.com/Microsoft/vcpkg && cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install libsystemd
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.