### PR TITLE
[patternia] update to 0.9.3

### DIFF
--- a/ports/patternia/portfile.cmake
+++ b/ports/patternia/portfile.cmake
@@ -2,9 +2,9 @@ set(VCPKG_BUILD_TYPE release)
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
-  REPO SentoMK/patternia
-  REF "v${VERSION}"
-  SHA512 727fbde75b30e38b4a813b966115b7a2e142617a8a8143bb88eb7dbbb6ce99979a25d4ee288aac5eafe9d48798a6dc6936b58804882b22acfa60b1a609a0ae53
+  REPO sentomk/patternia
+  REF ae21772a77caffc7dbe4734030cf46c518416e2e # url of v0.9.3 returns 300, so use the commit hash instead
+  SHA512 2edf6a0f2f34d33777772355fdc5087145f98b5f00f238f1cadb57c380a6a7adb3b46874dde91203193d9afae65b610d1757f1eaace2970cde523ca095d82787
   HEAD_REF main
 )
 

--- a/ports/patternia/vcpkg.json
+++ b/ports/patternia/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "patternia",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Header-only pattern matching library for modern C++",
-  "homepage": "https://github.com/SentoMK/patternia",
+  "homepage": "https://github.com/sentomk/patternia",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7617,7 +7617,7 @@
       "port-version": 0
     },
     "patternia": {
-      "baseline": "0.9.2",
+      "baseline": "0.9.3",
       "port-version": 0
     },
     "pbc": {

--- a/versions/p-/patternia.json
+++ b/versions/p-/patternia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d0536df85c4fe9d6b7cf5a9975986d57c2a9edb",
+      "version": "0.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "18a2c9d2978dbc16d667c6a1b2385b1ccea1a0c5",
       "version": "0.9.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/sentomk/patternia/releases/tag/v0.9.3

- author name changed lower case `SentoMK` to `sentomk`
- the url of v0.9.3 returns 300, so use the commit hash instead
