### PR TITLE
Make sure Serf can build on Visual Studio 2026.

### DIFF
--- a/ports/serf/portfile.cmake
+++ b/ports/serf/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
+      vs_2026.diff
       dependencies.diff
 )
 

--- a/ports/serf/vs_2026.diff
+++ b/ports/serf/vs_2026.diff
@@ -1,0 +1,27 @@
+diff --git a/SConstruct b/SConstruct
+--- a/SConstruct
++++ b/SConstruct
+@@ -203,21 +203,8 @@
+                       'ARM64': 'arm64'
+                      }),
+ 
+-    EnumVariable('MSVC_VERSION',
+-                 "Visual C++ to use for building",
+-                 None,
+-                 allowed_values=('14.3', '14.2', '14.1', '14.0', '12.0',
+-                                 '11.0', '10.0', '9.0', '8.0', '6.0'),
+-                 map={'2005' :  '8.0',
+-                      '2008' :  '9.0',
+-                      '2010' : '10.0',
+-                      '2012' : '11.0',
+-                      '2013' : '12.0',
+-                      '2015' : '14.0',
+-                      '2017' : '14.1',
+-                      '2019' : '14.2',
+-                      '2022' : '14.3',
+-                     }),
++    ('MSVC_VERSION', "Visual C++ to use for building (see " +
++     "https://scons.org/doc/latest/HTML/scons-user.html#cv-MSVC_VERSION)", None),
+ 
+     # We always documented that we handle an install layout, but in fact we
+     # hardcoded source layouts. Allow disabling this behavior.


### PR DESCRIPTION
Based on Serf trunk commit r1933327.

Add a new patch and update portfile to apply the patch.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [n/a] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [n/a] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [n/a] Exactly one version is added in each modified versions file.
