### PR TITLE
[libzim] update to 9.7.0

### DIFF
--- a/ports/libzim/cross-builds.diff
+++ b/ports/libzim/cross-builds.diff
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index 39fb782..f460ebe 100644
+index c75d103..ad5e856 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,9 +1,9 @@
  project('libzim', ['c', 'cpp'],
-   version : '9.6.0',
+   version : '9.7.0',
    license : 'GPL2',
 -  default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 +  default_options : ['c_std=c11', 'cpp_std=c++17'])

--- a/ports/libzim/portfile.cmake
+++ b/ports/libzim/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openzim/libzim
     REF "${VERSION}"
-    SHA512 28d81076ff4ffed0a417240c86b70cfb003cac1ab10d38b34392c0b3c55b61d4c893a1eade06efbd9ca4e24da53612f83ef53d5af1861e104635623b1229a707
+    SHA512 3f635eaf4363bf12b92f12a4d089883f10bb8cfe4c572876ab410d88273f8a44455ce93ef74bcb0836051ea3dd51d39f25f703d6c01d6599cce0a8801bc09fba
     HEAD_REF main
     PATCHES
         cross-builds.diff

--- a/ports/libzim/vcpkg.json
+++ b/ports/libzim/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libzim",
-  "version": "9.6.0",
+  "version": "9.7.0",
   "description": "The Libzim is the reference implementation for the ZIM file format. It's a software library to read and write ZIM files on many systems and architectures. More information about the ZIM format and the openZIM project at https://openzim.org/.",
   "homepage": "https://github.com/openzim/libzim",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6037,7 +6037,7 @@
       "port-version": 0
     },
     "libzim": {
-      "baseline": "9.6.0",
+      "baseline": "9.7.0",
       "port-version": 0
     },
     "libzip": {

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28d90812c3709d2a019e23316cf4d55b92494701",
+      "version": "9.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a719e8149928a4f490c6922e5abb1443e1dba39",
       "version": "9.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/openzim/libzim/releases/tag/9.7.0
