### PR TITLE
[gameinput] Update for 3.2.138 release

### DIFF
--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -46,7 +46,7 @@ else()
     vcpkg_download_distfile(ARCHIVE
         URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
         FILENAME "gameinput.${VERSION}.zip"
-        SHA512 7377a8cf9291318b99db4f94b6e2db6d8bd2a5afdac0b35bd38b3f51c75948a247e74dab155f2ba67d4ece78899e87c3e0e35510f1547bbc9b7c8202573a8ff6
+        SHA512 559aef9bc7963ea86a8526833fccf855d994d704001635513b6602e5c2dde7cf0b36b8fd0dba62b6ed6a4196cce41c37cdc0920506989e66826faf4289e91530
     )
 
     vcpkg_extract_source_archive(

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gameinput",
-  "version": "3.1.26100.6879",
+  "version": "3.2.138",
   "description": "GameInput",
   "homepage": "https://aka.ms/gameinput",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3289,7 +3289,7 @@
       "port-version": 0
     },
     "gameinput": {
-      "baseline": "3.1.26100.6879",
+      "baseline": "3.2.138",
       "port-version": 0
     },
     "gamenetworkingsockets": {

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "962b3f4d1eb3f36ddf34cbc9b39488672bd6a78d",
+      "version": "3.2.138",
+      "port-version": 0
+    },
+    {
       "git-tree": "e7eca0e7d1866ac7c18a817bec8e1b8df92ab5da",
       "version": "3.1.26100.6879",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
