### PR TITLE
[pxlib] enable iconv on Windows

### DIFF
--- a/ports/pxlib/portfile.cmake
+++ b/ports/pxlib/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         add_cmake_config.patch
         add_extern_c.patch
+        use_modern_find_iconv.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pxlib/use_modern_find_iconv.patch
+++ b/ports/pxlib/use_modern_find_iconv.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b2af5c..f9484ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,23 +36,10 @@ check_include_file("gsf/gsf-input-stdio.h" HAVE_GSF_GSFINPUTSTDIO_H)
+ include(CheckFunctionExists)
+ include(CheckLibraryExists)
+ 
+-# Check for iconv
+-if(HAVE_ICONV_H)
+-    # First check if iconv is in libc
+-    check_function_exists(iconv ICONV_IN_LIBC)
+-    
+-    if(NOT ICONV_IN_LIBC)
+-        # Check if iconv is in a separate library
+-        check_library_exists(iconv iconv "" HAVE_ICONV_LIB)
+-        if(HAVE_ICONV_LIB)
+-            set(ICONV_LIBRARIES iconv)
+-        endif()
+-    endif()
+-    
+-    if(ICONV_IN_LIBC OR HAVE_ICONV_LIB)
+-        set(HAVE_ICONV 1)
+-    endif()
+-endif()
++# Check for iconv via CMake's modern Iconv module (CMake 3.11+)
++find_package(Iconv REQUIRED)
++set(HAVE_ICONV 1)
++set(ICONV_LIBRARIES Iconv::Iconv)
+ 
+ # Endianess
+ include(TestBigEndian)

--- a/ports/pxlib/use_modern_find_iconv.patch
+++ b/ports/pxlib/use_modern_find_iconv.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0b2af5c..f9484ad 100644
+index 0b2af5c..9214e66 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -36,23 +36,10 @@ check_include_file("gsf/gsf-input-stdio.h" HAVE_GSF_GSFINPUTSTDIO_H)
+@@ -36,22 +36,11 @@ check_include_file("gsf/gsf-input-stdio.h" HAVE_GSF_GSFINPUTSTDIO_H)
  include(CheckFunctionExists)
  include(CheckLibraryExists)
  
@@ -22,11 +22,11 @@ index 0b2af5c..f9484ad 100644
 -    if(ICONV_IN_LIBC OR HAVE_ICONV_LIB)
 -        set(HAVE_ICONV 1)
 -    endif()
--endif()
 +# Check for iconv via CMake's modern Iconv module (CMake 3.11+)
-+find_package(Iconv REQUIRED)
-+set(HAVE_ICONV 1)
-+set(ICONV_LIBRARIES Iconv::Iconv)
++find_package(Iconv)
++if(Iconv_FOUND)
++    set(HAVE_ICONV 1)
++    set(ICONV_LIBRARIES Iconv::Iconv)
+ endif()
  
  # Endianess
- include(TestBigEndian)

--- a/ports/pxlib/vcpkg.json
+++ b/ports/pxlib/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "pxlib",
   "version-date": "2025-12-16",
+  "port-version": 1,
   "description": "Library to read and write Paradox files",
   "homepage": "https://github.com/steinm/pxlib",
   "license": "GPL-2.0-only",
   "dependencies": [
+    "libiconv",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8042,7 +8042,7 @@
     },
     "pxlib": {
       "baseline": "2025-12-16",
-      "port-version": 0
+      "port-version": 1
     },
     "pybind11": {
       "baseline": "3.0.1",

--- a/versions/p-/pxlib.json
+++ b/versions/p-/pxlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44e1032ef50f0c39102264499e3d12fd9f90bb70",
+      "git-tree": "4a7d87174536037ba5e747f6f02bf752fa1bd70d",
       "version-date": "2025-12-16",
       "port-version": 1
     },

--- a/versions/p-/pxlib.json
+++ b/versions/p-/pxlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44e1032ef50f0c39102264499e3d12fd9f90bb70",
+      "version-date": "2025-12-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "ddcb41f51c9979a88cbe574679b7bdac6eaaf509",
       "version-date": "2025-12-16",
       "port-version": 0


### PR DESCRIPTION
The pxlib port was previously published with `PX_USE_ICONV=0`, which renders pxlib's `PX_set_targetencoding()` API a silent no-op on Windows. Consumers reading Paradox `.DB` files with CP437 or CP850 codepages get raw single-byte data instead of the requested target encoding, and have no signal that the API didn't work — they're forced to write Win32-`MultiByteToWideChar` workarounds.

### Root cause

Upstream pxlib's `CMakeLists.txt` (lines 39–55) detects iconv with the legacy pair:

```cmake
check_include_file("iconv.h" HAVE_ICONV_H)
...
check_library_exists(iconv iconv "" HAVE_ICONV_LIB)
```

The second check fails against vcpkg's `libiconv` because the installed `iconv.lib` doesn't expose a bare `iconv` symbol findable by `check_library_exists` (it exports `libiconv`, `iconv_open`, etc.). So `HAVE_ICONV_LIB` stays undefined, `HAVE_ICONV` is never set, and `PX_HAVE_ICONV` (line 62) is forced to 0. The generated `paradox.h` ends up with `#define PX_USE_ICONV 0`.

Adding `libiconv` to `dependencies` alone is not enough — the upstream detection logic itself has to be fixed.

### Fix

1. Add `libiconv` to `dependencies` in `vcpkg.json`.
2. Patch upstream `CMakeLists.txt` (`use_modern_find_iconv.patch`) to use CMake's built-in `FindIconv` module:

```cmake
find_package(Iconv)
if(Iconv_FOUND)
    set(HAVE_ICONV 1)
    set(ICONV_LIBRARIES Iconv::Iconv)
endif()
```

`FindIconv` ships with CMake since 3.11; this project already requires 3.12, so no minimum-version bump is needed. The module handles glibc-iconv, system iconv on macOS, and libiconv on Windows uniformly. The detection is left non-`REQUIRED` to match upstream's existing "build without iconv if iconv isn't available" contract — for vcpkg, `libiconv` is declared as a hard dependency, so `Iconv_FOUND` is always true on this path and `PX_USE_ICONV` resolves to 1.

### Why a patch (not just a dependency)

Per the maintainer guide's "prefer options over patching" principle, the option-only path was attempted first (just adding `libiconv` to `dependencies`). It still produced `PX_USE_ICONV 0` for the reason above, so a patch to the detection logic is required.

The patch is the minimum surgical change to `CMakeLists.txt` (replaces 17 lines with 6) and is upstream-relevant — it's been submitted to upstream pxlib at **steinm/pxlib#14** ([link](https://github.com/steinm/pxlib/pull/14)). The plan is to remove this port-local patch once upstream merges.

### Before / after

`installed/x64-windows/include/paradox.h` line 10:

| Before | After |
|---|---|
| `#define PX_USE_ICONV 0` | `#define PX_USE_ICONV 1` |

`dumpbin /imports installed/x64-windows/bin/pxlib.dll` after the change:

```
    iconv-2.dll        <-- new
    VCRUNTIME140.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
```

Tested on Windows 11 Pro (build 10.0.26200) + MSVC 14.44.35207 (Visual Studio 2022 Community) + vcpkg `libiconv` 1.18#4, triplet `x64-windows`.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. *(no source change — same upstream ref `cd65ac2`)*
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
