### PR TITLE
[dpdk] Add support for building drivers that depend on libfdt

### DIFF
--- a/ports/dpdk/0002-fix-dependencies.patch
+++ b/ports/dpdk/0002-fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/buildtools/pkg-config/meson.build b/buildtools/pkg-config/meson.build
-index b36add1..a0a265a 100644
+index b36add17e3..a0a265ad92 100644
 --- a/buildtools/pkg-config/meson.build
 +++ b/buildtools/pkg-config/meson.build
 @@ -47,8 +47,7 @@ pkg.generate(name: 'DPDK', # main DPDK pkgconfig file
@@ -13,10 +13,10 @@ index b36add1..a0a265a 100644
              dpdk_drivers + dpdk_static_libraries +
              ['-Wl,--no-whole-archive'] + platform_flags
 diff --git a/config/meson.build b/config/meson.build
-index bbdad71..a9c63b5 100644
+index bbdad71ffc..e0a3ecc5f9 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -238,17 +238,15 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
+@@ -238,12 +238,10 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
      find_libnuma = false
  endif
  if find_libnuma
@@ -31,12 +31,6 @@ index bbdad71..a9c63b5 100644
      endif
  endif
  
- has_libfdt = false
--fdt_dep = cc.find_library('fdt', required: false)
-+fdt_dep = disabler()
- if fdt_dep.found() and cc.has_header('fdt.h') and cc.links(min_c_code, dependencies: fdt_dep)
-     dpdk_conf.set10('RTE_HAS_LIBFDT', true)
-     has_libfdt = true
 @@ -269,28 +267,28 @@ if libarchive.found()
  endif
  
@@ -71,8 +65,49 @@ index bbdad71..a9c63b5 100644
  endif
  if (pcap_dep.found() and cc.has_header('pcap.h', dependencies: pcap_dep)
          and cc.links(min_c_code, dependencies: pcap_dep))
+diff --git a/drivers/net/intel/ipn3ke/meson.build b/drivers/net/intel/ipn3ke/meson.build
+index 23c4d36b4f..a29abb1f77 100644
+--- a/drivers/net/intel/ipn3ke/meson.build
++++ b/drivers/net/intel/ipn3ke/meson.build
+@@ -16,9 +16,7 @@ endif
+ #
+ 
+ if not has_libfdt
+-    build = false
+-    reason = 'missing dependency, "libfdt"'
+-    subdir_done()
++    error('missing dependency: "libfdt"')
+ endif
+ 
+ includes += include_directories('../../../raw/ifpga')
+diff --git a/drivers/raw/ifpga/meson.build b/drivers/raw/ifpga/meson.build
+index 8d5f41fd5d..84c8c875b3 100644
+--- a/drivers/raw/ifpga/meson.build
++++ b/drivers/raw/ifpga/meson.build
+@@ -2,9 +2,7 @@
+ # Copyright(c) 2018 Intel Corporation
+ 
+ if not has_libfdt
+-    build = false
+-    reason = 'missing dependency, "libfdt"'
+-    subdir_done()
++    error('missing dependency: "libfdt"')
+ endif
+ 
+ rtdep = dependency('librt', required: false)
+@@ -12,9 +10,7 @@ if not rtdep.found()
+     rtdep = cc.find_library('rt', required: false)
+ endif
+ if not rtdep.found() or not cc.links(min_c_code, dependencies: rtdep)
+-    build = false
+-    reason = 'missing dependency, "librt"'
+-    subdir_done()
++    error('missing dependency: "librt"')
+ endif
+ 
+ ext_deps += rtdep
 diff --git a/lib/eal/linux/meson.build b/lib/eal/linux/meson.build
-index 29ba313..5a173c4 100644
+index 29ba313218..5a173c43d6 100644
 --- a/lib/eal/linux/meson.build
 +++ b/lib/eal/linux/meson.build
 @@ -25,5 +25,6 @@ endif
@@ -83,7 +118,7 @@ index 29ba313..5a173c4 100644
      dpdk_conf.set10('RTE_EAL_NUMA_AWARE_HUGEPAGES', true)
  endif
 diff --git a/lib/vhost/meson.build b/lib/vhost/meson.build
-index 6a24981..5283e79 100644
+index 6a24981d10..5283e7904f 100644
 --- a/lib/vhost/meson.build
 +++ b/lib/vhost/meson.build
 @@ -6,6 +6,7 @@ if not is_linux

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -78,10 +78,18 @@ if(PYTHON_PACKAGES)
   x_vcpkg_get_python_packages(OUT_PYTHON_VAR PYTHON3 PYTHON_VERSION "3" PACKAGES ${PYTHON_PACKAGES})
 endif()
 
+set(DISABLE_DRIVERS "regex/cn9k")
+if(NOT "rawdev-ifpga" IN_LIST FEATURES)
+  string(APPEND DISABLE_DRIVERS ",raw/ifpga")
+endif()
+if(NOT "pmd-ipn3ke" IN_LIST FEATURES)
+  string(APPEND DISABLE_DRIVERS ",net/intel/ipn3ke")
+endif()
+
 vcpkg_configure_meson(SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
     -Ddeveloper_mode=disabled
-    -Ddisable_drivers=regex/cn9k
+    "-Ddisable_drivers=${DISABLE_DRIVERS}"
     ${DPDK_OPTIONS}
   OPTIONS_RELEASE
     ${DPDK_OPTIONS_RELEASE}

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dpdk",
   "version": "26.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/",
@@ -28,6 +28,20 @@
   "features": {
     "docs": {
       "description": "Build and install docs"
+    },
+    "pmd-ipn3ke": {
+      "description": "Build the IPN3KE Poll Mode Driver",
+      "supports": "!windows",
+      "dependencies": [
+        "dtc"
+      ]
+    },
+    "rawdev-ifpga": {
+      "description": "Build the IFPGA Rawdev Driver",
+      "supports": "!windows",
+      "dependencies": [
+        "dtc"
+      ]
     },
     "tests": {
       "description": "Build and install tests"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2602,7 +2602,7 @@
     },
     "dpdk": {
       "baseline": "26.3",
-      "port-version": 1
+      "port-version": 2
     },
     "dpp": {
       "baseline": "10.1.4",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17d1ec9766dea33a0a556e51a1369a82b693fe21",
+      "version": "26.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "bc5eb55c71122f48fd77ac874d09e0cc6b96bda7",
       "version": "26.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.