### PR TITLE
[sdl3] add libusb feature

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         vulkan   SDL_VULKAN
         wayland  SDL_WAYLAND
         x11      SDL_X11
+        libusb   SDL_HIDAPI_LIBUSB
 )
 
 if (VCPKG_TARGET_IS_EMSCRIPTEN)
@@ -39,6 +40,15 @@ endif()
 if ("ibus" IN_LIST FEATURES)
     message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
 endif()
+
+if ("libusb" IN_LIST FEATURES)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        vcpkg_list(APPEND FEATURE_OPTIONS "-DSDL_HIDAPI_LIBUSB_SHARED=ON")
+    else()
+        vcpkg_list(APPEND FEATURE_OPTIONS "-DSDL_HIDAPI_LIBUSB_SHARED=OFF")
+    endif()
+endif()
+
 # option for not need to show windows
 list(APPEND FEATURE_OPTIONS -DSDL_UNIX_CONSOLE_BUILD=ON)
 if (VCPKG_TARGET_IS_LINUX AND NOT "x11" IN_LIST FEATURES AND NOT "wayland" IN_LIST FEATURES)
@@ -59,7 +69,6 @@ vcpkg_cmake_configure(
         -DSDL_INSTALL_CMAKEDIR_ROOT=share/${PORT}
         # Specifying the revision skips the need to use git to determine a version
         -DSDL_REVISION=vcpkg
-        -DCMAKE_DISABLE_FIND_PACKAGE_LibUSB=1
     MAYBE_UNUSED_VARIABLES
         SDL_FORCE_STATIC_VCRT
 )

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl3",
   "version": "3.4.8",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0",
@@ -56,6 +57,12 @@
     "ibus": {
       "description": "Build with ibus IME support",
       "supports": "linux"
+    },
+    "libusb": {
+      "description": "Use libusb for joystick support",
+      "dependencies": [
+        "libusb"
+      ]
     },
     "vulkan": {
       "description": "Vulkan functionality for SDL"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9102,7 +9102,7 @@
     },
     "sdl3": {
       "baseline": "3.4.8",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl3-image": {
       "baseline": "3.4.4",

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c4f5fd6e369cc9699cc5176eef458d64b07912a",
+      "version": "3.4.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "c3a9eeaee64a945a280bd3eeda988129400a8e63",
       "version": "3.4.8",
       "port-version": 0


### PR DESCRIPTION
Add feature "libusb" to the sdl3 port that enables HID (joysticks) support using libusb, which is necessary for some game controllers like the Switch 2 controller.

The feature depends on the libusb port.

Increment `port-version`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.