### PR TITLE
[libgit2] update to 1.9.3

### DIFF
--- a/ports/libgit2/c-standard.diff
+++ b/ports/libgit2/c-standard.diff
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5be7bef..5f9ed79 100644
+index bb6cdf0..3b4a6ce 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -57,7 +57,7 @@ option(DEPRECATE_HARD          "Do not include deprecated functions in the libra
@@ -11,13 +11,13 @@ index 5be7bef..5f9ed79 100644
  endif()
  option(CMAKE_C_EXTENSIONS      "Whether compiler extensions are supported"             OFF)
  option(ENABLE_WERROR           "Enable compilation with -Werror"                       OFF)
-/tmp/bbb.patch (END)diff --git a/src/libgit2/CMakeLists.txt b/src/libgit2/CMakeLists.txt
-index 0dddb02..af85510 100644
+diff --git a/src/libgit2/CMakeLists.txt b/src/libgit2/CMakeLists.txt
+index 6b76afb..62c8bec 100644
 --- a/src/libgit2/CMakeLists.txt
 +++ b/src/libgit2/CMakeLists.txt
 @@ -60,7 +60,7 @@ target_link_libraries(libgit2package ${LIBGIT2_SYSTEM_LIBS})
  target_include_directories(libgit2package SYSTEM PRIVATE ${LIBGIT2_INCLUDES})
- target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:include>)
+ target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
  
 -set_target_properties(libgit2package PROPERTIES C_STANDARD 90)
 +set_target_properties(libgit2package PROPERTIES C_STANDARD 99)

--- a/ports/libgit2/dependencies.diff
+++ b/ports/libgit2/dependencies.diff
@@ -1,5 +1,5 @@
 diff --git a/cmake/SelectRegex.cmake b/cmake/SelectRegex.cmake
-index 840ec7f..9533202 100644
+index 840ec7f..d12ef50 100644
 --- a/cmake/SelectRegex.cmake
 +++ b/cmake/SelectRegex.cmake
 @@ -22,7 +22,9 @@ if(REGEX_BACKEND STREQUAL "regcomp_l")
@@ -13,16 +13,25 @@ index 840ec7f..9533202 100644
  
  	if(NOT PCRE2_FOUND)
  		MESSAGE(FATAL_ERROR "PCRE2 support was requested but not found")
-@@ -31,6 +33,9 @@ elseif(REGEX_BACKEND STREQUAL "pcre2")
+@@ -30,7 +32,7 @@ elseif(REGEX_BACKEND STREQUAL "pcre2")
+ 
  	add_feature_info(regex ON "using system PCRE2")
  	set(GIT_REGEX_PCRE2 1)
+-
++	set(PCRE2_LIBRARIES "${PCRE2_LINK_LIBRARIES}")
+ 	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${PCRE2_INCLUDE_DIRS})
+ 	list(APPEND LIBGIT2_SYSTEM_LIBS ${PCRE2_LIBRARIES})
+ 	list(APPEND LIBGIT2_PC_REQUIRES "libpcre2-8")
+@@ -38,6 +40,9 @@ elseif(REGEX_BACKEND STREQUAL "pcre")
+ 	add_feature_info(regex ON "using system PCRE")
+ 	set(GIT_REGEX_PCRE 1)
  
 +	find_package(PkgConfig REQUIRED)
 +	pkg_check_modules(PCRE REQUIRED libpcre)
 +	set(PCRE_LIBRARIES "${PCRE_LINK_LIBRARIES}")
- 	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${PCRE2_INCLUDE_DIRS})
- 	list(APPEND LIBGIT2_SYSTEM_LIBS ${PCRE2_LIBRARIES})
- 	list(APPEND LIBGIT2_PC_REQUIRES "libpcre2-8")
+ 	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${PCRE_INCLUDE_DIRS})
+ 	list(APPEND LIBGIT2_SYSTEM_LIBS ${PCRE_LIBRARIES})
+ 	list(APPEND LIBGIT2_PC_REQUIRES "libpcre")
 diff --git a/cmake/SelectSSH.cmake b/cmake/SelectSSH.cmake
 index a925579..5a2a677 100644
 --- a/cmake/SelectSSH.cmake

--- a/ports/libgit2/dependencies.diff
+++ b/ports/libgit2/dependencies.diff
@@ -1,8 +1,8 @@
 diff --git a/cmake/SelectRegex.cmake b/cmake/SelectRegex.cmake
-index 2a3a91b..523fa72 100644
+index 840ec7f..9533202 100644
 --- a/cmake/SelectRegex.cmake
 +++ b/cmake/SelectRegex.cmake
