### PR TITLE
[aistemsplitter] add port

### DIFF
--- a/ports/aistemsplitter/fix-windows-nominmax.patch
+++ b/ports/aistemsplitter/fix-windows-nominmax.patch
@@ -1,0 +1,14 @@
+diff --git a/src/client.cpp b/src/client.cpp
+index 8cf7f4d..72871dd 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -1,5 +1,9 @@
+ #include "aistemsplitter/client.hpp"
+ 
++#ifdef _WIN32
++#define NOMINMAX
++#endif
++
+ #include <curl/curl.h>
+ 
+ #include <algorithm>

--- a/ports/aistemsplitter/fix-windows-nominmax.patch
+++ b/ports/aistemsplitter/fix-windows-nominmax.patch
@@ -1,14 +1,15 @@
 diff --git a/src/client.cpp b/src/client.cpp
-index 8cf7f4d..72871dd 100644
+index e07f9f0a70..9eb0b3e2ed 100644
 --- a/src/client.cpp
 +++ b/src/client.cpp
-@@ -1,5 +1,9 @@
- #include "aistemsplitter/client.hpp"
- 
+@@ -1 +1,5 @@
 +#ifdef _WIN32
 +#define NOMINMAX
 +#endif
 +
- #include <curl/curl.h>
- 
- #include <algorithm>
+ #include "aistemsplitter/client.hpp"
+@@ -435,3 +439,3 @@ AudioSplit Client::wait_for_split(const std::string& split_id,
+         deadline - std::chrono::steady_clock::now());
+-    sleep_(std::min(interval, remaining));
++    sleep_((std::min)(interval, remaining));
+   }

--- a/ports/aistemsplitter/portfile.cmake
+++ b/ports/aistemsplitter/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v0.1.0
     SHA512 17279384bd6b993b669778b3034d2fb7266d718e62e053f372e5c326ee02bccde8c3c011ef0755b92eb74005822ef64742121893fc5440a46d116d05dcc1c5c9
     HEAD_REF main
+    PATCHES
+        fix-windows-nominmax.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/aistemsplitter/portfile.cmake
+++ b/ports/aistemsplitter/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO aistemsplitter/aistemsplitter-cpp
+    REF v0.1.0
+    SHA512 17279384bd6b993b669778b3034d2fb7266d718e62e053f372e5c326ee02bccde8c3c011ef0755b92eb74005822ef64742121893fc5440a46d116d05dcc1c5c9
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAISTEMSPLITTER_BUILD_TESTS=OFF
+        -DAISTEMSPLITTER_BUILD_EXAMPLES=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/aistemsplitter)
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/aistemsplitter/aistemsplitterConfig.cmake" [[
+include(CMakeFindDependencyMacro)
+find_dependency(CURL)
+include("${CMAKE_CURRENT_LIST_DIR}/aistemsplitterTargets.cmake")
+]])
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aistemsplitter/vcpkg.json
+++ b/ports/aistemsplitter/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "aistemsplitter",
+  "version": "0.1.0",
+  "description": "Official C++ SDK for the AIStemSplitter public API.",
+  "homepage": "https://aistemsplitter.org",
+  "license": "MIT",
+  "dependencies": [
+    "curl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/aistemsplitter.json
+++ b/versions/a-/aistemsplitter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89d90b87c305e6311388a4b5f55c58a3536562e4",
+      "git-tree": "ecc312784456fae8319569ed3c819ce81fcc0ef8",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/a-/aistemsplitter.json
+++ b/versions/a-/aistemsplitter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10bc9d659196efea05379fe9d523dbe06ec55f3a",
+      "git-tree": "89d90b87c305e6311388a4b5f55c58a3536562e4",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/a-/aistemsplitter.json
+++ b/versions/a-/aistemsplitter.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "10bc9d659196efea05379fe9d523dbe06ec55f3a",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -68,6 +68,10 @@
       "baseline": "1.1.2",
       "port-version": 3
     },
+    "aistemsplitter": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "aixlog": {
       "baseline": "1.5.0",
       "port-version": 1


### PR DESCRIPTION
Adds the aistemsplitter C++ SDK port at v0.1.0.\n\nValidation run locally on macOS arm64:\n- ./vcpkg format-manifest ports/aistemsplitter/vcpkg.json\n- ./vcpkg x-add-version aistemsplitter --overwrite-version --verbose\n- ./vcpkg install aistemsplitter --disable-metrics\n- ./vcpkg x-ci-verify-versions --verbose\n- git diff --check