### PR TITLE
[atomic-queue] update to 1.9.1

### DIFF
--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO max0x7ba/atomic_queue
     REF "v${VERSION}"
-    SHA512 6046c451b2bb032187cfe8fb959c8ab27d6876df01028b52484c89dcd77d2553d68cd24d91611e21b91fdf0ca6e4f772edcd20dae7d88adb27374f91634ff7dd
+    SHA512 5fa8ca9e2dabde453eb4178f5e854b7e78456fb8f493fa50b153914fd2fe6e6056ead30677fcee4ecc077c6ce5b15d029fb7840252fe2b3a0a15396be3ceb780
     HEAD_REF master
 )
 

--- a/ports/atomic-queue/vcpkg.json
+++ b/ports/atomic-queue/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-queue",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Minimalistic header-only thread-safe ultra-low-latency multiple-producer-multiple-consumer lockless queues based on circular buffer with std::atomic.",
   "homepage": "https://github.com/max0x7ba/atomic_queue",
   "license": "MIT",

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e885d17c29e06c5c5ae2cf17278df0fd10e0c2b0",
+      "version": "1.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "60da5f33935be17715ce328fd298e10e0b45e734",
       "version": "1.9.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -389,7 +389,7 @@
       "port-version": 4
     },
     "atomic-queue": {
-      "baseline": "1.9.0",
+      "baseline": "1.9.1",
       "port-version": 0
     },
     "attr": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/max0x7ba/atomic_queue/releases/tag/v1.9.1
