### PR TITLE
[amd-amf] Update to 1.5.2

### DIFF
--- a/ports/amd-amf/portfile.cmake
+++ b/ports/amd-amf/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${VERSION}/AMF-headers-v${VERSION}.tar.gz"
     FILENAME "AMF-headers-v${VERSION}.tar.gz"
-    SHA512 37d618c846bd2ba77ee282ac152fc5f807631007fca8156fca7e541ad1d1cb23786794aaad1ee3d3eb30b2011c4336bec9011031202c3238d91fe48d1e92f97b
+    SHA512 b992d4a1f59f7b1c789d03e7bd9876417a569fb239bfe2e2178f2434ae18653bbacc912de2b8a5f8ff0a85fad28b0c1091c2a8d3417407a37c22c1e907e4c159
 )
 
 vcpkg_extract_source_archive(

--- a/ports/amd-amf/vcpkg.json
+++ b/ports/amd-amf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "amd-amf",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "AMD Advanced Media Framework headers",
   "homepage": "https://github.com/GPUOpen-LibrariesAndSDKs/AMF",
   "license": "MIT",

--- a/versions/a-/amd-amf.json
+++ b/versions/a-/amd-amf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4db7571915af70f9ca7ee6efeb02c398514d28fd",
+      "version": "1.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "773d9ad1a04f02b47d3798dd7857e04c25fbbae6",
       "version": "1.5.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -117,7 +117,7 @@
       "port-version": 0
     },
     "amd-amf": {
-      "baseline": "1.5.0",
+      "baseline": "1.5.2",
       "port-version": 0
     },
     "ampl-asl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
