### PR TITLE
[picohttpparser] Add new port, devendor from [cinatra]

### DIFF
--- a/ports/cinatra/fix-picohttpparser-include-guard.patch
+++ b/ports/cinatra/fix-picohttpparser-include-guard.patch
@@ -1,0 +1,27 @@
+From dfdd983a4daed8a12c0283e579d8d2e31a2504fc Mon Sep 17 00:00:00 2001
+From: vcpkg <patch@vcpkg>
+Date: Wed, 13 May 2026 15:05:10 -0700
+Subject: [PATCH] Use unique include guard for vendored picohttpparser
+
+---
+ include/cinatra/picohttpparser.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/cinatra/picohttpparser.h b/include/cinatra/picohttpparser.h
+index 30e3b45..dc26bb4 100644
+--- a/include/cinatra/picohttpparser.h
++++ b/include/cinatra/picohttpparser.h
+@@ -24,8 +24,8 @@
+  * IN THE SOFTWARE.
+  */
+ 
+-#ifndef picohttpparser_h
+-#define picohttpparser_h
++#ifndef cinatra_picohttpparser_h
++#define cinatra_picohttpparser_h
+ #include <assert.h>
+ #include <stddef.h>
+ #include <string.h>
+-- 
+2.54.0.windows.1
+

--- a/ports/cinatra/portfile.cmake
+++ b/ports/cinatra/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 dfc58ab01ea962f007e8922a4614b3017f4e6da03d5f79edf3b8ee2750a23803b20fc905ffb1600ee7d2440339b84543c61ddae58e13a587d357db8372baf510
     HEAD_REF master
+    PATCHES
+        fix-picohttpparser-include-guard.patch
 )
 
 # Install Cinatra’s headers

--- a/ports/cinatra/vcpkg.json
+++ b/ports/cinatra/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cinatra",
   "version": "1.0.0",
+  "port-version": 1,
   "description": "Cinatra is a high performance HTTP framework with modern C++ features.",
   "homepage": "https://github.com/qicosmos/cinatra",
   "license": "MIT",

--- a/ports/picohttpparser/CMakeLists.txt
+++ b/ports/picohttpparser/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.14)
+project(picohttpparser C)
+
+add_library(picohttpparser picohttpparser.c)
+
+target_include_directories(picohttpparser
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS picohttpparser
+    EXPORT unofficial-picohttpparser-config
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES picohttpparser.h DESTINATION include)
+
+install(EXPORT unofficial-picohttpparser-config
+    FILE unofficial-picohttpparser-config.cmake
+    NAMESPACE unofficial::picohttpparser::
+    DESTINATION share/unofficial-picohttpparser
+)

--- a/ports/picohttpparser/portfile.cmake
+++ b/ports/picohttpparser/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO h2o/picohttpparser
+    REF f4d94b48b31e0abae029ebeafcfd9ca0680ede58
+    SHA512 7d94d107572c0fcf138636fb0693e87b8302adf08265d6361763384d428f979d9c1f5a627ffa8ad2ee855ec29d3b5c39ee8fba63b5e757830c3bad266940cf54
+    HEAD_REF master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-picohttpparser)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/picohttpparser.h")

--- a/ports/picohttpparser/usage
+++ b/ports/picohttpparser/usage
@@ -1,0 +1,4 @@
+picohttpparser provides CMake targets:
+
+  find_package(unofficial-picohttpparser CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::picohttpparser::picohttpparser)

--- a/ports/picohttpparser/vcpkg.json
+++ b/ports/picohttpparser/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "picohttpparser",
+  "version-date": "2026-04-06",
+  "description": "Tiny, primitive, fast HTTP request/response parser",
+  "homepage": "https://github.com/h2o/picohttpparser",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/picohttpparser/vcpkg.json
+++ b/ports/picohttpparser/vcpkg.json
@@ -3,7 +3,7 @@
   "version-date": "2026-04-06",
   "description": "Tiny, primitive, fast HTTP request/response parser",
   "homepage": "https://github.com/h2o/picohttpparser",
-  "license": "MIT",
+  "license": "MIT OR Artistic-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7732,6 +7732,10 @@
       "baseline": "2.9.0",
       "port-version": 0
     },
+    "picohttpparser": {
+      "baseline": "2026-04-06",
+      "port-version": 0
+    },
     "picojson": {
       "baseline": "1.3.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1746,7 +1746,7 @@
     },
     "cinatra": {
       "baseline": "1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cista": {
       "baseline": "0.16",

--- a/versions/c-/cinatra.json
+++ b/versions/c-/cinatra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89f5d9ea7ec5934de0cc2a2ce16c236988e26450",
+      "version": "1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "69d3ae25fd17ae739b6f5cff68a5a12249090182",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/p-/picohttpparser.json
+++ b/versions/p-/picohttpparser.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5506ba520a575863b56575fc95ad98bc5672bd06",
+      "git-tree": "696c1ab34b006932dbe48891f1d46e64e06bef4d",
       "version-date": "2026-04-06",
       "port-version": 0
     }

--- a/versions/p-/picohttpparser.json
+++ b/versions/p-/picohttpparser.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5506ba520a575863b56575fc95ad98bc5672bd06",
+      "version-date": "2026-04-06",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Required by #51671, created with the create-port skill in #51187.

Adds a port for https://github.com/h2o/picohttpparser. 

The `cinatra` port vendors an extensively modified copy of `picohttpparser.h` but namespaced to avoid conflicts with upstream. Both versions have been tested using a test project and are installable side-by-side.

---

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [X] The project is in Repology: https://repology.org/project/picohttpparser/versions
    - [X] The project is amongst the first web search results for "picohttpparser" or "picohttpparser C++". Include a screenshot of the search engine results in the PR.
      <img width="320" alt="image" src="https://github.com/user-attachments/assets/04cb861c-55e9-45e4-bcd1-25541065f25c" />
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [X] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
    - Upstream recommends live-at-head over tag releases: https://github.com/h2o/picohttpparser/blob/f4d94b48b31e0abae029ebeafcfd9ca0680ede58/picohttpparser.h#L41-L42
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.


