### PR TITLE
[uriparser] update to 1.0.2

### DIFF
--- a/ports/uriparser/portfile.cmake
+++ b/ports/uriparser/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uriparser/uriparser
     REF "uriparser-${VERSION}"
-    SHA512 181c110fefcbc0a4443f3a6ee3f145d5f48bd507376819ebb0f4d91d1e2d81254442c0afe9c2fdbdb8ce4230a133f357a5b9de96d65817d83de29960ed63f584
+    SHA512 1e4c397418e71e705b5712de2dc3ea6e95163c9d95bfbaa5f7d2fd2344d34eaf167d7d9389ab9671cfb314af026621b56e632ea34b681c2f4d7951a1b32a98b4
     HEAD_REF master
 )
 

--- a/ports/uriparser/vcpkg.json
+++ b/ports/uriparser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uriparser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Strictly RFC 3986 compliant URI parsing and handling library written in C89.",
   "homepage": "https://uriparser.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10377,7 +10377,7 @@
       "port-version": 0
     },
     "uriparser": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "usbmuxd": {

--- a/versions/u-/uriparser.json
+++ b/versions/u-/uriparser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4be433413c0dbaedf85eacfcaf998b00ad4e778",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e4b122288f72d1c903ef7a6ea17bdc93f9c4a168",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/uriparser/uriparser/releases/tag/uriparser-1.0.2
