### PR TITLE
[roaring] update to 4.7.0

### DIFF
--- a/ports/roaring/portfile.cmake
+++ b/ports/roaring/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RoaringBitmap/CRoaring
     REF "v${VERSION}"
-    SHA512 1559e600d9adc4701a009d9f230dcdb9a248756ecd81188637e7893803d045ecdb100fa9e10451bedec5cb1399a417867a1f4318e389d304da166d94e86ef5ba
+    SHA512 5d9e5c1b37c0da5fc88fe0ea93db4ba58dcdeed981c8d2c03c0c51c15700ee84bcc5a2a2fd58856d6be6ac129476e71aeea48deea6fbf41c809c6251b52f40c9
     HEAD_REF master
 )
 

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "roaring",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",
+  "supports": "!(android & arm32)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8833,7 +8833,7 @@
       "port-version": 0
     },
     "roaring": {
-      "baseline": "4.6.1",
+      "baseline": "4.7.0",
       "port-version": 0
     },
     "robin-hood-hashing": {

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a426c1db5717d8c3b3cfceb60315f2b9050290b1",
+      "git-tree": "5cd37bd7d758cb802a570f884985e34c9ce0feab",
       "version": "4.7.0",
       "port-version": 0
     },

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a426c1db5717d8c3b3cfceb60315f2b9050290b1",
+      "version": "4.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b295eef4d27ad28661903521afd0a59d2b7be94e",
       "version": "4.6.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/RoaringBitmap/CRoaring/releases/tag/v4.7.0
