### PR TITLE
[catch2] Update to 3.15.0

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 6eeeedc4e38b79a0a7253edfce3e29862a8761b6556f77aa3f77debd4e6631e0b57cdce7657eba2df01c4e2fd494c5b3f4bbf0dbdff32763387cf6c75d6e0c50
+    SHA512 09df8b291d0c756c492871ce0a4fb5c703162d1364a9864470b227d4d19d9865a0ba5293a5f38d0117cbc7c230f42be35db9f6e0ca5d889dff02f1745807f380
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.14.0",
+  "version-semver": "3.15.0",
   "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1621,7 +1621,7 @@
       "port-version": 0
     },
     "catch2": {
-      "baseline": "3.14.0",
+      "baseline": "3.15.0",
       "port-version": 0
     },
     "cblas": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26ec816a5d58f54d00bf585df74dd950d272a75d",
+      "version-semver": "3.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ca0981c00662c1c56cb85f99200177377ebdf2c5",
       "version-semver": "3.14.0",
       "port-version": 0


### PR DESCRIPTION
Update catch2 port from 3.14.0 to 3.15.0: https://github.com/catchorg/Catch2/releases/tag/v3.15.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.