### PR TITLE
[libgossip] update to 1.4.0

### DIFF
--- a/ports/libgossip/portfile.cmake
+++ b/ports/libgossip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO caomengxuan666/libgossip
     REF "v${VERSION}"
-    SHA512 ee463b28d6eea77f0d5ff63e849c768f054d2e8c7fbffb83a5dd38f05a9bec1c2fa9d25fddbb52e29d122cc3c8a735e6b901221aa34234f314d0f3c1cdf71d57
+    SHA512 7e4e66b7c469313014cb1e0ef0dfd33c1999c27d3480c030f8a665a6d6e3fc82f88693cd328d4689d7600bd97bbb0fe316c16c3b148aa7509fc5c1882ddc5ef9
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libgossip/portfile.cmake
+++ b/ports/libgossip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO caomengxuan666/libgossip
     REF "v${VERSION}"
-    SHA512 9e1237aa6d354922cc876177788699cb92e1d220afde241e22afcaf4ec5cd91b5a22f5b55f0c350f77585cabb7284b1d978921b9c854dc62a76cb240976317c2
+    SHA512 ee463b28d6eea77f0d5ff63e849c768f054d2e8c7fbffb83a5dd38f05a9bec1c2fa9d25fddbb52e29d122cc3c8a735e6b901221aa34234f314d0f3c1cdf71d57
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libgossip/vcpkg.json
+++ b/ports/libgossip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgossip",
-  "version": "1.3.0.0",
+  "version": "1.4.0",
   "description": "A C++17 implementation of the Gossip protocol, designed for decentralized distributed systems.",
   "homepage": "https://github.com/caomengxuan666/libgossip",
   "license": "MIT",

--- a/ports/libgossip/vcpkg.json
+++ b/ports/libgossip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgossip",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "A C++17 implementation of the Gossip protocol, designed for decentralized distributed systems.",
   "homepage": "https://github.com/caomengxuan666/libgossip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5053,7 +5053,7 @@
       "port-version": 6
     },
     "libgossip": {
-      "baseline": "1.4.0",
+      "baseline": "1.4.2",
       "port-version": 0
     },
     "libgpg-error": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5053,7 +5053,7 @@
       "port-version": 6
     },
     "libgossip": {
-      "baseline": "1.3.0.0",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "libgpg-error": {

--- a/versions/l-/libgossip.json
+++ b/versions/l-/libgossip.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "300191fec52f25f2ffeb82484d64fcfe441577b4",
-      "version": "1.4.0",
+      "git-tree": "d03a931a33bf62bd2f2fc09859ae6d4728e9792e",
+      "version": "1.4.2",
       "port-version": 0
     },
     {

--- a/versions/l-/libgossip.json
+++ b/versions/l-/libgossip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "300191fec52f25f2ffeb82484d64fcfe441577b4",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "22c45cf3fac1c7cfedca59426f763b842f2c4cf2",
       "version": "1.3.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/caomengxuan666/libgossip/releases/tag/v1.4.0
