### PR TITLE
[vincentlaucsb-csv-parser] update to 5.2.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 a4d8ddce2a99c1a459ca3d63280181295f7be999e46301de3718131db3d3dd8dc81b89a25b0687ee210d1887829e971b8dcc3d96f320161a23bd5d6fbb2c3d0f
+    SHA512 bd97f9366afcc882b095c8a51ff3b67af71ebf33268f41353fa3fcd2e81a1cf8609b00f11e1b916f0b3283eacb2f606fb3e86289e6640ab4bc6a4d6566fbc526
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10621,7 +10621,7 @@
       "port-version": 0
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "5.1.0",
+      "baseline": "5.2.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c76910aed938c1c711d67c3b736e14860aaaf53d",
+      "version": "5.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "22d0cf743bc13d1662c43fc905ea8bfd4b2d1e1d",
       "version": "5.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/5.2.0
