### PR TITLE
[bde] Update to 4.37.0.0

### DIFF
--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
     REF "${BDE_TOOLS_VER}"
-    SHA512 c1ec488c6cd4e4859e916aab52d809a3cb292e933dbf3e8cf662d60617956c44eceec1853b2d310d587dcb0fe70eba74271ca2d2a2d06e06393852acae9311ab
+    SHA512 209a6803b6b769263e7ec496a122dcd200c3b073665e5fe5ff5fd4c1690df080f00020dfe131ad35305e967bcba9a0a75c224ca5b4804a0349a60d939d1b0060
     HEAD_REF main
 )
 
@@ -23,9 +23,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 f9d7433fc3a7ebf1e2a1fddab850b6f10f7ced78aec0e1f1e86c152187fcf2434846102cfb95621e95a22d8977f5d8af46deeef0400b8debba3511c6e6552882
+    SHA512 b65936ea36f5bdeb6a099b05bf2757f1c9de8fc0df7fa912454761f795031bc192b776b5a177df16dd2b08899369bd4f06edd864ad06a5d2f1ac203f866029cd
     HEAD_REF main
-    PATCHES fix-bdlar-target.patch use-vcpkg-pcre2.patch
+    PATCHES
+        fix-bdlar-target.patch
+        use-vcpkg-pcre2.patch
 )
 
 vcpkg_cmake_configure(
@@ -38,10 +40,6 @@ vcpkg_cmake_configure(
         -DBBS_BUILD_SYSTEM=1
         -DBDE_USE_EXTERNAL_PCRE2=1
         "-DBdeBuildSystem_DIR:PATH=${TOOLS_PATH}/BdeBuildSystem"
-    OPTIONS_RELEASE
-        -DBDE_BUILD_TARGET_OPT=1
-    OPTIONS_DEBUG
-        -DBDE_BUILD_TARGET_DBG=1
 )
 
 # Build release

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "bde",
-  "version": "4.36.0.0",
+  "version": "4.37.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "homepage": "https://techatbloomberg.com/",
   "documentation": "https://bloomberg.github.io/bde/",

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1fc42df5ce9ff26229a7f8b32d6fd37630ffd74",
+      "version": "4.37.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3bd5bb14040cc6181f1e2abeb2aca8aeaf967bca",
       "version": "4.36.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -661,7 +661,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "4.36.0.0",
+      "baseline": "4.37.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: Removed the `BDE_BUILD_TARGET_*` variables due to:
```
CMake Warning at installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:344 (message):
  The following variables are not used in CMakeLists.txt:

      BDE_BUILD_TARGET_OPT

  Please recheck them and remove the unnecessary options from the
  `vcpkg_cmake_configure` call.

  If these options should still be passed for whatever reason, please use the
  `MAYBE_UNUSED_VARIABLES` argument.
```

As far as I found it, it is a leftover of BDE 3.x and automatically set in case CMake [is used](https://bloomberg.github.io/bde-tools/bbs/reference/bbs_build_configuration.html).