### PR TITLE
[libdatachannel] update to 0.24.3

### DIFF
--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libdatachannel
     REF "v${VERSION}"
-    SHA512 49be0df0705e9623ac2fee34201f3f61bc9cb5ac4804581295d82a0c216aeca2224f3105bf0e55060233a206354996af3f9b12f012a7868d2d4dc0dfa9178ac5
+    SHA512 92a173e4d23c03a69d4b019ff92e0723538c6f2ee549a7bf602c65682954b7fc0f6c4b10a9be3ccf89e5b0bea115a5136d5f5afb04964cf26b9071e2d752ce1b
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdatachannel",
-  "version-semver": "0.24.2",
+  "version-semver": "0.24.3",
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4845,7 +4845,7 @@
       "port-version": 1
     },
     "libdatachannel": {
-      "baseline": "0.24.2",
+      "baseline": "0.24.3",
       "port-version": 0
     },
     "libdatrie": {

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33fc1a45e1e10993592b8a6ed85424f5eca07285",
+      "version-semver": "0.24.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "443c53a9813a9e7569033cb56e59a6e37909ace2",
       "version-semver": "0.24.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/paullouisageneau/libdatachannel/releases/tag/v0.24.3
