### PR TITLE
[pxlib] Fix iconv handle sentinel check for Windows compatibility (port-version 2)

### DIFF
--- a/ports/pxlib/fix_iconv_handle_check.patch
+++ b/ports/pxlib/fix_iconv_handle_check.patch
@@ -1,0 +1,22 @@
+diff --git a/src/px_encode.c b/src/px_encode.c
+index 112ef43..0000000 100644
+--- a/src/px_encode.c
++++ b/src/px_encode.c
+@@ -46,7 +46,7 @@ int px_set_targetencoding(pxdoc_t *pxdoc) {
+ #if PX_USE_ICONV
+ 		char buffer[30];
+ 		sprintf(buffer, "CP%d", pxdoc->px_head->px_doscodepage);
+-		if(pxdoc->out_iconvcd > 0)
++		if(pxdoc->out_iconvcd != (iconv_t) -1)
+ 			iconv_close(pxdoc->out_iconvcd);
+ 		if((iconv_t)(-1) == (pxdoc->out_iconvcd = iconv_open(pxdoc->targetencoding, buffer))) {
+ 			return -1;
+@@ -74,7 +74,7 @@ int px_set_inputencoding(pxdoc_t *pxdoc) {
+ #if PX_USE_ICONV
+ 		char buffer[30];
+ 		sprintf(buffer, "CP%d", pxdoc->px_head->px_doscodepage);
+-		if(pxdoc->in_iconvcd > 0)
++		if(pxdoc->in_iconvcd != (iconv_t) -1)
+ 			iconv_close(pxdoc->in_iconvcd);
+ 		if((iconv_t)(-1) == (pxdoc->in_iconvcd = iconv_open(buffer, pxdoc->inputencoding))) {
+ 			return -1;

--- a/ports/pxlib/portfile.cmake
+++ b/ports/pxlib/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         add_cmake_config.patch
         add_extern_c.patch
         use_modern_find_iconv.patch
+        fix_iconv_handle_check.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pxlib/vcpkg.json
+++ b/ports/pxlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pxlib",
   "version-date": "2025-12-16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library to read and write Paradox files",
   "homepage": "https://github.com/steinm/pxlib",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8050,7 +8050,7 @@
     },
     "pxlib": {
       "baseline": "2025-12-16",
-      "port-version": 1
+      "port-version": 2
     },
     "pybind11": {
       "baseline": "3.0.1",

--- a/versions/p-/pxlib.json
+++ b/versions/p-/pxlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc74a2af9e402cd11e56cc7e9088b4208b95d0b3",
+      "version-date": "2025-12-16",
+      "port-version": 2
+    },
+    {
       "git-tree": "4a7d87174536037ba5e747f6f02bf752fa1bd70d",
       "version-date": "2025-12-16",
       "port-version": 1


### PR DESCRIPTION
Follows #51615 (port-version 1, iconv support on Windows).

Fixes a Windows-only crash: `pxlib` initialises `out_iconvcd` /
`in_iconvcd` to `(iconv_t)-1` as the "no open handle" sentinel. On
Windows, `iconv_t` is pointer-sized so `(iconv_t)-1 == 0xFFFFFFFFFFFFFFFF`,
which is `> 0`. The guard `if(pxdoc->out_iconvcd > 0)` therefore fires on
the first call to `PX_set_targetencoding` / `PX_set_inputencoding` before
any real handle is open, causing `iconv_close((iconv_t)-1)` →
`free(invalid ptr)` → `STATUS_HEAP_CORRUPTION` in the Windows debug heap.

The patch replaces `> 0` with `!= (iconv_t) -1`, consistent with the
cleanup code already in `paradox.c`. Companion upstream PR:
[steinm/pxlib#15](https://github.com/steinm/pxlib/pull/15).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. *(N/A — source REF and SHA512 are unchanged; only a new patch file is added.)*
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary. *(N/A — this port has no `supports` field.)*
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed. *(N/A — pxlib has no CI baseline entries.)*
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.