### PR TITLE
[rdma-core] fix baseline issue on arm64-linux

### DIFF
--- a/ports/rdma-core/portfile.cmake
+++ b/ports/rdma-core/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_cmake_configure(
         -DVCPKG_LOCK_FIND_PACKAGE_cython=OFF
         -DVCPKG_LOCK_FIND_PACKAGE_pandoc=OFF
         -DVCPKG_LOCK_FIND_PACKAGE_rst2man=OFF
+        -DPython_EXECUTABLE=${PYTHON3}
     MAYBE_UNUSED_VARIABLES
         VCPKG_LOCK_FIND_PACKAGE_PythonLibs
         VCPKG_LOCK_FIND_PACKAGE_cython

--- a/ports/rdma-core/portfile.cmake
+++ b/ports/rdma-core/portfile.cmake
@@ -17,6 +17,8 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC)
 
+vcpkg_get_vcpkg_installed_python(PYTHON3)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/rdma-core/vcpkg.json
+++ b/ports/rdma-core/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rdma-core",
   "version": "62.0",
+  "port-version": 1,
   "description": "The userspace components for the Linux Kernel's drivers/infiniband subsystem.",
   "homepage": "https://github.com/linux-rdma/rdma-core",
   "license": "(GPL-2.0-only OR Linux-OpenIB) AND (GPL-2.0-only OR BSD-3-Clause) AND (GPL-2.0-only OR BSD-2-Clause) AND CC0-1.0 AND MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8650,7 +8650,7 @@
     },
     "rdma-core": {
       "baseline": "62.0",
-      "port-version": 0
+      "port-version": 1
     },
     "re2": {
       "baseline": "2025-11-05",

--- a/versions/r-/rdma-core.json
+++ b/versions/r-/rdma-core.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fbbd9c79785bc7c7d63e1e350bd974fc170f580b",
+      "git-tree": "54af715001197fdaa1dcf76571ff083d68863e0b",
       "version": "62.0",
       "port-version": 1
     },

--- a/versions/r-/rdma-core.json
+++ b/versions/r-/rdma-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbbd9c79785bc7c7d63e1e350bd974fc170f580b",
+      "version": "62.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "33b95cc4f1a4eb8f5051cf643392fe50ee09e7db",
       "version": "62.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


baseline issue:
```
CMake Error at /vcpkg/downloads/tools/cmake-4.3.2-linux/cmake-4.3.2-linux-x86_64/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find Python (missing: Interpreter) (found suitable version
  "3.12.13", minimum required is "3")

      Reason given by package: 
          Interpreter: Cannot run the interpreter "/mnt/vcpkg-ci/installed/arm64-linux/tools/python3/python3.12"
```

Related: https://github.com/microsoft/vcpkg/pull/51531