### PR TITLE
[zpp-bits] update to 4.7.1

### DIFF
--- a/ports/zpp-bits/portfile.cmake
+++ b/ports/zpp-bits/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalz800/zpp_bits
     REF "v${VERSION}"
-    SHA512 b5df44cb9eaafb1926e6acc795e47673d84206da3e33c5b863fedddee56f5c10b45e1b4b33fe0ee6ca64dab68d44c7b3c981cd04482b7c30e4342f45f6d4258c
+    SHA512 6c82f140b6092114ada23f216a4d2d0299a6cd422069f8660db98bca9b1bb515dfba818dae1b8ca4fadedaa6fa8f3ef98da0e8c50ee2ea2884f559c8a0db5fd1
     HEAD_REF master
 )
 

--- a/ports/zpp-bits/vcpkg.json
+++ b/ports/zpp-bits/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zpp-bits",
-  "version": "4.7",
+  "version": "4.7.1",
   "description": "A lightweight C++20 serialization and RPC library",
   "homepage": "https://github.com/eyalz800/zpp_bits",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11217,7 +11217,7 @@
       "port-version": 4
     },
     "zpp-bits": {
-      "baseline": "4.7",
+      "baseline": "4.7.1",
       "port-version": 0
     },
     "zserge-webview": {

--- a/versions/z-/zpp-bits.json
+++ b/versions/z-/zpp-bits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49bc0dc22b6caf1c3657974e4221769006e7d21c",
+      "version": "4.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a3a33f91322bccec5f5ba5ac74acfd8e4e89b2ee",
       "version": "4.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/eyalz800/zpp_bits/releases/tag/v4.7.1
