### PR TITLE
[ada-idna] Update to 0.5.2

### DIFF
--- a/ports/ada-idna/portfile.cmake
+++ b/ports/ada-idna/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/idna
     REF "${VERSION}"
-    SHA512 5e2ab8f36ec5171a0fdf185308ec752351b367ac28b21cb8ca5f4838e9f75db488180cee43c3c4ab2927f1ac796484b79978f9e38a54127bfc8d1e1db9db5a5b
+    SHA512 55ddf9799c81ee8a50be591db9858dca3db507a12c7b9c9387e8171ccb38e61416344da9abe86979a35158b196ea8980cbba798720ae8ab630e4efce612a8e38
     HEAD_REF main
     PATCHES
         install.patch

--- a/ports/ada-idna/vcpkg.json
+++ b/ports/ada-idna/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-idna",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "C++ library implementing the to_ascii and to_unicode functions from the Unicode Technical Standard.",
   "homepage": "https://github.com/ada-url/idna",
   "license": "Apache-2.0 AND MIT",

--- a/versions/a-/ada-idna.json
+++ b/versions/a-/ada-idna.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "762b193dbd00ff145a0eff5f1d17f9b61536b23f",
+      "version": "0.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "71d859ec7966983f97717e03eed862aca8ecb4c3",
       "version": "0.5.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,7 +41,7 @@
       "port-version": 18
     },
     "ada-idna": {
-      "baseline": "0.5.1",
+      "baseline": "0.5.2",
       "port-version": 0
     },
     "ada-url": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

