### PR TITLE
[sdl3-mixer] Update to version 3.2.2

### DIFF
--- a/ports/sdl3-mixer/portfile.cmake
+++ b/ports/sdl3-mixer/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO libsdl-org/SDL_mixer
     REF "release-${VERSION}"
     HEAD_REF main
-    SHA512 5f53ab3011e5727df51e405a687c0699e1530d4d597ab299ce8a6008a3c8295cf9170b072bf07ec49fb0af6eee757005a10cf67aa283b23575a3f58874c9b6be
+    SHA512 9c66e0157c6a8e8d2269a7979da099618bcff760a641ed8949c42e806f4ffe07df908f3b62caf40a24cfba10f918a86ec21c4ecef2a1e9611a80935440035783
     PATCHES
         fluidsynth.diff
 )

--- a/ports/sdl3-mixer/vcpkg.json
+++ b/ports/sdl3-mixer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl3-mixer",
-  "version": "3.2.0",
-  "port-version": 3,
+  "version": "3.2.2",
   "description": "An audio mixer that supports various file formats for Simple Directmedia Layer.",
   "homepage": "https://github.com/libsdl-org/SDL_mixer",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9109,8 +9109,8 @@
       "port-version": 0
     },
     "sdl3-mixer": {
-      "baseline": "3.2.0",
-      "port-version": 3
+      "baseline": "3.2.2",
+      "port-version": 0
     },
     "sdl3-shadercross": {
       "baseline": "3.0.0-preview2",

--- a/versions/s-/sdl3-mixer.json
+++ b/versions/s-/sdl3-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7eea821bd013f9c2019acdecd0cbd43a7fbbdaa7",
+      "version": "3.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c4c581e3201a02b4b9856eefdaeafe10ba12ab99",
       "version": "3.2.0",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.