### PR TITLE
[duckdb] Avoid stdext::checked_array_iterator.

### DIFF
--- a/ports/duckdb/avoid-stdext-checked-array-iterator.diff
+++ b/ports/duckdb/avoid-stdext-checked-array-iterator.diff
@@ -1,0 +1,13 @@
+diff --git a/third_party/fmt/include/fmt/format.h b/third_party/fmt/include/fmt/format.h
+index 4c51630..bc2496c 100644
+--- a/third_party/fmt/include/fmt/format.h
++++ b/third_party/fmt/include/fmt/format.h
+@@ -321,7 +321,7 @@ inline typename Container::value_type* get_data(Container& c) {
+   return c.data();
+ }
+ 
+-#ifdef _SECURE_SCL
++#if defined(_SECURE_SCL) && defined(_MSC_VER) && _MSC_VER < 1951
+ // Make a checked iterator to avoid MSVC warnings.
+ template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+ template <typename T> checked_ptr<T> make_checked(T* p, std::size_t size) {

--- a/ports/duckdb/library-linkage.diff
+++ b/ports/duckdb/library-linkage.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4e9d498..70414b4 100644
+index 3246265..295da5f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -410,7 +410,6 @@ option(EXTENSION_STATIC_BUILD
+@@ -420,7 +420,6 @@ option(EXTENSION_STATIC_BUILD
          FALSE)
  
  if(WIN32 OR ZOS)
@@ -10,7 +10,7 @@ index 4e9d498..70414b4 100644
    add_definitions(-D_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS=1)
  endif()
  
-@@ -857,6 +856,7 @@ if (NOT EXTENSION_CONFIG_BUILD AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_TID
+@@ -863,6 +862,7 @@ if (NOT ${EXTENSION_CONFIG_BUILD} AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_
      message(STATUS "Extensions will be deployed to: ${LOCAL_EXTENSION_REPO_DIR}")
    endif()
  endif()
@@ -18,7 +18,7 @@ index 4e9d498..70414b4 100644
  
  function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTENSION_VERSION CAPI_VERSION PARAMETERS)
    set(TARGET_NAME ${NAME}_loadable_extension)
-@@ -875,6 +875,8 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
+@@ -881,6 +881,8 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
  
    if(EMSCRIPTEN)
       add_library(${TARGET_NAME} STATIC ${FILES})

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -1,15 +1,17 @@
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO duckdb/duckdb
-        REF v${VERSION}
-        SHA512 2287ff1af67808e495ca4da527bd54e9c9f2044ed1bb4749cdaeee7993a7b0edca73cccd476a607442a4bf313b43e2358bf6ca28035e2dbe52b16847f6e5b30a
-        HEAD_REF main
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO duckdb/duckdb
+    REF v${VERSION}
+    SHA512 2287ff1af67808e495ca4da527bd54e9c9f2044ed1bb4749cdaeee7993a7b0edca73cccd476a607442a4bf313b43e2358bf6ca28035e2dbe52b16847f6e5b30a
+    HEAD_REF main
     PATCHES
         library-linkage.diff
+        avoid-stdext-checked-array-iterator.diff
 )
+
 # Remove vendored dependencies which are optional or not properly namespaced
 file(REMOVE_RECURSE
-    "${SOURCE_PATH}/extension/third_party/icu"
+    "${SOURCE_PATH}/extension/icu/third_party/icu"
     "${SOURCE_PATH}/third_party/catch"
     "${SOURCE_PATH}/third_party/imdb"
     "${SOURCE_PATH}/third_party/snowball"

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "duckdb",
   "version": "1.4.4",
+  "port-version": 1,
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2642,7 +2642,7 @@
     },
     "duckdb": {
       "baseline": "1.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "duckx": {
       "baseline": "1.2.2",

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ba0158231318c84f32a9c56525d13d733e89161",
+      "version": "1.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d8bae3bb7089ffc184af199c454e7aa704e4eee",
       "version": "1.4.4",
       "port-version": 0


### PR DESCRIPTION
As part of May Patch Tuesday we are updating vcpkg's build lab to Visual Studio 2026, and this fixes building duckdb with that.

I initially tried devendoring fmt but they have put it in its own namespace that makes it not devendorable.

Resolves:

```
\third_party\fmt\include\fmt/format.h(326): error C2653: 'stdext': is not a class or namespace name
\third_party\fmt\include\fmt/format.h(326): error C2061: syntax error: identifier 'checked_array_iterator'
\third_party\fmt\include\fmt/format.h(327): error C2988: unrecognizable template declaration/definition
\third_party\fmt\include\fmt/format.h(327): error C2143: syntax error: missing ';' before '<'
\third_party\fmt\include\fmt/format.h(327): error C2059: syntax error: '<'
\third_party\fmt\include\fmt/format.h(327): error C2143: syntax error: missing ';' before '{'
\third_party\fmt\include\fmt/format.h(327): error C2447: '{': missing function header (old-style formal list?)
\third_party\fmt\include\fmt/format.h(335): warning C4346: 'value': dependent name is not a type
\third_party\fmt\include\fmt/format.h(335): note: prefix the qualified-id with 'typename' to indicate a type
\third_party\fmt\include\fmt/format.h(336): error C2988: unrecognizable template declaration/definition
\third_party\fmt\include\fmt/format.h(336): error C2143: syntax error: missing ';' before '<'
\third_party\fmt\include\fmt/format.h(336): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
\third_party\fmt\include\fmt/format.h(336): error C2059: syntax error: '<'
\third_party\fmt\include\fmt/format.h(336): error C2653: 'Container': is not a class or namespace name
\third_party\fmt\include\fmt/format.h(337): error C2065: 'Container': undeclared identifier
\third_party\fmt\include\fmt/format.h(337): error C2923: 'std::back_insert_iterator': 'Container' is not a valid template type argument for parameter '_Container'
\third_party\fmt\include\fmt/format.h(337): note: see declaration of 'Container'
\third_party\fmt\include\fmt/format.h(337): error C2143: syntax error: missing ';' before '{'
\third_party\fmt\include\fmt/format.h(337): error C2447: '{': missing function header (old-style formal list?)
```
