### PR TITLE
[vcpkg-tool-meson] Fix skip symbolic link warning on windows

### DIFF
--- a/ports/vcpkg-tool-meson/vcpkg-port-config.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg-port-config.cmake
@@ -29,7 +29,7 @@ if(NOT SCRIPT_MESON)
     file(MAKE_DIRECTORY "${path_to_search}-tmp")
     file(ARCHIVE_EXTRACT INPUT "${archive_path}"
         DESTINATION "${path_to_search}-tmp"
-        #PATTERNS "**/mesonbuild/*" "**/*.py"
+        PATTERNS "meson-${ref}/mesonbuild" "meson-${ref}/meson.py"
         )
     z_vcpkg_apply_patches(
         SOURCE_PATH "${path_to_search}-tmp/meson-${ref}"

--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-tool-meson",
   "version": "1.9.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10562,7 +10562,7 @@
     },
     "vcpkg-tool-meson": {
       "baseline": "1.9.0",
-      "port-version": 6
+      "port-version": 7
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf7f8a95eef222e762d63ce7ae0aaa78d834f291",
+      "version": "1.9.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "959b8c5fa5c73a2e66d088fd6ae7cf4fd2d6fbae",
       "version": "1.9.0",
       "port-version": 6


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

#51599