### PR TITLE
[breakpad] Avoid stdext::checked_array_iterator

### DIFF
--- a/ports/breakpad/add-algorithm-1.patch
+++ b/ports/breakpad/add-algorithm-1.patch
@@ -1,5 +1,5 @@
 diff --git a/src/common/string_view.h b/src/common/string_view.h
-index a8e15922..bcaa7b96 100644
+index a8e1592..bcaa7b9 100644
 --- a/src/common/string_view.h
 +++ b/src/common/string_view.h
 @@ -29,6 +29,7 @@

--- a/ports/breakpad/avoid-checked-array-iterator.diff
+++ b/ports/breakpad/avoid-checked-array-iterator.diff
@@ -1,0 +1,13 @@
+diff --git a/src/client/windows/crash_generation/minidump_generator.cc b/src/client/windows/crash_generation/minidump_generator.cc
+index a0454cf..a977fc3 100644
+--- a/src/client/windows/crash_generation/minidump_generator.cc
++++ b/src/client/windows/crash_generation/minidump_generator.cc
+@@ -179,7 +179,7 @@ bool HandleTraceData::CollectHandleData(
+   stream_data->Reserved = 0;
+   std::copy(operations_.begin(),
+             operations_.end(),
+-#if defined(_MSC_VER) && !defined(_LIBCPP_STD_VER)
++#if defined(_MSC_VER) && !defined(_LIBCPP_STD_VER) && _MSC_VER < 1951
+             stdext::checked_array_iterator<AVRF_HANDLE_OPERATION*>(
+                 reinterpret_cast<AVRF_HANDLE_OPERATION*>(stream_data + 1),
+                 operations_.size())

--- a/ports/breakpad/portfile.cmake
+++ b/ports/breakpad/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         add-algorithm-1.patch
+        avoid-checked-array-iterator.diff
 )
 
 if(VCPKG_HOST_IS_LINUX OR VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_ANDROID)

--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "breakpad",
   "version-date": "2024-02-16",
+  "port-version": 1,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8447b574fa2cbca8b2343a609dcec8779ea7611",
+      "version-date": "2024-02-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "d0b9b0c733d8e82f954990673865df8768b5d8e7",
       "version-date": "2024-02-16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1478,7 +1478,7 @@
     },
     "breakpad": {
       "baseline": "2024-02-16",
-      "port-version": 0
+      "port-version": 1
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
For VS 2026 18.6.0 / MSVC 19.51