### PR TITLE
[autodiff] Add new port

### DIFF
--- a/ports/autodiff/portfile.cmake
+++ b/ports/autodiff/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO autodiff/autodiff
+    REF "v${VERSION}"
+    SHA512 a8f3c3126fc8fb9502384eaf6cb416bfb24dede83edc70a8333c9e2824fefcb4221da71d2f0b30b52dcbe86042cb79a9dd1d93249bfdb052af71c0c1c63c819e
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAUTODIFF_BUILD_TESTS=OFF
+        -DAUTODIFF_BUILD_PYTHON=OFF
+        -DAUTODIFF_BUILD_EXAMPLES=OFF
+        -DAUTODIFF_BUILD_DOCS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/autodiff)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/autodiff/portfile.cmake
+++ b/ports/autodiff/portfile.cmake
@@ -25,5 +25,3 @@ file(REMOVE_RECURSE
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/autodiff/usage
+++ b/ports/autodiff/usage
@@ -1,0 +1,4 @@
+autodiff provides CMake targets:
+
+    find_package(autodiff CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE autodiff::autodiff)

--- a/ports/autodiff/usage
+++ b/ports/autodiff/usage
@@ -1,4 +1,0 @@
-autodiff provides CMake targets:
-
-    find_package(autodiff CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE autodiff::autodiff)

--- a/ports/autodiff/vcpkg.json
+++ b/ports/autodiff/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "autodiff",
+  "version": "1.1.2",
+  "description": "A modern, fast and expressive C++ library for automatic differentiation.",
+  "homepage": "https://autodiff.github.io",
+  "license": "MIT",
+  "dependencies": [
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/autodiff.json
+++ b/versions/a-/autodiff.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ff453396da001c656ff522f20a193c9f6da6dd07",
+      "version": "1.1.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/autodiff.json
+++ b/versions/a-/autodiff.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff453396da001c656ff522f20a193c9f6da6dd07",
+      "git-tree": "06ed96df4f4bc57404578d4176cf02db04a82191",
       "version": "1.1.2",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -420,6 +420,10 @@
       "baseline": "0.5.1",
       "port-version": 0
     },
+    "autodiff": {
+      "baseline": "1.1.2",
+      "port-version": 0
+    },
     "autodock-vina": {
       "baseline": "1.2.7",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/autodiff/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.