### PR TITLE
[mujs] Update to 1.3.9

### DIFF
--- a/ports/mujs/portfile.cmake
+++ b/ports/mujs/portfile.cmake
@@ -4,10 +4,9 @@ endif()
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
-  GITHUB_HOST https://codeberg.org
-  REPO ccxvii/mujs
+  REPO ArtifexSoftware/mujs
   REF "${VERSION}"
-  SHA512 b553c09f2994b54ef6aa48ece3e6f8355ea69c6ec9ee2ea101fd33b3054dd6b57482c923c063929b3f108a5244ab51ffbd807d5a1d0f3f4ed4f40896ac97ab87
+  SHA512 a3be06a861f88fe8b10151bc2e56c19b8122078579f3c65a84f0874385d1e7c90dbc7891eff5c78c75c290fff62160a3babc43717fe03982668ca7aa40289552
   HEAD_REF master
 )
 

--- a/ports/mujs/vcpkg.json
+++ b/ports/mujs/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "mujs",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "An embeddable Javascript interpreter in C",
-  "homepage": "https://codeberg.org/ccxvii/mujs",
+  "homepage": "https://mujs.com/",
   "license": "ISC",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6789,7 +6789,7 @@
       "port-version": 0
     },
     "mujs": {
-      "baseline": "1.3.8",
+      "baseline": "1.3.9",
       "port-version": 0
     },
     "munit": {

--- a/versions/m-/mujs.json
+++ b/versions/m-/mujs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6742ebfd33e70bdbeb0d39e9bbb6486e6ce67857",
+      "version": "1.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b7d5921d1b954f32b668da52a2cb1dd631b2f8f",
       "version": "1.3.8",
       "port-version": 0


### PR DESCRIPTION
Cf. https://repology.org/project/mujs/versions

The 1.3.9 tag is not on https://codeberg.org/ccxvii/mujs. But that repo's description points to  http://mujs.com/.

https://mujs.com/ belongs to Artifex and offers tarballs ("Downloads") and a cgit repo ("Source"). The reliability of the cgit repo is unknown.

The Artifex homepage points to Github, https://github.com/ArtifexSoftware.

And this the chosen upstream now.
