### PR TITLE
[ctre] update to 3.11.0

### DIFF
--- a/ports/ctre/portfile.cmake
+++ b/ports/ctre/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hanickadot/compile-time-regular-expressions
     REF "v${VERSION}"
-    SHA512 4bed66b8adbf1de4f73963370e8b210787ace2f50d956cac141f1353c6a4e0ed0dcd62eb61cf54ae3e64875752ffdc04b67985a25aa50a2a245bc9039ab39f46
+    SHA512 a973f0485db23b4f595cf312f2e89fbc1ec2b2ee77ffb88975c8130089df3c73dbe3cbc56ab60c11abd8d84b3d11887a295485d5cf67f551d5e56ab85a98382e
     HEAD_REF main
 )
 

--- a/ports/ctre/vcpkg.json
+++ b/ports/ctre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ctre",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "A Compile time PCRE (almost) compatible regular expression matcher",
   "homepage": "https://github.com/hanickadot/compile-time-regular-expressions",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2249,7 +2249,7 @@
       "port-version": 2
     },
     "ctre": {
-      "baseline": "3.10.0",
+      "baseline": "3.11.0",
       "port-version": 0
     },
     "ctstraffic": {

--- a/versions/c-/ctre.json
+++ b/versions/c-/ctre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b610b6b0d29c81fe2d3671a1542963f16bb7cc0",
+      "version": "3.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "33e1d6f404d8374a60c29037b3b5b2516a73ca88",
       "version": "3.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/hanickadot/compile-time-regular-expressions/releases/tag/v3.11.0
