### PR TITLE
[hyperscan] Disable unit tests.

### DIFF
--- a/ports/hyperscan/0001-remove-Werror.patch
+++ b/ports/hyperscan/0001-remove-Werror.patch
@@ -1,27 +1,13 @@
-From e2c0779de8096623be874c5fa0d275113b9d1204 Mon Sep 17 00:00:00 2001
-From: Nicole Mazzuca <mazzucan@outlook.com>
-Date: Tue, 22 Sep 2020 14:44:36 -0700
-Subject: [PATCH] remove Werror
-
----
- CMakeLists.txt | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 83197af..d27eb76 100644
+index 7757916..14d12d0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -235,8 +235,8 @@ else()
+@@ -242,8 +242,6 @@ else()
      if (NOT RELEASE_BUILD)
          # -Werror is most useful during development, don't potentially break
          # release builds
 -        set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Werror")
 -        set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Werror")
-+        #set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Werror")
-+        #set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Werror")
      endif()
  
      if (DISABLE_ASSERTS)
--- 
-2.24.3 (Apple Git-128)
-

--- a/ports/hyperscan/0003-disable-tests.patch
+++ b/ports/hyperscan/0003-disable-tests.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 14d12d0..5b9ff9c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -546,7 +546,6 @@ if (CORRECT_PCRE_VERSION AND PCRE_BUILD_SOURCE AND BUILD_STATIC_LIBS)
+     set(BUILD_CHIMERA TRUE)
+ endif()
+ 
+-add_subdirectory(unit)
+ if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
+     add_subdirectory(tools)
+ endif()

--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         0001-remove-Werror.patch
         0002-fix-threads.patch
+        0003-disable-tests.patch # also avoids old vendored gtest that fails on MSVC 19.51+ due to removed std::tr1
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/hyperscan/vcpkg.json
+++ b/ports/hyperscan/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperscan",
   "version": "5.4.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.",
   "homepage": "https://www.hyperscan.io",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3890,7 +3890,7 @@
     },
     "hyperscan": {
       "baseline": "5.4.2",
-      "port-version": 2
+      "port-version": 3
     },
     "hypodermic": {
       "baseline": "2023-03-03",

--- a/versions/h-/hyperscan.json
+++ b/versions/h-/hyperscan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f362c4cd38fb85f99792228ddac5fbd66ccdcc18",
+      "version": "5.4.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "9dbae1281767ae0d017623fd79e4e46a54779b17",
       "version": "5.4.2",
       "port-version": 2


### PR DESCRIPTION
Also avoids old vendored copy of Google Test that fails on MSVC 19.51+ due to the removal of std::tr1::tuple:

```console
\unit\gtest/gtest.h(9688): error C2039: 'tr1': is not a member of 'std'
C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Tools\MSVC\14.51.36231\include\set(22): note: see declaration of 'std'
\unit\gtest/gtest.h(9688): error C3083: 'tr1': the symbol to the left of a '::' must be a type
\unit\gtest/gtest.h(9693): error C3083: 'tr1': the symbol to the left of a '::' must be a type
\unit\gtest/gtest.h(9698): error C3083: 'tr1': the symbol to the left of a '::' must be a type
\unit\gtest/gtest.h(9703): error C3083: 'tr1': the symbol to the left of a '::' must be a type
```

Also minimized remove-werror patch
