### PR TITLE
[sdl2-mixer] Update to version 2.8.2

### DIFF
--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_mixer
     REF "release-${VERSION}"
-    SHA512 653ec1f0af0b749b9ed0acd3bfcaa40e1e1ecf34af3127eb74019502ef42a551de226daef4cc89e6a51715f013e0ba0b1e48ae17d6aeee931271f2d10e82058a
+    SHA512 4c2ba587a89721e060472b65e8a846ed3012121b4de7a2952704dab5df5f9e5d828a4105a7eb9b2fd65158ea9264e8b53eb689b87cb7f098452c2ab959a25a06
     PATCHES 
         fix-pkg-prefix.patch
 )

--- a/ports/sdl2-mixer/vcpkg.json
+++ b/ports/sdl2-mixer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl2-mixer",
-  "version": "2.8.1",
-  "port-version": 2,
+  "version": "2.8.2",
   "description": "Multi-channel audio mixer library for SDL.",
   "homepage": "https://github.com/libsdl-org/SDL_mixer",
   "license": "Zlib",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1311,7 +1311,6 @@ sdl1-net:arm64-linux=cascade
 sdl1-net(android | osx)=cascade
 sdl2[dbus]:arm64-linux=cascade
 sdl2-gfx:arm64-linux=cascade
-sdl2-mixer:arm64-linux=cascade
 sdl2-mixer-ext:arm64-linux=cascade
 sdl2-net:arm64-linux=cascade
 sdl2-ttf:arm64-linux=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9081,8 +9081,8 @@
       "port-version": 0
     },
     "sdl2-mixer": {
-      "baseline": "2.8.1",
-      "port-version": 2
+      "baseline": "2.8.2",
+      "port-version": 0
     },
     "sdl2-mixer-ext": {
       "baseline": "2.6.0",

--- a/versions/s-/sdl2-mixer.json
+++ b/versions/s-/sdl2-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18ee78fca44eded18994f10466b12aee9df58254",
+      "version": "2.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee2053a681764a5fda41536fee42df58397d0c37",
       "version": "2.8.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.