### PR TITLE
[podofo] Revise port for 1.1.0 release

### DIFF
--- a/ports/podofo/dependencies.diff
+++ b/ports/podofo/dependencies.diff
@@ -1,50 +1,44 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 54a90f1..e40c529 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -301,6 +301,7 @@ if(JPEG_FOUND)
-     string(APPEND PODOFO_PKGCONFIG_REQUIRES_PRIVATE " libjpeg")
- endif()
- list(APPEND PODOFO_LIB_DEPENDS ZLIB::ZLIB)
-+string(APPEND PODOFO_PKGCONFIG_REQUIRES_PRIVATE " libutf8proc")
- string(APPEND PODOFO_PKGCONFIG_REQUIRES_PRIVATE " zlib")
- if (PODOFO_DEVENDOR_TCBSPAN)
-     list(APPEND PODOFO_LIB_DEPENDS $<COMPILE_ONLY:tcbspan::tcbspan>)
-@@ -354,6 +355,25 @@ add_subdirectory(3rdparty)
- add_subdirectory(src/podofo)
- include_directories(${PODOFO_INCLUDE_DIRS})
+diff --git a/3rdparty/CMakeLists.txt b/3rdparty/CMakeLists.txt
+index a539c776..7cc32371 100644
+--- a/3rdparty/CMakeLists.txt
++++ b/3rdparty/CMakeLists.txt
+@@ -22,7 +22,11 @@ endif()
+ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/adobe/afdko/resource")
+ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/adobe/afdko/include")
+ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/chromium")
+-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/tcbspan")
  
-+find_package(date CONFIG REQUIRED)
-+find_package(FastFloat CONFIG REQUIRED)
-+find_package(fmt CONFIG REQUIRED)
-+find_package(utf8cpp CONFIG REQUIRED)
-+find_package(utf8proc CONFIG REQUIRED)
-+
-+target_link_libraries(podofo_private PRIVATE
-+    $<COMPILE_ONLY:date::date>
-+    $<COMPILE_ONLY:FastFloat::fast_float>
-+    $<COMPILE_ONLY:fmt::fmt-header-only>
-+    $<COMPILE_ONLY:utf8cpp::utf8cpp>
-+    utf8proc::utf8proc
-+)
-+if(PODOFO_BUILD_STATIC)
-+    target_link_libraries(podofo_static $<COMPILE_ONLY:utf8cpp::utf8cpp>)
+ add_library(podofo_3rdparty STATIC ${SOURCE_FILES})
+ target_link_libraries(podofo_3rdparty LibXml2::LibXml2)
++if (PODOFO_DEVENDOR_TCBSPAN)
++    target_link_libraries(podofo_3rdparty "$<COMPILE_ONLY:tcbspan::tcbspan>")
 +else()
-+    target_link_libraries(podofo_shared PRIVATE $<COMPILE_ONLY:utf8cpp::utf8cpp>)
++    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/tcbspan")
 +endif()
-+
- if(PODOFO_BUILD_TEST)
-     enable_testing()
-     add_subdirectory(test)
+diff --git a/src/podofo/auxiliary/span.h b/src/podofo/auxiliary/span.h
+index d484b775..3a307747 100644
+--- a/src/podofo/auxiliary/span.h
++++ b/src/podofo/auxiliary/span.h
+@@ -2,7 +2,7 @@
+ #define AUX_SPAN_H
+ #pragma once
+ 
+-#include <podofo/3rdparty/span.hpp>
++#include <tcb/span.hpp>
+ 
+ namespace PoDoFo
+ {
 diff --git a/src/podofo/podofo-config.cmake.in b/src/podofo/podofo-config.cmake.in
-index 700619b..b2d75f6 100644
+index 700619bb..87529246 100644
 --- a/src/podofo/podofo-config.cmake.in
 +++ b/src/podofo/podofo-config.cmake.in
-@@ -2,6 +2,7 @@
+@@ -2,6 +2,9 @@
  
  if("@PODOFO_BUILD_STATIC@")
      include(CMakeFindDependencyMacro)
-+    find_dependency(utf8proc CONFIG)
++    if("@PODOFO_DEVENDOR_UTF8PROC@")
++        find_dependency(utf8proc CONFIG)
++    endif()
      if("@Fontconfig_FOUND@")
          find_dependency(Fontconfig)
      endif()

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -8,8 +8,10 @@ vcpkg_from_github(
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/3rdparty/date"
-    "${SOURCE_PATH}/3rdparty/fast_float.h"
-    "${SOURCE_PATH}/3rdparty/fmt"
+    "${SOURCE_PATH}/3rdparty/fastfloat"
+    "${SOURCE_PATH}/3rdparty/fmtlib"
+    "${SOURCE_PATH}/3rdparty/tcbspan"
+    "${SOURCE_PATH}/3rdparty/tclap"
     "${SOURCE_PATH}/3rdparty/utf8cpp"
     "${SOURCE_PATH}/3rdparty/utf8proc"
 )
@@ -28,6 +30,13 @@ vcpkg_cmake_configure(
         -DPKG_CONFIG_FOUND=true # enable pc file for shared linkage
         -DPODOFO_BUILD_LIB_ONLY=1
         -DPODOFO_BUILD_STATIC=${PODOFO_BUILD_STATIC}
+        -DPODOFO_DEVENDOR_DATE=1
+        -DPODOFO_DEVENDOR_FASTFLOAT=1
+        -DPODOFO_DEVENDOR_FMT=1
+        -DPODOFO_DEVENDOR_FMT_HEADER_ONLY=1
+        -DPODOFO_DEVENDOR_TCBSPAN=1
+        -DPODOFO_DEVENDOR_UTF8CPP=1
+        -DPODOFO_DEVENDOR_UTF8PROC=1
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "podofo",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://github.com/podofo/podofo",
   "license": "LGPL-2.0-or-later OR MPL-2.0",
@@ -9,7 +10,10 @@
     "date",
     "fast-float",
     "fmt",
-    "freetype",
+    {
+      "name": "freetype",
+      "default-features": false
+    },
     "libjpeg-turbo",
     "libpng",
     {
@@ -17,6 +21,7 @@
       "default-features": false
     },
     "openssl",
+    "tcb-span",
     {
       "name": "tiff",
       "default-features": false
@@ -40,7 +45,10 @@
     "fontconfig": {
       "description": "Use Fontconfig",
       "dependencies": [
-        "fontconfig"
+        {
+          "name": "fontconfig",
+          "default-features": false
+        }
       ]
     },
     "fontmanager": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7850,7 +7850,7 @@
     },
     "podofo": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "poissonrecon": {
       "baseline": "2021-09-26",

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "571a8c0a07bc5ed3a4a4cf9a4e9e30573453cf5c",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9647a08fffc0ba477c87819ab0a1a4e4e1abd452",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/pull/51521#issuecomment-4409266135.

@czetko 
- Upstream tcb-span devendoring is incomplete, hidden by the vendored copy.
  The transitive usage requirement in `span.h` was only noticed when building a test port.
- utf8-proc devendoring needs help in CMake config.
- `3rdparty/tclap` seems unused as far as `git grep tclap` can tell.