### PR TITLE
[libmultisense] Update to `v7.7.0`

### DIFF
--- a/ports/libmultisense/0001-have-opencv-odr-fix.patch
+++ b/ports/libmultisense/0001-have-opencv-odr-fix.patch
@@ -1,0 +1,146 @@
+diff --git a/README.md b/README.md
+index ad0a76f..5a3c324 100644
+--- a/README.md
++++ b/README.md
+@@ -677,7 +677,6 @@ if __name__ == "__main__":
+ 
+ #include <opencv2/opencv.hpp>
+ 
+-#define HAVE_OPENCV 1
+ #include <MultiSense/MultiSenseChannel.hh>
+ #include <MultiSense/MultiSenseUtilities.hh>
+ 
+@@ -772,7 +771,6 @@ if __name__ == "__main__":
+ 
+ #include <opencv2/opencv.hpp>
+ 
+-#define HAVE_OPENCV 1
+ #include <MultiSense/MultiSenseChannel.hh>
+ #include <MultiSense/MultiSenseUtilities.hh>
+ 
+@@ -1259,7 +1257,6 @@ if __name__ == "__main__":
+ #include <iostream>
+ #include <opencv2/opencv.hpp>
+ 
+-#define HAVE_OPENCV 1
+ #include <MultiSense/MultiSenseChannel.hh>
+ #include <MultiSense/MultiSenseUtilities.hh>
+ 
+diff --git a/source/LibMultiSense/CMakeLists.txt b/source/LibMultiSense/CMakeLists.txt
+index f868142..a6efa0f 100644
+--- a/source/LibMultiSense/CMakeLists.txt
++++ b/source/LibMultiSense/CMakeLists.txt
+@@ -37,7 +37,7 @@ target_include_directories(MultiSense
+ 
+ if (BUILD_OPENCV)
+   if(OpenCV_FOUND)
+-    target_compile_definitions(MultiSense PRIVATE HAVE_OPENCV)
++    target_compile_definitions(MultiSense PUBLIC MULTISENSE_HAVE_OPENCV)
+ 
+     target_include_directories(MultiSense PUBLIC ${OpenCV_INCLUDE_DIRS})
+ 
+diff --git a/source/LibMultiSense/details/utilities.cc b/source/LibMultiSense/details/utilities.cc
+index b1ea135..199015b 100644
+--- a/source/LibMultiSense/details/utilities.cc
++++ b/source/LibMultiSense/details/utilities.cc
+@@ -53,7 +53,7 @@
+ #include <iostream>
+ #include <stdexcept>
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+ #include <opencv2/imgcodecs.hpp>
+ #include <opencv2/features2d.hpp>
+ #endif
+@@ -64,7 +64,7 @@
+ namespace multisense {
+ namespace {
+ 
+-#ifndef HAVE_OPENCV
++#ifndef MULTISENSE_HAVE_OPENCV
+ bool write_binary_image(const Image &image, const std::filesystem::path &path)
+ {
+     std::ofstream output(path, std::ios::binary | std::ios::out);
+@@ -193,7 +193,7 @@ std::string to_string(const DataSource &source)
+ }
+ 
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+ cv::Mat Image::cv_mat() const
+ {
+     int cv_type = 0;
+@@ -243,7 +243,7 @@ cv::Mat FeatureMessage::cv_descriptors() const
+ 
+ bool write_image(const Image &image, const std::filesystem::path &path)
+ {
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+     return cv::imwrite(path.string(), image.cv_mat());
+ #else
+     const auto extension = path.extension();
+diff --git a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+index 3d4590c..4ba56b6 100644
+--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
++++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+@@ -47,7 +47,7 @@
+ #include <tuple>
+ #include <vector>
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+ #include <opencv2/core/mat.hpp>
+ #endif
+ 
+@@ -289,7 +289,7 @@ struct Image
+         return std::nullopt;
+     }
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+     ///
+     /// @brief Transform a image into a cv::Mat object if the user wants to build OpenCV utilities
+     ///        The cv::Mat returned here wraps the underlying image data pointer associated with
+@@ -392,7 +392,7 @@ struct FeatureMessage
+     ///
+     std::vector<uint8_t> descriptors{};
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+     ///
+     /// @brief Convert keypoints to native OpenCV keypoints
+     ///
+diff --git a/source/LibMultiSense/test/feature_test.cc b/source/LibMultiSense/test/feature_test.cc
+index 1124393..22fe563 100644
+--- a/source/LibMultiSense/test/feature_test.cc
++++ b/source/LibMultiSense/test/feature_test.cc
+@@ -40,7 +40,7 @@
+ #include <MultiSense/wire/FeatureMessage.hh>
+ #include <MultiSense/wire/FeatureMetaMessage.hh>
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+ #include <opencv2/core.hpp>
+ #include <opencv2/features2d.hpp>
+ #endif
+@@ -90,7 +90,7 @@ TEST(ImageFrame, Features)
+     EXPECT_EQ(frame.frame_id, 1234);
+ }
+ 
+-#ifdef HAVE_OPENCV
++#ifdef MULTISENSE_HAVE_OPENCV
+ TEST(FeatureMessage, OpenCVConversion)
+ {
+     FeatureMessage msg;
+diff --git a/source/Utilities/LibMultiSense/FeatureDetectorUtility/FeatureDetectorUtility.cc b/source/Utilities/LibMultiSense/FeatureDetectorUtility/FeatureDetectorUtility.cc
+index e371757..6bc5575 100644
+--- a/source/Utilities/LibMultiSense/FeatureDetectorUtility/FeatureDetectorUtility.cc
++++ b/source/Utilities/LibMultiSense/FeatureDetectorUtility/FeatureDetectorUtility.cc
+@@ -49,7 +49,6 @@
+ #include <iostream>
+ #include <thread>
+ 
+-#define HAVE_OPENCV 1
+ #include <opencv2/features2d.hpp>
+ #include <opencv2/highgui.hpp>
+ #include <opencv2/imgproc.hpp>

--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0000-disable-error-on-warning.patch
+        0001-have-opencv-odr-fix.patch
 )
 
 vcpkg_check_features(

--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -53,6 +53,9 @@ if ("utilities" IN_LIST FEATURES)
     if ("json-serialization" IN_LIST FEATURES)
         list(APPEND _tool_names DeviceInfoUtility)
     endif ()
+    if ("opencv" IN_LIST FEATURES)
+        list(APPEND _tool_names FeatureDetectorUtility)
+    endif ()
     vcpkg_copy_tools(
         TOOL_NAMES ${_tool_names}
         AUTO_CLEAN

--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO carnegierobotics/LibMultiSense
     REF ${VERSION}
-    SHA512 71c779cc0f23818aaab4cbba0a5aa5b3ad979180247a3d76b0f8fd5a3b7ced106520fa5df69946cd84510211b6508f5df80b09aecbbabb6601fee5f38ec79bc7
+    SHA512 9c4cb8c1e0cf10fc4cc773015a0f55fadae1c7c10c52708b5d7f2b72a8fcecedfbe400fadbc981492bbe70107f51cfd0eb5878bf7ae5f1f320d56d9038bd4f9b
     HEAD_REF master
     PATCHES
         0000-disable-error-on-warning.patch

--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -39,6 +39,11 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+# LibMultiSense installs additional CMake helper modules alongside `MultiSenseConfig.cmake`.
+# `vcpkg_cmake_config_fixup()` only removes debug-side `*Config`/`*Targets` files, which leaves
+# `${CURRENT_PACKAGES_DIR}/debug/share/MultiSense` populated and triggers a post-build policy error.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
 if ("utilities" IN_LIST FEATURES)
     set(_tool_names
         ChangeIpUtility

--- a/ports/libmultisense/vcpkg.json
+++ b/ports/libmultisense/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmultisense",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "A C++ library for interfacing with the MultiSense S family of sensors from Carnegie Robotics.",
   "homepage": "https://github.com/carnegierobotics/LibMultiSense",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5325,7 +5325,7 @@
       "port-version": 1
     },
     "libmultisense": {
-      "baseline": "7.6.0",
+      "baseline": "7.7.0",
       "port-version": 0
     },
     "libmupdf": {

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8b40d299a0683d2e766b6ee49e4aa32967f19457",
+      "git-tree": "e93615ce2c7e9290bab01fc0c477321fd2f19189",
       "version": "7.7.0",
       "port-version": 0
     },

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "50b14981407b01a1216162e7a5e5f457b6081da3",
+      "git-tree": "8b40d299a0683d2e766b6ee49e4aa32967f19457",
       "version": "7.7.0",
       "port-version": 0
     },

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ed19fcc9036ae29826e59650f6e30e1a8933460",
+      "git-tree": "50b14981407b01a1216162e7a5e5f457b6081da3",
       "version": "7.7.0",
       "port-version": 0
     },

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ed19fcc9036ae29826e59650f6e30e1a8933460",
+      "version": "7.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "88faa7763bbf94f2670b23f179e1a8a840965582",
       "version": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
