### PR TITLE
[crashpad] Support the VS Build Tools SKU

### DIFF
--- a/ports/crashpad/fix-lib-name-conflict-1.patch
+++ b/ports/crashpad/fix-lib-name-conflict-1.patch
@@ -1,5 +1,5 @@
 diff --git a/base/BUILD.gn b/base/BUILD.gn
-index 0bcf519..c637f2b 100644
+index 0bcf519..5e7b553 100644
 --- a/base/BUILD.gn
 +++ b/base/BUILD.gn
 @@ -5,6 +5,7 @@

--- a/ports/crashpad/fix-linux.patch
+++ b/ports/crashpad/fix-linux.patch
@@ -4,11 +4,11 @@ index 3013d7b..4cc135f 100644
 +++ b/util/misc/uuid.cc
 @@ -41,7 +41,8 @@
  namespace crashpad {
-
+ 
  static_assert(sizeof(UUID) == 16, "UUID must be 16 bytes");
 -static_assert(std::is_pod<UUID>::value, "UUID must be POD");
 +static_assert(std::is_standard_layout<UUID>::value, "UUID must be a standard-layout type");
 +static_assert(std::is_trivial<UUID>::value, "UUID must be a trivial type");
-
+ 
  bool UUID::operator==(const UUID& that) const {
    return memcmp(this, &that, sizeof(*this)) == 0;

--- a/ports/crashpad/fix-std-20.patch
+++ b/ports/crashpad/fix-std-20.patch
@@ -4,7 +4,7 @@ index 2486fb7..88e2d2d 100644
 +++ b/base/atomicops_internals_portable.h
 @@ -51,13 +51,7 @@ static_assert(sizeof(*(AtomicLocation32) nullptr) == sizeof(Atomic32),
                "incompatible 32-bit atomic layout");
-
+ 
  inline void MemoryBarrier() {
 -#if defined(__GLIBCXX__)
 -  // Work around libstdc++ bug 51038 where atomic_thread_fence was declared but
@@ -14,5 +14,5 @@ index 2486fb7..88e2d2d 100644
    std::atomic_thread_fence(std::memory_order_seq_cst);
 -#endif
  }
-
+ 
  inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -26,8 +26,10 @@ if(NOT EXISTS "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/BUILD.gn")
         PATCHES
             fix-std-20.patch
             ndk-toolchain.diff
+            support-build-tools-sku.diff
             fix-lib-name-conflict-1.patch
     )
+
     file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium")
     file(RENAME "${mini_chromium}" "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium")
 endif()

--- a/ports/crashpad/support-build-tools-sku.diff
+++ b/ports/crashpad/support-build-tools-sku.diff
@@ -1,0 +1,13 @@
+diff --git a/build/win_helper.py b/build/win_helper.py
+index be977c8..dd5d06d 100644
+--- a/build/win_helper.py
++++ b/build/win_helper.py
+@@ -186,7 +186,7 @@ class WinTool(object):
+           'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+       if os.path.exists(vswhere_path):
+         installation_path = subprocess.check_output(
+-            [vswhere_path, '-latest', '-property', 'installationPath']).strip()
++            [vswhere_path, '-latest', '-products', '*', '-property', 'installationPath']).strip()
+         if installation_path:
+           return (installation_path.decode("utf-8"),
+                   os.path.join('VC', 'Auxiliary', 'Build', 'vcvarsall.bat'))

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 11,
+  "port-version": 12,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2178,7 +2178,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 11
+      "port-version": 12
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "991d306e67bce6818dbf33d079075358b8943f59",
+      "version-date": "2024-04-11",
+      "port-version": 12
+    },
+    {
       "git-tree": "72faa94ef243fcd582120dac62c2573e538234bc",
       "version-date": "2024-04-11",
       "port-version": 11


### PR DESCRIPTION
`vswhere` says:

```console
  -products arg  One or more product IDs to find. Defaults to Community, Professional, and Enterprise.
                 Specify "*" by itself to search all product instances installed.
                 See https://aka.ms/vs/workloads for a list of product IDs.
```

Crashpad doing this rather than getting the path from vcpkg is incorrect but I'm not fixing that as part of a version update.
