### PR TITLE
[libsrt] Update to 1.5.5

### DIFF
--- a/ports/libsrt/portfile.cmake
+++ b/ports/libsrt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Haivision/srt
     REF "v${VERSION}"
-    SHA512 ec4e5923531a8a7fd7778c739cb52208d24a91c569f31f3995d6e0695dffd83492e5eca2530b2e112ca37f1fd4520061d89ef42d1ded95e2516a9acda009bcaf 
+    SHA512 afb35de76be5c1b8558b3956586b8b7b044aa7709d7ce1b99b6b55e54f72c604eea50ae44962985c68ef681a69accb0a2a7f6a8678b8165e2aeee93632a0ff2f
     HEAD_REF master
     PATCHES
         fix-static.patch

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libsrt",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.",
   "homepage": "https://github.com/Haivision/srt",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5677,7 +5677,7 @@
       "port-version": 15
     },
     "libsrt": {
-      "baseline": "1.5.4",
+      "baseline": "1.5.5",
       "port-version": 0
     },
     "libsrtp": {

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c874078f84e81cdbd7bc745cacc07fde3a10a56c",
+      "version": "1.5.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "7ce0f41466df0eacd6c8e69c951c8831ee34cb60",
       "version": "1.5.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

