### PR TITLE
[lcms] update to 2.19.1

### DIFF
--- a/ports/lcms/portfile.cmake
+++ b/ports/lcms/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mm2/Little-CMS
     REF "lcms${VERSION}"
-    SHA512 1e256b6b7c06800ad21a5cd35971f39963710cc086cf22bc91a86f6f736b2bfa63cb705ada4431b6eb25714fe16a0e562acf51da742503d590fc1dd665a58b54
+    SHA512 1b2781ed8898e65f15be17cf0130a1500ec0bf5ca5159f871dff5692e387747be9526feef0bc7c370200656fc0aabe3036746041285a3978e90adec200d685f2
     HEAD_REF master
     PATCHES
         ${SHARED_LIBRARY_PATCH}
@@ -38,7 +38,7 @@ vcpkg_fixup_pkgconfig()
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(
-        TOOL_NAMES jpgicc linkicc psicc tificc transicc
+        TOOL_NAMES jpgicc linkicc psicc tificc transicc tifdiff
         AUTO_CLEAN
     )
 endif()

--- a/ports/lcms/vcpkg.json
+++ b/ports/lcms/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lcms",
-  "version": "2.18",
+  "version": "2.19.1",
   "description": "Little CMS.",
   "homepage": "https://github.com/mm2/Little-CMS",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4605,7 +4605,7 @@
       "port-version": 0
     },
     "lcms": {
-      "baseline": "2.18",
+      "baseline": "2.19.1",
       "port-version": 0
     },
     "lely-core": {

--- a/versions/l-/lcms.json
+++ b/versions/l-/lcms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae3a606e2990806e4beae526422426116a9ea56d",
+      "version": "2.19.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "5e713d8bb26bac060c839776cdb34861767be1d9",
       "version": "2.18",
       "port-version": 0


### PR DESCRIPTION
Supersedes https://github.com/microsoft/vcpkg/pull/51389

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
