### PR TITLE
[vincentlaucsb-csv-parser] update to 5.1.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7bd1223..4269b41 100644
+index 95fa984..13f389f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,5 +1,8 @@
@@ -9,9 +9,9 @@ index 7bd1223..4269b41 100644
 +
 +find_package(mio CONFIG REQUIRED)
 
- if(CSV_CXX_STANDARD)
+ if(DEFINED CSV_CXX_STANDARD AND NOT "${CSV_CXX_STANDARD}" STREQUAL "")
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
-@@ -85,9 +88,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
+@@ -102,9 +105,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  include_directories(${CSV_INCLUDE_DIR})
 
  ## Load developer specific CMake settings
@@ -22,7 +22,7 @@ index 7bd1223..4269b41 100644
 
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
-@@ -106,6 +107,22 @@ endif()
+@@ -175,6 +176,22 @@ endif()
 
  ## Tests
  option(CSV_BUILD_TESTS "Allow to disable building of tests" ON)
@@ -46,10 +46,10 @@ index 7bd1223..4269b41 100644
  ## Developer settings
  if (CSV_DEVELOPER)
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index 8674389..76f0f1a 100644
+index 03a2eab..efb1302 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
-@@ -27,7 +27,7 @@ target_sources(csv
+@@ -44,7 +44,7 @@ target_sources(csv
  		thread_safe_deque.hpp
  	)
 
@@ -58,7 +58,7 @@ index 8674389..76f0f1a 100644
 
  if(CSV_NO_SIMD)
  	target_compile_definitions(csv PUBLIC CSV_NO_SIMD=1)
-@@ -44,8 +44,6 @@ if(MSVC AND NOT CSV_NO_SIMD)
+@@ -61,8 +61,6 @@ if(MSVC AND NOT CSV_NO_SIMD AND CSV_TARGET_X86)
  	target_compile_options(csv PUBLIC /arch:AVX2)
  endif()
 
@@ -67,7 +67,7 @@ index 8674389..76f0f1a 100644
  # Scalar-only variant of the library: same sources, CSV_NO_SIMD defined.
  # Used by csv_bench_no_simd to provide a fair apples-to-apples benchmark.
  add_library(csv_no_simd STATIC "")
-@@ -59,4 +57,11 @@ if(CSV_ENABLE_THREADS)
+@@ -76,4 +74,11 @@ if(CSV_ENABLE_THREADS)
  else()
  	target_compile_definitions(csv_no_simd PUBLIC CSV_ENABLE_THREADS=0)
  endif()

--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -1,43 +1,21 @@
-diff --git a/include/internal/basic_csv_parser.hpp b/include/internal/basic_csv_parser.hpp
-index d662817..4861734 100644
---- a/include/internal/basic_csv_parser.hpp
-+++ b/include/internal/basic_csv_parser.hpp
-@@ -12,7 +12,7 @@
- #include <vector>
- 
- #if !defined(__EMSCRIPTEN__)
--#include "../external/mio.hpp"
-+#include "mio/mmap.hpp"
- #endif
- #include "basic_csv_parser_simd.hpp"
- #include "col_names.hpp"
 diff --git a/include/internal/common.hpp b/include/internal/common.hpp
-index d96b982..4e632e3 100644
+index 82e1404..c95cb98 100644
 --- a/include/internal/common.hpp
 +++ b/include/internal/common.hpp
-@@ -109,7 +109,7 @@
+@@ -125,7 +125,7 @@
  #endif
- 
+
  // Include string_view BEFORE csv namespace to avoid namespace pollution issues
 -#ifdef CSV_HAS_CXX17
 +#if 1
  #include <string_view>
  #else
  #include "../external/string_view.hpp"
-@@ -145,7 +145,7 @@ namespace csv {
-     #define CSV_DEBUG_ASSERT(x) assert(x)
- #endif
- 
--#ifdef CSV_HAS_CXX17
-+#if 1
-      /** @typedef string_view
-       *  The string_view class used by this library.
-       */
 diff --git a/include/internal/csv_row.hpp b/include/internal/csv_row.hpp
-index 85c0444..43411a4 100644
+index 7651f86..000f645 100644
 --- a/include/internal/csv_row.hpp
 +++ b/include/internal/csv_row.hpp
-@@ -36,7 +36,7 @@
+@@ -33,7 +33,7 @@
  #include <ranges>
  #endif
  #include "data_type.hpp"
@@ -45,17 +23,30 @@ index 85c0444..43411a4 100644
 +#include "classify_scalar.hpp"
  #include "json_converter.hpp"
  #include "raw_csv_data.hpp"
- 
+
 diff --git a/include/internal/data_type.hpp b/include/internal/data_type.hpp
 index b3f85d4..5a8be67 100644
 --- a/include/internal/data_type.hpp
 +++ b/include/internal/data_type.hpp
 @@ -7,7 +7,7 @@
  #include <cstdint>
- 
+
  #include "common.hpp"
 -#include "../external/classify_scalar.hpp"
 +#include "classify_scalar.hpp"
- 
+
  namespace csv {
      /** Enumerates the different CSV field types recognized by this library. */
+diff --git a/include/internal/parser/driver.hpp b/include/internal/parser/driver.hpp
+index 357a785..64b3c12 100644
+--- a/include/internal/parser/driver.hpp
++++ b/include/internal/parser/driver.hpp
+@@ -16,7 +16,7 @@
+ #include <vector>
+
+ #if !defined(__EMSCRIPTEN__)
+-#include "../../external/mio.hpp"
++#include "mio/mmap.hpp"
+ #endif
+ #include "../basic_csv_parser_simd.hpp"
+ #include "../col_names.hpp"

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 0b6656749296af9a3ea640414f60f1c13d261280a09ca6a899d6e07430ed5d28564aea636011cb235bf031a4cf0f0e4789b5bc8aadc0941c3d19007678feaa25
+    SHA512 a4d8ddce2a99c1a459ca3d63280181295f7be999e46301de3718131db3d3dd8dc81b89a25b0687ee210d1887829e971b8dcc3d96f320161a23bd5d6fbb2c3d0f
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "4.1.0",
+  "version": "5.1.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10601,7 +10601,7 @@
       "port-version": 0
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "4.1.0",
+      "baseline": "5.1.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22d0cf743bc13d1662c43fc905ea8bfd4b2d1e1d",
+      "version": "5.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7672666ba941cb7d262f14e5419c3b073e522c5",
       "version": "4.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/5.1.0
