### PR TITLE
[gmsh] Update to 4.15.2

### DIFF
--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://gmsh.info/src/gmsh-${VERSION}-source.tgz"
     FILENAME "gmsh-${VERSION}-source.tgz"
-    SHA512 dc3ba00c2788d95f30d0cedac490b72cdf6805ef67d81f8636e4ff45510640991cc85e950b3953335f1ba73f9458b980949469844f65d6d5fb09b51936ddef12
+    SHA512 9e05267e3d2bae54eeab21b384ab5cc85383e8040ed622ff859485fabd3dc9fc4b5a87d9d58acf3fc5573471d9c3c8e0831df4f44ae196d1a26ecbe9c613753c
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmsh",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
   "license": "LGPL-2.0-or-later",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -385,7 +385,6 @@ glpk[odbc]:arm64-linux=cascade
 glpk[odbc](!windows | uwp)=cascade
 glui:arm64-linux=cascade
 gmmlib:arm64-linux=fail
-gmsh[mpi]:arm64-linux=cascade
 gmsh[mpi]:arm64-windows=cascade
 gmsh[mpi]:x64-windows-static-md=cascade
 gmsh[mpi]:x64-windows-static=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3505,7 +3505,7 @@
       "port-version": 3
     },
     "gmsh": {
-      "baseline": "4.15.1",
+      "baseline": "4.15.2",
       "port-version": 0
     },
     "gobject-introspection": {

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a37f5abcf7e81672c39b276871582cef586cc1e2",
+      "version": "4.15.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "33c365b0696bb024d512cfc0ddfa2f5cb8ef7922",
       "version": "4.15.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.