-@@ -17,7 +17,9 @@ if(REGEX_BACKEND STREQUAL "regcomp_l")
+@@ -22,7 +22,9 @@ if(REGEX_BACKEND STREQUAL "regcomp_l")
  	add_feature_info(regex ON "using system regcomp_l")
  	set(GIT_REGEX_REGCOMP_L 1)
  elseif(REGEX_BACKEND STREQUAL "pcre2")
@@ -13,22 +13,22 @@ index 2a3a91b..523fa72 100644
  
  	if(NOT PCRE2_FOUND)
  		MESSAGE(FATAL_ERROR "PCRE2 support was requested but not found")
-@@ -33,6 +35,9 @@ elseif(REGEX_BACKEND STREQUAL "pcre")
- 	add_feature_info(regex ON "using system PCRE")
- 	set(GIT_REGEX_PCRE 1)
+@@ -31,6 +33,9 @@ elseif(REGEX_BACKEND STREQUAL "pcre2")
+ 	add_feature_info(regex ON "using system PCRE2")
+ 	set(GIT_REGEX_PCRE2 1)
  
 +	find_package(PkgConfig REQUIRED)
 +	pkg_check_modules(PCRE REQUIRED libpcre)
 +	set(PCRE_LIBRARIES "${PCRE_LINK_LIBRARIES}")
- 	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${PCRE_INCLUDE_DIRS})
- 	list(APPEND LIBGIT2_SYSTEM_LIBS ${PCRE_LIBRARIES})
- 	list(APPEND LIBGIT2_PC_REQUIRES "libpcre")
+ 	list(APPEND LIBGIT2_SYSTEM_INCLUDES ${PCRE2_INCLUDE_DIRS})
+ 	list(APPEND LIBGIT2_SYSTEM_LIBS ${PCRE2_LIBRARIES})
+ 	list(APPEND LIBGIT2_PC_REQUIRES "libpcre2-8")
 diff --git a/cmake/SelectSSH.cmake b/cmake/SelectSSH.cmake
-index 079857f50..a2e2bd212 100644
+index a925579..5a2a677 100644
 --- a/cmake/SelectSSH.cmake
 +++ b/cmake/SelectSSH.cmake
 @@ -4,7 +4,11 @@ if(USE_SSH STREQUAL "exec")
-
+ 
  	add_feature_info(SSH ON "using OpenSSH exec support")
  elseif(USE_SSH STREQUAL ON OR USE_SSH STREQUAL "libssh2")
 -	find_pkglibraries(LIBSSH2 libssh2)
@@ -37,7 +37,6 @@ index 079857f50..a2e2bd212 100644
 +	set(LIBSSH2_LIBRARIES "${LIBSSH2_LINK_LIBRARIES}")
 +	set(LIBSSH2_LDFLAGS "")
 +	list(APPEND LIBGIT2_PC_REQUIRES "libssh2")
-
- 	if(NOT LIBSSH2_FOUND)
- 		find_package(LibSSH2)
-
+ 
+ 	if(LIBSSH2_FOUND)
+ 		set(LIBSSH2_FOUND_PKGCONFIG 1)

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libgit2/libgit2
     REF "v${VERSION}"
-    SHA512 b9ac2d0a7cc92a31057fbf066e47145cdda89ebf0489d712d4452c709c3de9923a93a3c37128fdcfd8fbb5498f513a519a7f2a77ad6ef4efafe865323d481f18
+    SHA512 5359d07b85b691b92784d5ef52825be2c1f1616bab8e969e51177bf8f5e767edbaf267943296407f62df1f3d7fa08e48c802374289046b71da2cc1ac7d43a15f
     HEAD_REF main
     PATCHES
         c-standard.diff # for 'inline' in system headers

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgit2",
-  "version-semver": "1.9.2",
+  "version-semver": "1.9.3",
   "description": "A C library implementing the Git core methods with a solid API",
   "homepage": "https://github.com/libgit2/libgit2",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5029,7 +5029,7 @@
       "port-version": 0
     },
     "libgit2": {
-      "baseline": "1.9.2",
+      "baseline": "1.9.3",
       "port-version": 0
     },
     "libgme": {

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4aa7c5a15e5957aff56c55849e83c73c67af9000",
+      "version-semver": "1.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "2fd041b43ab1c68f47f7a23ff487e7dfe3f92d30",
       "version-semver": "1.9.2",
       "port-version": 0

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4aa7c5a15e5957aff56c55849e83c73c67af9000",
+      "git-tree": "8edcfd58769b34a0911a9515a5b64841ce6c31ca",
       "version-semver": "1.9.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libgit2/libgit2/releases/tag/v1.9.3
