### PR TITLE
[vectorscan] add chimera feature

### DIFF
--- a/ports/vectorscan/enable-chimera.patch
+++ b/ports/vectorscan/enable-chimera.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 577f90e..e8e2f81 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -210,8 +210,9 @@ if (NOT CORRECT_PCRE_VERSION)
+ endif()
+ 
+ # we need static libs for Chimera - too much deep magic for shared libs
+-if (CORRECT_PCRE_VERSION AND PCRE_BUILD_SOURCE AND BUILD_STATIC_LIBS)
+-    set(BUILD_CHIMERA TRUE)
++option(BUILD_CHIMERA "Build Chimera" OFF)
++if (BUILD_CHIMERA AND NOT CORRECT_PCRE_VERSION)
++    message(FATAL_ERROR "Chimera requires PCRE 8.41+")
+ endif()
+ 
+ set(RAGEL_C_FLAGS "-Wno-unused -funsigned-char")
+diff --git a/chimera/CMakeLists.txt b/chimera/CMakeLists.txt
+index c3c50c3..8f1bd3c 100644
+--- a/chimera/CMakeLists.txt
++++ b/chimera/CMakeLists.txt
+@@ -28,8 +28,13 @@ SET(chimera_SRCS
+ )
+ 
+ add_library(chimera STATIC ${chimera_SRCS})
+-add_dependencies(chimera hs pcre)
+-target_link_libraries(chimera hs pcre)
++add_dependencies(chimera hs)
++if (PCRE_BUILD_SOURCE)
++    add_dependencies(chimera pcre)
++    target_link_libraries(chimera hs pcre)
++else()
++    target_link_libraries(chimera hs ${PCRE_LIBRARIES})
++endif()
+ 
+ install(TARGETS chimera DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 

--- a/ports/vectorscan/enable-chimera.patch
+++ b/ports/vectorscan/enable-chimera.patch
@@ -33,4 +33,5 @@ index c3c50c3..8f1bd3c 100644
 +endif()
  
  install(TARGETS chimera DESTINATION ${CMAKE_INSTALL_LIBDIR})
- 
+
+

--- a/ports/vectorscan/fix-libch-pkgconfig.patch
+++ b/ports/vectorscan/fix-libch-pkgconfig.patch
@@ -1,0 +1,17 @@
+diff --git a/chimera/CMakeLists.txt b/chimera/CMakeLists.txt
+index c3c50c3..d23c458 100644
+--- a/chimera/CMakeLists.txt
++++ b/chimera/CMakeLists.txt
+@@ -43,7 +43,11 @@ foreach (LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
+         set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
+     endif()
+ endforeach()
+-set(PRIVATE_LIBS "${PRIVATE_LIBS} -L${LIBDIR} -lpcre")
++if (PCRE_BUILD_SOURCE)
++    set(PRIVATE_LIBS "${PRIVATE_LIBS} -L${LIBDIR} -lpcre")
++else()
++    set(PRIVATE_LIBS "${PRIVATE_LIBS} ${PCRE_LDFLAGS}")
++endif()
+ 
+ configure_file(libch.pc.in libch.pc @ONLY) # only replace @ quoted vars
+ install(FILES ${CMAKE_BINARY_DIR}/chimera/libch.pc

--- a/ports/vectorscan/portfile.cmake
+++ b/ports/vectorscan/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         remove-Werror.patch
         enable-chimera.patch
+        fix-libch-pkgconfig.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/vectorscan/portfile.cmake
+++ b/ports/vectorscan/portfile.cmake
@@ -6,10 +6,12 @@ vcpkg_from_github(
     HEAD_REF develop
     PATCHES
         remove-Werror.patch
+        enable-chimera.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        chimera         BUILD_CHIMERA
         dump            DUMP_SUPPORT
 )
 

--- a/ports/vectorscan/vcpkg.json
+++ b/ports/vectorscan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vectorscan",
   "version": "5.4.12",
+  "port-version": 1,
   "description": "A portable fork of the high-performance regular expression matching library",
   "homepage": "https://vectorcamp.gr/project/vectorscan/",
   "license": "BSD-3-Clause",
@@ -34,6 +35,12 @@
     }
   ],
   "features": {
+    "chimera": {
+      "description": "PCRE-compatible API",
+      "dependencies": [
+        "pcre"
+      ]
+    },
     "dump": {
       "description": "Dump code support"
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10574,7 +10574,7 @@
     },
     "vectorscan": {
       "baseline": "5.4.12",
-      "port-version": 0
+      "port-version": 1
     },
     "veigar": {
       "baseline": "1.4",

--- a/versions/v-/vectorscan.json
+++ b/versions/v-/vectorscan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dab6b125d89d259630b3f2cf1dd47846e2c690ed",
+      "git-tree": "f4646a6fc92549991bf0d88e997c9aca440c28cd",
       "version": "5.4.12",
       "port-version": 1
     },

--- a/versions/v-/vectorscan.json
+++ b/versions/v-/vectorscan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dab6b125d89d259630b3f2cf1dd47846e2c690ed",
+      "version": "5.4.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "270483f40e6971ca7272a14bf14715ae671f91e6",
       "version": "5.4.12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The `chimera` feature uses pcre library. (not pcre2)