### PR TITLE
[openjph] Fix non-standard `CMAKE_DEBUG_POSTFIX` causing pkg-config link failure in debug builds

### DIFF
--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -23,6 +23,10 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DOJPH_BUILD_EXECUTABLES=OFF
+        # OpenJPH sets CMAKE_DEBUG_POSTFIX "_d" for non-MSVC (vs "d" for MSVC).
+        # Override it to empty: vcpkg convention is same lib name in separate dirs (lib/ vs debug/lib/), no postfix.
+        # This also keeps pkg-config consumers working without manual .pc patching.
+        -DCMAKE_DEBUG_POSTFIX=""
 )
 
 vcpkg_cmake_install()

--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -23,15 +23,23 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DOJPH_BUILD_EXECUTABLES=OFF
-        # OpenJPH sets CMAKE_DEBUG_POSTFIX "_d" for non-MSVC (vs "d" for MSVC).
-        # Override it to empty: vcpkg convention is same lib name in separate dirs (lib/ vs debug/lib/), no postfix.
-        # This also keeps pkg-config consumers working without manual .pc patching.
-        -DCMAKE_DEBUG_POSTFIX=""
 )
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/openjph)
+
+# OpenJPH sets CMAKE_DEBUG_POSTFIX ("d" for MSVC, "_d" for others) but the
+# generated .pc file always references -lopenjph. Fix the debug .pc to match
+# the actual library name on disk.
+if(NOT VCPKG_BUILD_TYPE)
+    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/openjph.pc" "-lopenjph" "-lopenjphd")
+    else()
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/openjph.pc" "-lopenjph" "-lopenjph_d")
+    endif()
+endif()
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/openjph/vcpkg.json
+++ b/ports/openjph/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openjph",
   "version": "0.27.2",
+  "port-version": 1,
   "description": "Open-source implementation of JPEG2000 Part-15 (or JPH or HTJ2K)",
   "homepage": "https://github.com/aous72/OpenJPH",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7398,7 +7398,7 @@
     },
     "openjph": {
       "baseline": "0.27.2",
-      "port-version": 0
+      "port-version": 1
     },
     "openldap": {
       "baseline": "2.6.12",

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae24a73077d3e31f09ceb1c8eed960929c3919bc",
+      "version": "0.27.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "6e13f0c0ad629fd6744f60f124df3f9e53a1a075",
       "version": "0.27.2",
       "port-version": 0

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae24a73077d3e31f09ceb1c8eed960929c3919bc",
+      "git-tree": "2b04ee12d933984dbd040fd96b9ac4e9cdc20222",
       "version": "0.27.2",
       "port-version": 1
     },


### PR DESCRIPTION
OpenJPH's `src/core/CMakeLists.txt` sets `CMAKE_DEBUG_POSTFIX` conditionally by compiler: "d" for MSVC and "_d" for others.

This produces `libopenjph_d.a` (Clang/GCC) or `libopenjphd.lib` (MSVC) in debug builds.

vcpkg's convention is **no debug postfix** - debug libraries live in a separate `debug/lib/` tree with the same file name as the release library.  
`vcpkg_fixup_pkgconfig()` is designed around this convention: it rewrites include and library paths in `.pc` files for the debug prefix, but it does not rename the library.

As a result, the generated `debug/lib/pkgconfig/openjph.pc` contains:
```
Libs: "-L${libdir}" -lopenjph
```
but the actual file on disk is `libopenjph_d.a` (or `openjphd.lib` on Windows).  
Any consumer that discovers openjph via pkg-config in a **debug build** fails to link with:
```
/usr/bin/ld: cannot find -lopenjph: No such file or directory
```

### Fix

Pass `-DCMAKE_DEBUG_POSTFIX=""` in `OPTIONS_DEBUG` of `vcpkg_cmake_configure()`.  
Because the upstream code guards both assignments with `if (NOT DEFINED CMAKE_DEBUG_POSTFIX)`, an empty string passed via CMake command-line takes precedence and suppresses the postfix without patching any upstream source file.

The debug library is then installed as `libopenjph.a` / `openjph.lib`, consistent with vcpkg convention, and `vcpkg_fixup_pkgconfig()` works correctly.

## Impact

| Scenario                             | Before                                                        | After             |
|:------------------------------------ |:------------------------------------------------------------- |:----------------- |
| Debug static link via `find_package` | Works (CMake targets carry correct `IMPORTED_LOCATION_DEBUG`) | Works             |
| Debug link via pkg-config            | **Fails** (`-lopenjph`, file is `libopenjph_d.a`)             | Works             |
| Release link (any)                   | Works                                                         | Works (unchanged) |

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
