### PR TITLE
[openxr-loader] update to 1.1.59

### DIFF
--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/OpenXR-SDK-Source
     REF "release-${VERSION}"
-    SHA512 df3f3617e174636a59995a2260846381929f1131d5bca600b83c3cb92f1f5a04fe4ab86b8d7b305110e9234de3f5319e26a278faa219fadc6741553a4a63bd27
+    SHA512 1c3bc960f99d34c8c17939bcafdc358d01290a56da182f2ddc3b61c75b84330370d2666afc29e8e02aed42530a09fc00f37aa35b0f4bde3f86f258781a0cc681
     HEAD_REF master
     PATCHES
         fix-openxr-sdk-jsoncpp.patch

--- a/ports/openxr-loader/vcpkg.json
+++ b/ports/openxr-loader/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openxr-loader",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "A royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices",
   "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7465,7 +7465,7 @@
       "port-version": 0
     },
     "openxr-loader": {
-      "baseline": "1.1.58",
+      "baseline": "1.1.59",
       "port-version": 0
     },
     "openzl": {

--- a/versions/o-/openxr-loader.json
+++ b/versions/o-/openxr-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebdd08984dddfdc4b18e24b9cd1f47d5e9914744",
+      "version": "1.1.59",
+      "port-version": 0
+    },
+    {
       "git-tree": "c38b9a55cc961efaf23f12d1f7f0417f5f694d6a",
       "version": "1.1.58",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/KhronosGroup/OpenXR-SDK/releases/tag/release-1.1.59
