### PR TITLE
[tcl] Fix build with MSVC 19.51

### DIFF
--- a/ports/tcl/fix-uuid-ctrl-z.diff
+++ b/ports/tcl/fix-uuid-ctrl-z.diff
@@ -1,0 +1,12 @@
+diff --git a/win/makefile.vc b/win/makefile.vc
+--- a/win/makefile.vc
++++ b/win/makefile.vc
+@@ -886,7 +886,7 @@ $(ROOT)\manifest.uuid:
+ 	git rev-parse HEAD >>$(ROOT)\manifest.uuid
+ 
+ $(TMP_DIR)\tclUuid.h:	$(ROOT)\manifest.uuid
+-	copy $(WIN_DIR)\tclUuid.h.in+$(ROOT)\manifest.uuid $(TMP_DIR)\tclUuid.h
++	copy /b $(WIN_DIR)\tclUuid.h.in+$(ROOT)\manifest.uuid $(TMP_DIR)\tclUuid.h
+ 
+ $(TMP_DIR)\tclEvent.obj: $(GENERICDIR)\tclEvent.c $(TMP_DIR)\tclUuid.h
+ 	$(cc32) $(pkgcflags) -I$(COMPATDIR)\zlib -I$(TMP_DIR) \

--- a/ports/tcl/portfile.cmake
+++ b/ports/tcl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     PATCHES
         dependencies.diff
         nmake.diff
+        fix-uuid-ctrl-z.diff
 )
 file(GLOB sqlite3_sources "${SOURCE_PATH}/pkgs/sqlite3.51.0/compat/sqlite3/*.c" "${SOURCE_PATH}/pkgs/sqlite3.51.0/compat/sqlite3/*.h")
 file(GLOB precompiled_tools "${SOURCE_PATH}/win/*.exe" "${SOURCE_PATH}/pkgs/*/win/*.exe")

--- a/ports/tcl/vcpkg.json
+++ b/ports/tcl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tcl",
   "version": "9.0.3",
+  "port-version": 1,
   "description": "Tcl provides a powerful platform for creating integration applications that tie together diverse applications, protocols, devices, and frameworks. When paired with the Tk toolkit, Tcl provides the fastest and most powerful way to create GUI applications that run on PCs, Unix, and Mac OS X. Tcl can also be used for a variety of web-related tasks and for creating powerful command languages for applications.",
   "homepage": "https://github.com/tcltk/tcl",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9930,7 +9930,7 @@
     },
     "tcl": {
       "baseline": "9.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "tclap": {
       "baseline": "1.2.5",

--- a/versions/t-/tcl.json
+++ b/versions/t-/tcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb841e8b157edf680c0f8ef284bff02bd1388bd8",
+      "version": "9.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "ecf39d065f594ac59d91f1e2da8ac13e866dacb5",
       "version": "9.0.3",
       "port-version": 0


### PR DESCRIPTION
Made with Claude Sonnet 4.6

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
