### PR TITLE
[arcticdb-sparrow] Fix MSVC break.

### DIFF
--- a/ports/arcticdb-sparrow/portfile.cmake
+++ b/ports/arcticdb-sparrow/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO man-group/sparrow
-    REF "${VERSION}"
-    SHA512 c2d8f7da6d97f65a15960d598b554b5d8caa1e586cf442c05f5d3be1d65d7e0372e2ff130d0241ff7b52268679a067afd8409a5cbb13391ab563bfe18dbfe13f
+    REF 7c521929ca10afeea29b8500e57e54842f8fc837 # this is 2.4.0 + an MSVC build break fix https://github.com/man-group/sparrow/pull/672
+    SHA512 747da0b989207640fc14ea3406da4fb7e77e3c88a24d998db3c1d45a96e28a43dd1fdd40c320e5e373d6bfb74a1a71f499c714e2dedb3870f564db5945197047
     HEAD_REF main
 )
 

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arcticdb-sparrow",
   "version": "2.4.0",
+  "port-version": 1,
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17e92c3b71fe8bdc840b397777e7846c97c33956",
+      "version": "2.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6580c1c02c66e0b54c97b0185eea76dad8dd5cba",
       "version": "2.4.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -218,7 +218,7 @@
     },
     "arcticdb-sparrow": {
       "baseline": "2.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arcticdb-sparrow-extensions": {
       "baseline": "1.2.0",


### PR DESCRIPTION
Resolves:

```console
\include\sparrow/map_array.hpp(589): error C2672: 'make_arrow_array': no matching overloaded function found
\include\sparrow/arrow_interface/arrow_array.hpp(63): note: could be 'ArrowArray sparrow::make_arrow_array(int64_t,int64_t,int64_t,B,ArrowArray **,const CHILDREN_OWNERSHIP &,ArrowArray *,bool)'
\include\sparrow/map_array.hpp(594): note: 'initializing': cannot convert from 'ArrowArray *(*)[1]' to 'ArrowArray **'
\include\sparrow/map_array.hpp(594): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
\include\sparrow/map_array.hpp(589): note: 'make_arrow_array': function declaration must be available as none of the arguments depend on a template parameter
\include\sparrow/map_array.hpp(359): note: This diagnostic occurred in the compiler generated function 'sparrow::arrow_proxy sparrow::map_array::create_proxy_impl(sparrow::array &&,sparrow::array &&,sparrow::map_array::offset_buffer_type &&,sparrow::buffer<uint8_t> &&,int64_t,std::optional<std::unordered_set<sparrow::ArrowFlag,std::hash<sparrow::ArrowFlag>,std::equal_to<sparrow::ArrowFlag>,std::allocator<sparrow::ArrowFlag>>>,std::optional<std::string_view>,std::optional<_Ty>)'
```

Fixes build in VS2026 18.6.0 / MSVC 14.51