### PR TITLE
New port libspatialaudio

### DIFF
--- a/ports/libspatialaudio/portfile.cmake
+++ b/ports/libspatialaudio/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO videolan/libspatialaudio
+    REF "${VERSION}"
+    SHA512 80125610be6d9881bf49b72373d28931a1cd475d2eda1c6357db9c7fc959b674b30dc80afee4e33255ceb516d1d66d9f216f835d589e215aeed90d5dbbbc9699
+    HEAD_REF master
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dlibmysofa=disabled
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libspatialaudio/vcpkg.json
+++ b/ports/libspatialaudio/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libspatialaudio",
+  "version": "0.4.0",
+  "description": "Spatial Audio rendering library, with Ambisonic encoding/decoding, binauralization in C++",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5652,6 +5652,10 @@
       "baseline": "3.6.6",
       "port-version": 0
     },
+    "libspatialaudio": {
+      "baseline": "0.4.0",
+      "port-version": 0
+    },
     "libspatialindex": {
       "baseline": "2.1.0",
       "port-version": 0

--- a/versions/l-/libspatialaudio.json
+++ b/versions/l-/libspatialaudio.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c0e6ca9529813bd9353ae51040d2de7d4dd66056",
+      "version": "0.4.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/libspatialaudio/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR. <img width="835" height="970" alt="image" src="https://github.com/user-attachments/assets/99076ff3-4c7c-43bc-8bee-a42e573a8f80" />
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
