### PR TITLE
[libdvdread] Add missing dirent dependency

### DIFF
--- a/ports/libdvdread/vcpkg.json
+++ b/ports/libdvdread/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "libdvdread",
   "version-semver": "6.1.3",
+  "port-version": 1,
   "description": "Library to read DVD disks",
   "homepage": "https://www.videolan.org/developers/libdvdnav.html",
   "license": "GPL-2.0-or-later",
   "supports": "!uwp & !xbox",
   "dependencies": [
+    {
+      "name": "dirent",
+      "platform": "windows"
+    },
     "libdvdcss"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4906,7 +4906,7 @@
     },
     "libdvdread": {
       "baseline": "6.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libdwarf": {
       "baseline": "2.3.1",

--- a/versions/l-/libdvdread.json
+++ b/versions/l-/libdvdread.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7f471d8e3ea425d24624ded4b027715fc08cf6e",
+      "version-semver": "6.1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ffa5a51a9de24eab67fc6f620f05e03f5a21222",
       "version-semver": "6.1.3",
       "port-version": 0


### PR DESCRIPTION
libdvdread needs the package `dirent` on Windows, that is not listed in its dependencies.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.
