### PR TITLE
[unrar] Update to version 7.2.6

### DIFF
--- a/ports/unrar/portfile.cmake
+++ b/ports/unrar/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.rarlab.com/rar/unrarsrc-${VERSION}.tar.gz"
     FILENAME "unrarsrc-${VERSION}.tar.gz"
-    SHA512 8e2b7e801e1e1f8861657e7e613b4540c46938af377e43383ec2b509db1a59073d1e970fa20ee923db73a6c93777d677e7488ca6696177625cc1020922504346
+    SHA512 e0a317418fa9c853295f69f0fbb53d1caae493405b8785ab04ac612c87b9e294f4331108ca3650a75bca91acfb5f6907d00360a9579425b2f2eae12dcae40f96
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/unrar/vcpkg.json
+++ b/ports/unrar/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "unrar",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "description": "rarlab's unrar library",
   "homepage": "https://www.rarlab.com",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10337,7 +10337,7 @@
       "port-version": 0
     },
     "unrar": {
-      "baseline": "7.2.5",
+      "baseline": "7.2.6",
       "port-version": 0
     },
     "upa-url": {

--- a/versions/u-/unrar.json
+++ b/versions/u-/unrar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6b146edb610eb80c2883535166bb5b42d94b377",
+      "version": "7.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "54894143dc5cf8e6d12b7a25c32a72a13155676d",
       "version": "7.2.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.