### PR TITLE
[eccodes] Fix eccodes CMake config path after vcpkg fixup

### DIFF
--- a/ports/eccodes/portfile.cmake
+++ b/ports/eccodes/portfile.cmake
@@ -85,6 +85,17 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eccodes)
+
+# vcpkg_cmake_config_fixup moves upstream's config files from lib/cmake/eccodes
+# to share/eccodes. The upstream config still validates eccodes_CMAKE_DIR
+# against the original lib/cmake/eccodes path, which no longer exists after
+# fixup. Keep it pointing at the moved vcpkg config directory.
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/eccodes-config.cmake"
+    [[${PACKAGE_PREFIX_DIR}/lib/cmake/eccodes]]
+    [[${PACKAGE_PREFIX_DIR}/share/eccodes]]
+)
+
 vcpkg_fixup_pkgconfig()
 
 set(_eccodes_tool_names

--- a/ports/eccodes/vcpkg.json
+++ b/ports/eccodes/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eccodes",
   "version": "2.47.0",
+  "port-version": 1,
   "description": "ECMWF GRIB, BUFR and GTS decoding and encoding library and tools",
   "homepage": "https://github.com/ecmwf/eccodes",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2746,7 +2746,7 @@
     },
     "eccodes": {
       "baseline": "2.47.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ecm": {
       "baseline": "6.25.0",

--- a/versions/e-/eccodes.json
+++ b/versions/e-/eccodes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "200f406e036a844040064fd5ec808ce8543837bd",
+      "version": "2.47.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e0656f9403a69d03b2d32dda7f65466d9952e27",
       "version": "2.47.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Fix eccodes_CMAKE_DIR after CMake config fixup

vcpkg_cmake_config_fixup moves the ecCodes CMake package files from
lib/cmake/eccodes to share/eccodes. However, the generated
eccodes-config.cmake still sets eccodes_CMAKE_DIR to the original
lib/cmake/eccodes path, causing find_package(eccodes) to fail because
that directory no longer exists.

Patch eccodes-config.cmake after fixup so eccodes_CMAKE_DIR points to
the relocated share/eccodes directory.