### PR TITLE
[glaze] update to 7.6.0

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 7e9f81e8d031a9ceb86af105e7009bd858eb8f83a6b3512b96b6c780c34dd96d1cf5e24794f9b0e543286e9316c4d6ec2a5ea24412c75af4cf6e1587541319a0
+    SHA512 210f0fc202d8a3b2be908d5f5aaa84f785962db49da6f7b2dbc9b21c12ed4b64fa820fc1ddac33d2ecb2ded3c2ad853e6a005b522e03bfef408e801271f7a01d
     HEAD_REF main
 )
 

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3429,7 +3429,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "7.5.0",
+      "baseline": "7.6.0",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c620997f2725c087921f6189fbf429c400f2cc2",
+      "version": "7.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c8e2338962a03e01354d3d8fba0c61db06ba373b",
       "version": "7.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stephenberry/glaze/releases/tag/v7.6.0
