### PR TITLE
[gameinput, directxtk, directxtk12] Update for GameInput 3.3 with arm64

### DIFF
--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtk",
   "version-date": "2026-05-07",
+  "port-version": 1,
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
@@ -20,7 +21,7 @@
   "features": {
     "gameinput": {
       "description": "Build using GameInput API for input processing",
-      "supports": "windows & x64 & !uwp",
+      "supports": "windows & (arm64 | x64) & !uwp",
       "dependencies": [
         "gameinput"
       ]

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtk12",
   "version-date": "2026-05-07",
+  "port-version": 1,
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
@@ -36,7 +37,7 @@
   "features": {
     "gameinput": {
       "description": "Build using GameInput API for input processing",
-      "supports": "windows & x64 & !uwp",
+      "supports": "windows & (arm64 | x64) & !uwp",
       "dependencies": [
         "gameinput"
       ]

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -63,7 +63,7 @@ else()
     if(VCPKG_TARGET_IS_MINGW)
         # "Thick" GameInput.lib is not compatible with MinGW
 
-        file(COPY "${PACKAGE_PATH}/native/lib/x64/GameInput.cpp" DESTINATION "${CURRENT_BUILDTREES_DIR}/fixlib")
+        file(COPY "${PACKAGE_PATH}/native/src/GameInput.cpp" DESTINATION "${CURRENT_BUILDTREES_DIR}/fixlib")
 
         configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in"
             "${CURRENT_BUILDTREES_DIR}/fixlib/CMakeLists.txt"

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -46,7 +46,7 @@ else()
     vcpkg_download_distfile(ARCHIVE
         URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
         FILENAME "gameinput.${VERSION}.zip"
-        SHA512 559aef9bc7963ea86a8526833fccf855d994d704001635513b6602e5c2dde7cf0b36b8fd0dba62b6ed6a4196cce41c37cdc0920506989e66826faf4289e91530
+        SHA512 e91aef50dc929a9446772525a59e832050979b81c460314a9e42f45359cd533b196a0218adad70099a4b06863c4b640325c36bcd2445bad741eabf982cec5bf2
     )
 
     vcpkg_extract_source_archive(

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "gameinput",
-  "version": "3.2.138",
+  "version": "3.3.195",
   "description": "GameInput",
   "homepage": "https://aka.ms/gameinput",
   "license": null,
-  "supports": "windows & x64 & !uwp",
+  "supports": "windows & (arm64 | x64) & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2530,11 +2530,11 @@
     },
     "directxtk": {
       "baseline": "2026-05-07",
-      "port-version": 0
+      "port-version": 1
     },
     "directxtk12": {
       "baseline": "2026-05-07",
-      "port-version": 0
+      "port-version": 1
     },
     "dirent": {
       "baseline": "1.26",
@@ -3289,7 +3289,7 @@
       "port-version": 0
     },
     "gameinput": {
-      "baseline": "3.2.138",
+      "baseline": "3.3.195",
       "port-version": 0
     },
     "gamenetworkingsockets": {

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bd837ddca7efd128c2db51fe75993737c92451c",
+      "version-date": "2026-05-07",
+      "port-version": 1
+    },
+    {
       "git-tree": "6d6ae29af36aadef42a83a628770be6663659291",
       "version-date": "2026-05-07",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2b7acc029b571780b27e9901b03b2d78c724576",
+      "version-date": "2026-05-07",
+      "port-version": 1
+    },
+    {
       "git-tree": "7f9865dfa59c3a00086a41076d1e9f1d33dd9a6d",
       "version-date": "2026-05-07",
       "port-version": 0

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4e1f487ae4fa213b73462e825f2553d95d7f117c",
+      "git-tree": "df6cb72a5e5df44329dc686316ef7d9ef4a7f6cf",
       "version": "3.3.195",
       "port-version": 0
     },

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e1f487ae4fa213b73462e825f2553d95d7f117c",
+      "version": "3.3.195",
+      "port-version": 0
+    },
+    {
       "git-tree": "962b3f4d1eb3f36ddf34cbc9b39488672bd6a78d",
       "version": "3.2.138",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
