### PR TITLE
[luminoengine] Avoid naming stdext::checked_array_iterator.

### DIFF
--- a/ports/luminoengine/avoid-stdext-checked-array-iterator.patch
+++ b/ports/luminoengine/avoid-stdext-checked-array-iterator.patch
@@ -1,0 +1,13 @@
+diff --git a/lumino/LuminoCore/include/LuminoCore/Base/detail/fmt/format.h b/lumino/LuminoCore/include/LuminoCore/Base/detail/fmt/format.h
+index fa2d485..83decae 100644
+--- a/lumino/LuminoCore/include/LuminoCore/Base/detail/fmt/format.h
++++ b/lumino/LuminoCore/include/LuminoCore/Base/detail/fmt/format.h
+@@ -470,7 +470,7 @@ inline auto get_data(Container& c) -> typename Container::value_type* {
+   return c.data();
+ }
+ 
+-#if defined(_SECURE_SCL) && _SECURE_SCL
++#if defined(_SECURE_SCL) && _SECURE_SCL && (!defined(_MSC_VER) || _MSC_VER < 1951)
+ // Make a checked iterator to avoid MSVC warnings.
+ template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+ template <typename T>

--- a/ports/luminoengine/fix-cmake-config.patch
+++ b/ports/luminoengine/fix-cmake-config.patch
@@ -1,15 +1,14 @@
 diff --git a/cmake/LuminoConfig.cmake.in b/cmake/LuminoConfig.cmake.in
-index 283ad47..aa9bfd8 100644
+index 29dac4fde..71745973d 100644
 --- a/cmake/LuminoConfig.cmake.in
 +++ b/cmake/LuminoConfig.cmake.in
-@@ -13,5 +13,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/LuminoTargets.cmake")
+@@ -13,5 +13,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/LuminoTargets.cmake")
  # Combination target
  #-------------------------------------------------------------------------------
  add_library(lumino::Lumino INTERFACE IMPORTED)
 -target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoEngine lumino::LuminoCore)
-+if(LUMINO_BUILD_ENGINE)
-+    target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoEngine lumino::LuminoCore)
-+else()
-+    target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoCore)
+-
++target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoCore)
++if(@LUMINO_BUILD_ENGINE@)
++    target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoEngine)
 +endif()
- 

--- a/ports/luminoengine/portfile.cmake
+++ b/ports/luminoengine/portfile.cmake
@@ -5,12 +5,13 @@ vcpkg_from_github(
     SHA512 f43e48b36a48b5fcce4767de087f9953c905ac0af5522042a93c39ec75e4c9489b8910bc5b2f6fd129ce197309377a14b6eb9177a6ea9db4f5c2e7d1b13a137d
     HEAD_REF main
     PATCHES
-        fix-cmake-config.patch
+        avoid-stdext-checked-array-iterator.patch # https://github.com/LuminoEngine/Lumino/pull/222
+        fix-cmake-config.patch # https://github.com/LuminoEngine/Lumino/pull/223
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES 
-        engine  LUMINO_BUILD_ENGINE
+    FEATURES
+        engine LUMINO_BUILD_ENGINE
 )
 
 vcpkg_cmake_configure(
@@ -28,6 +29,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_copy_pdbs()
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-

--- a/ports/luminoengine/vcpkg.json
+++ b/ports/luminoengine/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luminoengine",
   "version": "0.10.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++17 games and visualization toolkit.",
   "homepage": "https://github.com/LuminoEngine/Lumino",
   "license": "MIT",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -724,6 +724,7 @@ loguru:arm64-linux=fail
 lua[tools]:arm64-linux=feature-fails
 luajit:arm-neon-android=cascade  # needs same pointer size for host
 luasec:x64-windows-static=fail
+luminoengine[engine]=feature-fails # https://github.com/LuminoEngine/Lumino/issues/221
 lunarg-vulkantools:arm64-linux=cascade
 luv:arm64-windows=cascade
 magma:arm64-linux=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6238,7 +6238,7 @@
     },
     "luminoengine": {
       "baseline": "0.10.1",
-      "port-version": 1
+      "port-version": 2
     },
     "lunarg-vulkantools": {
       "baseline": "1.4.341.0",

--- a/versions/l-/luminoengine.json
+++ b/versions/l-/luminoengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3af7002c6bdae5d621bc6440bd8bbf610b4a6e77",
+      "version": "0.10.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f1c9d587cda9c08d9a07a874769567354c84b003",
       "version": "0.10.1",
       "port-version": 1


### PR DESCRIPTION
Fixes Visual Studio 2026 18.6.0 / MSVC 19.51.

Also fixes https://github.com/microsoft/vcpkg/pull/29879 to actually hook up LUMINO_BUILD_ENGINE in the generated configs (it was missing `@`s)

See also: https://github.com/LuminoEngine/Lumino/issues/221
See also: https://github.com/LuminoEngine/Lumino/pull/222
See also: https://github.com/LuminoEngine/Lumino/pull/223
