### PR TITLE
[libcoap] Update to 4.3.5b

### DIFF
--- a/ports/libcoap/obgm-remove-self-configure-file.patch
+++ b/ports/libcoap/obgm-remove-self-configure-file.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1e86b422..7fd227ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -742,9 +742,6 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake_coap_config.h.in
+ configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake_coap_defines.h.in
+                ${CMAKE_CURRENT_BINARY_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_defines.h)
+ 
+-configure_file(${CMAKE_CURRENT_LIST_DIR}/tests/test_common.h.in
+-               ${CMAKE_CURRENT_LIST_DIR}/tests/test_common.h)
+-
+ #
+ # sources
+ #

--- a/ports/libcoap/portfile.cmake
+++ b/ports/libcoap/portfile.cmake
@@ -3,21 +3,16 @@ if(VCPKG_TARGET_IS_WINDOWS)
   vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_download_distfile(DLLEXPORT_PATCH
-    URLS https://github.com/obgm/libcoap/commit/0bd03b658ed2d75fdb7cb8f6add201b39b428298.patch?full_index=1
-    FILENAME obgm-remove-self-configure-file-0bd03b658ed2d75fdb7cb8f6add201b39b428298.patch
-    SHA512 6c120dc278a5d73d0b9bd2f66468c822ccde80513262201119cdceb9ed6fdf2f84d473926373f18ef69d709d4e95212e484079072a52d5c65d09e4ccb82368e5
-)
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO obgm/libcoap
   REF "v${VERSION}"
-  SHA512 9f46f8293e0cfd2c6c3300693ffc8de1c2217f1cad4cd05e59ea6b6995f42d5d31ea02d4fadddd9b071f711cf651b711c2a26e4b826244fc80e014ed66f368a7
+  SHA512 b8fc435412cd1909bc9ba5683cfa138a3ea08a76fecab78739ceedc7bb903d15d50d4362f702f7380fd047e5b6df3c76dfb75dd30bb20670a62205e6bc85021d
   HEAD_REF main
   PATCHES
-      "${DLLEXPORT_PATCH}"
-      remove-hardcoded-tinydtls-path.patch)
+      obgm-remove-self-configure-file.patch # https://github.com/obgm/libcoap/pull/1736
+      remove-hardcoded-tinydtls-path.patch
+)
 
 vcpkg_check_features(
   OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libcoap/vcpkg.json
+++ b/ports/libcoap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcoap",
-  "version-string": "4.3.5a",
+  "version-string": "4.3.5b",
   "description": "libcoap — A C implementation of the Constrained Application Protocol (RFC 7252)",
   "homepage": "https://libcoap.net/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4797,7 +4797,7 @@
       "port-version": 1
     },
     "libcoap": {
-      "baseline": "4.3.5a",
+      "baseline": "4.3.5b",
       "port-version": 0
     },
     "libconfig": {

--- a/versions/l-/libcoap.json
+++ b/versions/l-/libcoap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e35de302b10064b67a1194fa599b5d5a17da43c",
+      "version-string": "4.3.5b",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ef78e23f4bd28fb8a439b0956a9937697e659c3",
       "version-string": "4.3.5a",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Previous patch didn't applied correctly anymore, therefore added the relevant part as patch file.