### PR TITLE
[hamlib] New port

### DIFF
--- a/ports/hamlib/portfile.cmake
+++ b/ports/hamlib/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Hamlib/Hamlib
+    REF "${VERSION}"
+    SHA512 84541adc1de2132d272a823c21a80376da8effe0be4afd41e8f4bf4b2bf714b2abf8418ed0d21491f961cbe358cff2718a07b499d6277a9292f81ce2b1eee92f
+)
+
+vcpkg_list(SET options)
+if("usb" IN_LIST FEATURES)
+    list(APPEND options --with-libusb=yes)
+else()
+    list(APPEND options --with-libusb=no)
+endif()
+if("xml" IN_LIST FEATURES)
+    list(APPEND options --with-xml-support=yes)
+else()
+    list(APPEND options --with-xml-support=no)
+endif()
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    OPTIONS
+        ${options}
+        --with-cxx-binding=yes
+        --with-indi=no     # needs libindi/libnova
+        --with-readline=no # needs readline
+        --enable-html-matrix=no  # needs libgd
+        --enable-usrp=no
+
+)
+vcpkg_make_install()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hamlib/vcpkg.json
+++ b/ports/hamlib/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "hamlib",
+  "version": "4.7.1",
+  "description": "Ham radio control library for rigs (radios), rotators, and amplifiers.",
+  "homepage": "https://hamlib.github.io/",
+  "documentation": "https://github.com/Hamlib/Hamlib/wiki/Documentation",
+  "license": null,
+  "supports": "(!windows | mingw) & !android",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ],
+  "features": {
+    "usb": {
+      "description": "USB backend support",
+      "dependencies": [
+        "libusb"
+      ]
+    },
+    "xml": {
+      "description": "Rigmem XML support",
+      "dependencies": [
+        "libxml2"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3712,6 +3712,10 @@
       "baseline": "18.0.0",
       "port-version": 1
     },
+    "hamlib": {
+      "baseline": "4.7.1",
+      "port-version": 0
+    },
     "hanjingo-high-jump": {
       "baseline": "1.0.6",
       "port-version": 0

--- a/versions/h-/hamlib.json
+++ b/versions/h-/hamlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "66c568e74340fb28a72a507d2eaabfcf8b2f4d72",
+      "version": "4.7.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/hamlib/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
