### PR TITLE
[glibmm] Update to 2.88.0

### DIFF
--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIBMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIBMM_ARCHIVE
     URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/${GLIBMM_MAJOR_MINOR}/glibmm-${VERSION}.tar.xz"
     FILENAME "glibmm-${VERSION}.tar.xz"
-    SHA512 bd628bca76570f92c3c0f7cbc878ec74ae243c4f201c205ce0c1fcf8f6778da4ccf72d1a8c712020980278b1a518307cf7c77f16aeb72e0a0816f6bc1d9f2391
+    SHA512 550c9087ead950de3d7de2eac29ea7cab23c70ce1a0081c162df0369765d547d754dc296a0f06ab494df01f43f7bab29dfb88b6d2fdf920eebc3aef896dff1f0
 )
 
 vcpkg_extract_source_archive(

--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glibmm",
-  "version": "2.86.0",
+  "version": "2.88.0",
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3461,7 +3461,7 @@
       "port-version": 0
     },
     "glibmm": {
-      "baseline": "2.86.0",
+      "baseline": "2.88.0",
       "port-version": 0
     },
     "glm": {

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "473c7a4b9ab2ba7cbffa0c9f54357969363f0e6f",
+      "version": "2.88.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0af5315da4a63fcab340b6989a0870f9d184770a",
       "version": "2.86.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
