### PR TITLE
[dpdk] Add support for building drivers that depend on rdma-core

### DIFF
--- a/ports/dpdk/0002-fix-dependencies.patch
+++ b/ports/dpdk/0002-fix-dependencies.patch
@@ -65,6 +65,44 @@ index bbdad71ffc..e0a3ecc5f9 100644
  endif
  if (pcap_dep.found() and cc.has_header('pcap.h', dependencies: pcap_dep)
          and cc.links(min_c_code, dependencies: pcap_dep))
+diff --git a/drivers/common/mlx5/linux/meson.build b/drivers/common/mlx5/linux/meson.build
+index 3767e7a69b..9127dad034 100644
+--- a/drivers/common/mlx5/linux/meson.build
++++ b/drivers/common/mlx5/linux/meson.build
+@@ -29,9 +29,7 @@ foreach libname:libnames
+             ext_deps += lib
+         endif
+     else
+-        build = false
+-        reason = 'missing dependency, "' + libname + '"'
+-        subdir_done()
++        error('missing dependency: "' + libname + '"')
+     endif
+ endforeach
+ if static_ibverbs or dlopen_ibverbs
+diff --git a/drivers/common/mlx5/windows/meson.build b/drivers/common/mlx5/windows/meson.build
+index f454788a9f..78dfd12d5c 100644
+--- a/drivers/common/mlx5/windows/meson.build
++++ b/drivers/common/mlx5/windows/meson.build
+@@ -2,16 +2,12 @@
+ # Copyright 2019 Mellanox Technologies, Ltd
+ 
+ if not cc.has_header('mlx5devx.h')
+-    build = false
+-    reason = 'missing dependency, "mlx5devx.h"'
+-    subdir_done()
++    error('missing dependency: "mlx5devx.h"')
+ endif
+ 
+ devxlib = cc.find_library('mlx5devx', required: false)
+ if not devxlib.found() or not cc.links(min_c_code, dependencies: devxlib)
+-    build = false
+-    reason = 'missing dependency, "mlx5devx"'
+-    subdir_done()
++    error('missing dependency: "mlx5devx"')
+ endif
+ ext_deps += devxlib
+ 
 diff --git a/drivers/net/intel/ipn3ke/meson.build b/drivers/net/intel/ipn3ke/meson.build
 index 23c4d36b4f..a29abb1f77 100644
 --- a/drivers/net/intel/ipn3ke/meson.build
@@ -80,6 +118,36 @@ index 23c4d36b4f..a29abb1f77 100644
  endif
  
  includes += include_directories('../../../raw/ifpga')
+diff --git a/drivers/net/mana/meson.build b/drivers/net/mana/meson.build
+index 19d4b3695e..56323879d7 100644
+--- a/drivers/net/mana/meson.build
++++ b/drivers/net/mana/meson.build
+@@ -31,9 +31,7 @@ foreach libname:libnames
+         libs += lib
+         ext_deps += lib
+     else
+-        build = false
+-        reason = 'missing dependency, "' + libname + '"'
+-        subdir_done()
++        error('missing dependency: "' + libname + '"')
+     endif
+ endforeach
+ 
+diff --git a/drivers/net/mlx4/meson.build b/drivers/net/mlx4/meson.build
+index 1eb67f3c47..427e6e9f89 100644
+--- a/drivers/net/mlx4/meson.build
++++ b/drivers/net/mlx4/meson.build
+@@ -37,9 +37,7 @@ foreach libname:libnames
+             ext_deps += lib
+         endif
+     else
+-        build = false
+-        reason = 'missing dependency, "' + libname + '"'
+-        subdir_done()
++        error('missing dependency: "' + libname + '"')
+     endif
+ endforeach
+ if static_ibverbs or dlopen_ibverbs
 diff --git a/drivers/raw/ifpga/meson.build b/drivers/raw/ifpga/meson.build
 index 8d5f41fd5d..84c8c875b3 100644
 --- a/drivers/raw/ifpga/meson.build

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -79,11 +79,21 @@ if(PYTHON_PACKAGES)
 endif()
 
 set(DISABLE_DRIVERS "regex/cn9k")
-if(NOT "rawdev-ifpga" IN_LIST FEATURES)
-  string(APPEND DISABLE_DRIVERS ",raw/ifpga")
+
+IF(NOT "mlx5" IN_LIST FEATURES)
+  string(APPEND DISABLE_DRIVERS ",common/mlx5,compress/mlx5,crypto/mlx5,net/mlx5,regex/mlx5,vdpa/mlx5")
 endif()
 if(NOT "pmd-ipn3ke" IN_LIST FEATURES)
   string(APPEND DISABLE_DRIVERS ",net/intel/ipn3ke")
+endif()
+if(NOT "pmd-mana" IN_LIST FEATURES)
+  string(APPEND DISABLE_DRIVERS ",net/mana")
+endif()
+if(NOT "pmd-mlx4" IN_LIST FEATURES)
+  string(APPEND DISABLE_DRIVERS ",net/mlx4")
+endif()
+if(NOT "rawdev-ifpga" IN_LIST FEATURES)
+  string(APPEND DISABLE_DRIVERS ",raw/ifpga")
 endif()
 
 vcpkg_configure_meson(SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dpdk",
   "version": "26.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/",
@@ -29,11 +29,32 @@
     "docs": {
       "description": "Build and install docs"
     },
+    "mlx5": {
+      "description": "Build NVIDIA MLX5 drivers",
+      "supports": "linux",
+      "dependencies": [
+        "rdma-core"
+      ]
+    },
     "pmd-ipn3ke": {
       "description": "Build the IPN3KE Poll Mode Driver",
       "supports": "!windows",
       "dependencies": [
         "dtc"
+      ]
+    },
+    "pmd-mana": {
+      "description": "Build MANA Poll Mode Driver",
+      "supports": "linux",
+      "dependencies": [
+        "rdma-core"
+      ]
+    },
+    "pmd-mlx4": {
+      "description": "Build NVIDIA MLX4 Poll Mode Driver",
+      "supports": "linux",
+      "dependencies": [
+        "rdma-core"
       ]
     },
     "rawdev-ifpga": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2602,7 +2602,7 @@
     },
     "dpdk": {
       "baseline": "26.3",
-      "port-version": 2
+      "port-version": 3
     },
     "dpp": {
       "baseline": "10.1.4",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1648404bf87ba2993a3d7395aaab019b08787bdd",
+      "version": "26.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "17d1ec9766dea33a0a556e51a1369a82b693fe21",
       "version": "26.3",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.