### PR TITLE
[karchive] add OpenSSL encryption feature

### DIFF
--- a/ports/karchive/portfile.cmake
+++ b/ports/karchive/portfile.cmake
@@ -18,6 +18,8 @@ vcpkg_check_features(
         bzip2           VCPKG_LOCK_FIND_PACKAGE_BZip2
         lzma            WITH_LIBLZMA
         lzma            VCPKG_LOCK_FIND_PACKAGE_LibLZMA
+        openssl         WITH_OPENSSL
+        openssl         VCPKG_LOCK_FIND_PACKAGE_OpenSSL
         zstd            WITH_LIBZSTD
         zstd            VCPKG_LOCK_FIND_PACKAGE_LibZstd
     INVERTED_FEATURES

--- a/ports/karchive/vcpkg.json
+++ b/ports/karchive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "karchive",
   "version": "6.25.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "File compression",
   "homepage": "https://invent.kde.org/frameworks/karchive",
   "documentation": "https://api.kde.org/karchive-index.html",
@@ -34,6 +34,12 @@
       "description": "Support for xz compressed files and data streams",
       "dependencies": [
         "liblzma"
+      ]
+    },
+    "openssl": {
+      "description": "Support for encrypted archives",
+      "dependencies": [
+        "openssl"
       ]
     },
     "translations": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4218,7 +4218,7 @@
     },
     "karchive": {
       "baseline": "6.25.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kbreezeicons": {
       "baseline": "6.25.0",

--- a/versions/k-/karchive.json
+++ b/versions/k-/karchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79bdc4b66ed8b75bef7e9c8063bc0a88f6afe6ae",
+      "version": "6.25.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "d0b3065f564d5f63f48149974f4219303c9eb51f",
       "version": "6.25.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
