### PR TITLE
Prism: update to 0.15.0

### DIFF
--- a/ports/ethindp-prism/portfile.cmake
+++ b/ports/ethindp-prism/portfile.cmake
@@ -4,8 +4,8 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO ethindp/prism
-  REF v0.14.4
-  SHA512 ab5720bb6a73c2c432dbc71aafb1a553db8a66762c36653a728ad3560750e0e8d8ede4e4d7deff19076b3b0c8e07767d7ef584fe1ecdeb395780ab6799bdd97c
+  REF v0.15.0
+  SHA512 b83b7b46414e7750c11666b7ce4639dffe6776c985b6f22eb31251246a5ecf67c89196f6f8c8215498e7c3acbe9259cf901028aa3521c63f9291ce0d70a0bd11
   HEAD_REF master
 )
 vcpkg_check_features(

--- a/ports/ethindp-prism/vcpkg.json
+++ b/ports/ethindp-prism/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ethindp-prism",
-  "version": "0.14.4",
+  "version": "0.15.0",
   "description": "The Platform-agnostic Reader Interface for Speech and Messages",
   "license": "MPL-2.0",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2857,7 +2857,7 @@
       "port-version": 1
     },
     "ethindp-prism": {
-      "baseline": "0.14.4",
+      "baseline": "0.15.0",
       "port-version": 0
     },
     "etl": {

--- a/versions/e-/ethindp-prism.json
+++ b/versions/e-/ethindp-prism.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86b388df96fac63b9ecd141558c5cef7827ab442",
+      "version": "0.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fe31c40ed411163de73077bfac29065ac20ff0db",
       "version": "0.14.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
