### PR TITLE
[mpss] Add new port

### DIFF
--- a/ports/mpss/portfile.cmake
+++ b/ports/mpss/portfile.cmake
@@ -1,0 +1,54 @@
+# Android only supports shared libraries.
+if(VCPKG_TARGET_IS_ANDROID)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/mpss
+    REF "v${VERSION}"
+    SHA512 892052999aa045af768cfb708a4dc5de1ecc59f0e065ba8ab9331834cf19a8abb2cfac66a85b9c38abb9fb97cb506b1248b52f67647b257aa9e86240b0797213
+    HEAD_REF main
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(LIBRARY_LINKAGE "STATIC")
+    set(UNUSED_LINKAGE "SHARED")
+else()
+    set(LIBRARY_LINKAGE "SHARED")
+    set(UNUSED_LINKAGE "STATIC")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openssl    MPSS_BUILD_MPSS_OPENSSL_${LIBRARY_LINKAGE}
+        yubikey    MPSS_BACKEND_YUBIKEY
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DMPSS_BUILD_MPSS_CORE_${LIBRARY_LINKAGE}=ON
+        -DMPSS_BUILD_MPSS_CORE_${UNUSED_LINKAGE}=OFF
+        -DMPSS_BUILD_MPSS_OPENSSL_${UNUSED_LINKAGE}=OFF
+        -DMPSS_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/mpss")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mpss/usage
+++ b/ports/mpss/usage
@@ -1,0 +1,7 @@
+mpss provides CMake targets:
+
+  find_package(mpss CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:mpss::mpss>,mpss::mpss,mpss::mpss_static>)
+
+  # OpenSSL provider (if installed with vcpkg install mpss[openssl]):
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:mpss::mpss_openssl>,mpss::mpss_openssl,mpss::mpss_openssl_static>)

--- a/ports/mpss/vcpkg.json
+++ b/ports/mpss/vcpkg.json
@@ -1,0 +1,40 @@
+{
+  "name": "mpss",
+  "version": "1.2.1",
+  "description": "A multi-platform C++ library for hardware-backed digital signature key storage and signing.",
+  "homepage": "https://github.com/microsoft/mpss",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "mpss",
+      "features": [
+        "yubikey"
+      ],
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "openssl": {
+      "description": "Build the OpenSSL 3.x provider (mpss-openssl).",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "yubikey": {
+      "description": "Enable the YubiKey PIV backend. Required on Linux (no OS-native backend available).",
+      "supports": "!ios & !android",
+      "dependencies": [
+        "openssl",
+        "yubico-piv-tool"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6708,6 +6708,10 @@
       "baseline": "2021-12-01",
       "port-version": 0
     },
+    "mpss": {
+      "baseline": "1.2.1",
+      "port-version": 0
+    },
     "mqtt-cpp": {
       "baseline": "13.2.3",
       "port-version": 0

--- a/versions/m-/mpss.json
+++ b/versions/m-/mpss.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "b5cb63aa56def2becfb4572e69cb5acbf2a1adfa",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
+      "git-tree": "4a3580bd1323fda584237598489303e98a4da947",
+      "version": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<img width="2386" height="1283" alt="Screenshot_15-5-2026_175624_www google com" src="https://github.com/user-attachments/assets/6c7056ff-2f2c-459b-a2e1-e6eb0ca0d95d" />
