### PR TITLE
[libxmlpp] update to 5.6.1

### DIFF
--- a/ports/libxmlpp/portfile.cmake
+++ b/ports/libxmlpp/portfile.cmake
@@ -1,14 +1,10 @@
 string(REGEX MATCH "^([0-9]*[.][0-9]*)" MAJOR_MINOR "${VERSION}")
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/libxml++/${MAJOR_MINOR}/libxml++-${VERSION}.tar.xz"
-         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/libxml++/${MAJOR_MINOR}/libxml++-${VERSION}.tar.xz"
-    FILENAME "libxml++-${VERSION}.tar.xz"
-    SHA512 bba28edf40c60ac186ff1b704d9f4f41f73c1be3126cfb345005283b32bb5c9a596b8def64be8ad8e295e1e169bed91d120d5105cbbb6cecc4675d10b897dfe6
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libxmlplusplus/libxmlplusplus
+    REF ${VERSION}
+    SHA512 ad164deebcf874b54fcf2923c672fe95ab7e397bc17bf6f7079899e8732eb4665e78b6477671cf481bbcb301db146e83c25b8c159da086dd2dd2cf32bba12ffa
+    HEAD_REF master
 )
 
 vcpkg_configure_meson(

--- a/ports/libxmlpp/portfile.cmake
+++ b/ports/libxmlpp/portfile.cmake
@@ -1,4 +1,3 @@
-string(REGEX MATCH "^([0-9]*[.][0-9]*)" MAJOR_MINOR "${VERSION}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libxmlplusplus/libxmlplusplus

--- a/ports/libxmlpp/vcpkg.json
+++ b/ports/libxmlpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxmlpp",
-  "version": "5.4.0",
-  "port-version": 1,
+  "version": "5.6.1",
   "description": "A C++ wrapper for the libxml XML parser library.",
   "homepage": "https://libxmlplusplus.github.io/libxmlplusplus/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5981,8 +5981,8 @@
       "port-version": 4
     },
     "libxmlpp": {
-      "baseline": "5.4.0",
-      "port-version": 1
+      "baseline": "5.6.1",
+      "port-version": 0
     },
     "libxmp": {
       "baseline": "4.6.0",

--- a/versions/l-/libxmlpp.json
+++ b/versions/l-/libxmlpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98d1b71c1d2cbbc8282557e4d661bc0ee15861b2",
+      "version": "5.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "240ef9a1b77f7301926538286cfd9c785c6bc687",
       "version": "5.4.0",
       "port-version": 1

--- a/versions/l-/libxmlpp.json
+++ b/versions/l-/libxmlpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "98d1b71c1d2cbbc8282557e4d661bc0ee15861b2",
+      "git-tree": "4eb0af33eb187604f448fb6b90c835daa53ce86e",
       "version": "5.6.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libxmlplusplus/libxmlplusplus/releases/tag/5.6.1

GNOME download site stopped to update release tar ball since 5.4.0.

> You can download libxml++ from [GitHub releases](https://github.com/libxmlplusplus/libxmlplusplus/releases/) (since 2.42.0, 3.2.0, 4.0.0 and 5.0.0) or the [GNOME download site](https://download.gnome.org/sources/libxml++/) (until 2.42.3, 3.2.5, 4.2.0 and 5.4.0).