### PR TITLE
[hical61-hical] update to 2.6.0

### DIFF
--- a/ports/hical61-hical/include-cstdint.patch
+++ b/ports/hical61-hical/include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/core/WsDeflate.cpp b/src/core/WsDeflate.cpp
+index df8bef1..ded30a6 100644
+--- a/src/core/WsDeflate.cpp
++++ b/src/core/WsDeflate.cpp
+@@ -1,6 +1,7 @@
+ #include "WsDeflate.h"
+ #include <cstring>
+ #include <stdexcept>
++#include <cstdint>
+ #include <zlib.h>
+ 
+ namespace hical

--- a/ports/hical61-hical/portfile.cmake
+++ b/ports/hical61-hical/portfile.cmake
@@ -4,8 +4,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Hical61/Hical
     REF "v${VERSION}"
-    SHA512 51d22669034176e977f3ab0747f835162727870211668d53a8f9464031eae92f26c771438f1cdeb0a742af1f1007d8579499c62e94220f4af0913d52ff2070fd
+    SHA512 6bffc33be3be6e8147a2e64f1cece0e669a4b31f7fab830d35cc149a7936600d3330699660fd7c24b3b4a5ff252d86cf2cd3361b9e6bf42285d2c20f1bf8aede
     HEAD_REF main
+    PATCHES
+        include-cstdint.patch
 )
 
 vcpkg_check_features(

--- a/ports/hical61-hical/vcpkg.json
+++ b/ports/hical61-hical/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hical61-hical",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "Modern C++20/C++26 high-performance web framework based on Boost.Asio/Beast",
   "homepage": "https://github.com/Hical61/Hical",
   "license": "MIT",

--- a/ports/hical61-hical/vcpkg.json
+++ b/ports/hical61-hical/vcpkg.json
@@ -22,7 +22,8 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ],
   "features": {
     "database": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3813,7 +3813,7 @@
       "port-version": 0
     },
     "hical61-hical": {
-      "baseline": "2.5.2",
+      "baseline": "2.6.0",
       "port-version": 0
     },
     "hidapi": {

--- a/versions/h-/hical61-hical.json
+++ b/versions/h-/hical61-hical.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d92de5999c4018b4a47a3a0e37e1725290f72f42",
+      "git-tree": "b7ae7f15acc719b65521277233e0d1dbc898409e",
       "version": "2.6.0",
       "port-version": 0
     },

--- a/versions/h-/hical61-hical.json
+++ b/versions/h-/hical61-hical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d92de5999c4018b4a47a3a0e37e1725290f72f42",
+      "version": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c1dcf3c250514da9d17c743821d086fd18809dab",
       "version": "2.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Hical61/Hical/releases/tag/v2.6.0
