### PR TITLE
[pxlib] Apply targetencoding conversion to memo BLOb fields

### DIFF
--- a/ports/pxlib/fix_blob_targetencoding.patch
+++ b/ports/pxlib/fix_blob_targetencoding.patch
@@ -1,0 +1,43 @@
+diff --git a/src/paradox.c b/src/paradox.c
+index 0000000..0000000 100644
+--- a/src/paradox.c
++++ b/src/paradox.c
+@@ -2037,6 +2037,38 @@
+ 						ret = PX_get_data_blob(pxdoc, &data[offset], pxf->px_flen, &mod_nr, &size, &blobdata);
+ 					if(ret > 0) {
+ 						if(blobdata) {
++#if PX_USE_ICONV
++							/* Memo BLObs are text in the DB's source codepage;
++							 * convert to targetencoding here, mirroring
++							 * PX_get_data_alpha. Other blob types
++							 * (pxfBLOb, pxfGraphic, pxfOLE) stay binary. */
++							if((pxf->px_ftype == pxfMemoBLOb || pxf->px_ftype == pxfFmtMemoBLOb)
++							   && pxdoc->targetencoding != NULL
++							   && pxdoc->out_iconvcd != (iconv_t)-1 && size > 0) {
++								char *obuf, *iptr = blobdata, *optr;
++								size_t olen = 2*(size_t)size + 1, ilen = (size_t)size;
++								int res;
++								optr = obuf = (char *) malloc(olen);
++								if(obuf != NULL) {
++									res = (int)iconv(pxdoc->out_iconvcd, &iptr, &ilen, &optr, &olen);
++									if(0 <= res) {
++										char *nb;
++										*optr = '\0';
++										olen = optr - obuf;
++										nb = (char *) pxdoc->malloc(pxdoc, olen+1,
++											_("Allocate memory for re-encoded memo data."));
++										if(nb) {
++											memcpy(nb, obuf, olen);
++											nb[olen] = '\0';
++											pxdoc->free(pxdoc, blobdata);
++											blobdata = nb;
++											size = (int)olen;
++										}
++									}
++									free(obuf);
++								}
++							}
++#endif
+ 							dataptr[i]->value.str.val = blobdata;
+ 							dataptr[i]->value.str.len = size;
+ 						} else {

--- a/ports/pxlib/portfile.cmake
+++ b/ports/pxlib/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         add_extern_c.patch
         use_modern_find_iconv.patch
         fix_iconv_handle_check.patch
+        fix_blob_targetencoding.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pxlib/vcpkg.json
+++ b/ports/pxlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pxlib",
   "version-date": "2025-12-16",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Library to read and write Paradox files",
   "homepage": "https://github.com/steinm/pxlib",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8062,7 +8062,7 @@
     },
     "pxlib": {
       "baseline": "2025-12-16",
-      "port-version": 2
+      "port-version": 3
     },
     "pybind11": {
       "baseline": "3.0.1",

--- a/versions/p-/pxlib.json
+++ b/versions/p-/pxlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00d7597a7d82318b0c058cf719b44117774ef2da",
+      "version-date": "2025-12-16",
+      "port-version": 3
+    },
+    {
       "git-tree": "bc74a2af9e402cd11e56cc7e9088b4208b95d0b3",
       "version-date": "2025-12-16",
       "port-version": 2


### PR DESCRIPTION
Adds `fix_blob_targetencoding.patch` and bumps `port-version` from 2 to 3.

`PX_retrieve_record` was returning memo BLOb field bytes in the database's source codepage (e.g. CP437) even when `targetencoding` was set. Alpha fields correctly go through iconv via `PX_get_data_alpha`. The patch applies the same iconv conversion to `pxfMemoBLOb` / `pxfFmtMemoBLOb`; binary blob types (`pxfBLOb`, `pxfGraphic`, `pxfOLE`) are left untouched. No behavior change when `targetencoding` is NULL.

The patch is submitted upstream: steinm/pxlib#16. Once merged, a follow-up PR will update the `REF` to the merged commit and remove the patch file.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.