### PR TITLE
Add givp: GRASP-ILS-VND with Path Relinking optimizer

### DIFF
--- a/ports/givp/METADATA.json
+++ b/ports/givp/METADATA.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "kind": "port",
+  "port": {
+    "homepage": "https://github.com/Arnime/grasp_ils_vnd_pr",
+    "description": [
+      "GRASP-ILS-VND with Path Relinking optimizer for continuous and mixed-integer black-box optimization.",
+      "Header-only C++17 library implementing a metaheuristic combining GRASP construction, Iterated Local Search,",
+      "Variable Neighborhood Descent, and Path Relinking with elite pool and adaptive alpha refinement."
+    ],
+    "documentation": "https://arnime.github.io/grasp_ils_vnd_pr/",
+    "vcpkg-docs-url": "https://learn.microsoft.com/en-us/vcpkg/",
+    "license": "MIT",
+    "maintainers": [
+      "Arnaldo Mendes Pires Junior <arnaldo.mpires@gmail.com>"
+    ]
+  }
+}

--- a/ports/givp/portfile.cmake
+++ b/ports/givp/portfile.cmake
@@ -24,8 +24,11 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/givp
 )
 
-# Header-only, no need to keep debug files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+# Header-only, no need to keep debug or empty lib directories
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
 
 # Install license
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/givp/portfile.cmake
+++ b/ports/givp/portfile.cmake
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+# SPDX-License-Identifier: MIT
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Arnime/grasp_ils_vnd_pr
+    REF v${VERSION}
+    SHA512 f64004dec9f5913adca5d79ee4c71821aadbc9cd9527680bcfc3d1c6f8511355739fd0b78fa657d2aae0e0f6e2ff47dad1d7e8816e1435e0ae14de7336a5d715
+    FILENAME grasp_ils_vnd_pr-${VERSION}.tar.gz
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/cpp"
+    OPTIONS
+        -DGIVP_BUILD_TESTS=OFF
+        -DGIVP_BUILD_BENCHMARKS=OFF
+        -DGIVP_BUILD_FUZZ=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME givp
+    CONFIG_PATH lib/cmake/givp
+)
+
+# Header-only, no need to keep debug files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+# Install license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/givp/vcpkg.json
+++ b/ports/givp/vcpkg.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "givp",
   "version": "1.0.0",
   "description": "GRASP-ILS-VND with Path Relinking optimizer for continuous and mixed-integer black-box optimization",
@@ -8,7 +7,13 @@
   "license": "MIT",
   "supports": "(windows & !arm) | linux | osx | freebsd",
   "dependencies": [
-    "vcpkg-cmake",
-    "vcpkg-cmake-config"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/givp/vcpkg.json
+++ b/ports/givp/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "givp",
+  "version": "1.0.0",
+  "description": "GRASP-ILS-VND with Path Relinking optimizer for continuous and mixed-integer black-box optimization",
+  "homepage": "https://github.com/Arnime/grasp_ils_vnd_pr",
+  "documentation": "https://arnime.github.io/grasp_ils_vnd_pr/",
+  "license": "MIT",
+  "dependencies": [],
+  "features": {},
+  "supports": "(windows & !arm) | linux | osx | freebsd"
+}

--- a/ports/givp/vcpkg.json
+++ b/ports/givp/vcpkg.json
@@ -6,7 +6,9 @@
   "homepage": "https://github.com/Arnime/grasp_ils_vnd_pr",
   "documentation": "https://arnime.github.io/grasp_ils_vnd_pr/",
   "license": "MIT",
-  "dependencies": [],
-  "features": {},
-  "supports": "(windows & !arm) | linux | osx | freebsd"
+  "supports": "(windows & !arm) | linux | osx | freebsd",
+  "dependencies": [
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3412,6 +3412,10 @@
       "baseline": "1.11.0",
       "port-version": 0
     },
+    "givp": {
+      "port-version": 0,
+      "baseline": "1.0.0"
+    },
     "gklib": {
       "baseline": "2025-07-06",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3413,8 +3413,8 @@
       "port-version": 0
     },
     "givp": {
-      "port-version": 0,
-      "baseline": "1.0.0"
+      "baseline": "1.0.0",
+      "port-version": 0
     },
     "gklib": {
       "baseline": "2025-07-06",

--- a/versions/g-/givp.json
+++ b/versions/g-/givp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e18ec184c3ef90256ad5823047514b56b7098128",
+      "git-tree": "b9fb648c9fe8506d0c073d1eecb494cf70346059",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/g-/givp.json
+++ b/versions/g-/givp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4409a52d22e34c895a95180bc90088fc9cfc2fd5",
+      "git-tree": "e18ec184c3ef90256ad5823047514b56b7098128",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/g-/givp.json
+++ b/versions/g-/givp.json
@@ -1,8 +1,9 @@
 {
   "versions": [
     {
+      "git-tree": "4409a52d22e34c895a95180bc90088fc9cfc2fd5",
       "version": "1.0.0",
-      "git-tree": "4409a52d22e34c895a95180bc90088fc9cfc2fd5"
+      "port-version": 0
     }
   ]
 }

--- a/versions/g-/givp.json
+++ b/versions/g-/givp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9fb648c9fe8506d0c073d1eecb494cf70346059",
+      "git-tree": "3be9f56bdb5b5c1ad8ef6318067568d861ec4cf4",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/g-/givp.json
+++ b/versions/g-/givp.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "git-tree": "4409a52d22e34c895a95180bc90088fc9cfc2fd5"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the givp vcpkg port (ports/givp).

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [X] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [X] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.