### PR TITLE
[openvino] Avoid naming stdext::checked_array_iterator.

### DIFF
--- a/ports/openvino/msvc-debug-info-only-in-pdb.patch
+++ b/ports/openvino/msvc-debug-info-only-in-pdb.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/developer_package/compile_flags/os_flags.cmake b/cmake/developer_package/compile_flags/os_flags.cmake
-index 3ce87023ad..a2c5b2dda1 100644
+index 3ce87023..1f023280 100644
 --- a/cmake/developer_package/compile_flags/os_flags.cmake
 +++ b/cmake/developer_package/compile_flags/os_flags.cmake
 @@ -134,6 +134,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/ports/openvino/npu-deps.patch
+++ b/ports/openvino/npu-deps.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/features.cmake b/cmake/features.cmake
-index 8badc2e5cb..f8791b4c4e 100644
+index 8badc2e5..f8791b4c 100644
 --- a/cmake/features.cmake
 +++ b/cmake/features.cmake
 @@ -196,7 +196,7 @@ ov_dependent_option (ENABLE_SYSTEM_TBB  "Enables use of system TBB" ${ENABLE_SYS
@@ -21,7 +21,7 @@ index 8badc2e5cb..f8791b4c4e 100644
  ov_dependent_option(ENABLE_JS "Enables JS API building" ${ENABLE_JS_DEFAULT} "NOT ANDROID;NOT EMSCRIPTEN" OFF)
  
 diff --git a/src/plugins/intel_npu/cmake/download_compiler_libs.cmake b/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
-index 3f34a73e45..e561d5703d 100644
+index 3f34a73e..e561d570 100644
 --- a/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
 +++ b/src/plugins/intel_npu/cmake/download_compiler_libs.cmake
 @@ -115,7 +115,7 @@ if(ENABLE_INTEL_NPU_COMPILER)

--- a/ports/openvino/onednn-gpu-includes.patch
+++ b/ports/openvino/onednn-gpu-includes.patch
@@ -1,5 +1,5 @@
 diff --git a/src/plugins/intel_gpu/src/graph/CMakeLists.txt b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
-index 380159c387..ded4303aff 100644
+index 380159c3..ded4303a 100644
 --- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
 +++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
 @@ -81,7 +81,7 @@ macro(ov_gpu_add_backend_target)
@@ -12,7 +12,7 @@ index 380159c387..ded4303aff 100644
      endif()
      # Onednn headers use OCL/L0 headers
 diff --git a/src/plugins/intel_gpu/src/runtime/CMakeLists.txt b/src/plugins/intel_gpu/src/runtime/CMakeLists.txt
-index c8c872071e..6565ad7632 100644
+index c8c87207..6565ad76 100644
 --- a/src/plugins/intel_gpu/src/runtime/CMakeLists.txt
 +++ b/src/plugins/intel_gpu/src/runtime/CMakeLists.txt
 @@ -66,7 +66,7 @@ if(OV_COMPILER_IS_INTEL_LLVM)
@@ -25,7 +25,7 @@ index c8c872071e..6565ad7632 100644
  
  ov_set_threading_interface_for(${TARGET_NAME})
 diff --git a/src/plugins/intel_gpu/thirdparty/CMakeLists.txt b/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
-index 2bf709fc20..edf6cf8110 100644
+index 2bf709fc..edf6cf81 100644
 --- a/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
 +++ b/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
 @@ -178,7 +178,6 @@ if(ENABLE_ONEDNN_FOR_GPU)

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -5,10 +5,11 @@ vcpkg_from_github(
     SHA512 c8f222cf278017da610a8d0f0c5bd5c6c54c0324bfcfdf9352063df2706732eaa54b7b01408aec1ca266a3f02bd2bffa671d2415121d8f3675f46d8114355de6
     HEAD_REF master
     PATCHES
-        msvc_debug_info_only_in_pdb.patch
-        onednn_gpu_includes.patch
+        msvc-debug-info-only-in-pdb.patch
+        onednn-gpu-includes.patch
         protobuf-6.patch
-        npu_deps.patch
+        npu-deps.patch
+        remove-stdext-on-new-msvc.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openvino/protobuf-6.patch
+++ b/ports/openvino/protobuf-6.patch
@@ -1,8 +1,8 @@
 diff --git a/thirdparty/dependencies.cmake b/thirdparty/dependencies.cmake
-index 3d7f137ec9..39114b4b2f 100644
+index 95b97fcb..ac8b6c06 100644
 --- a/thirdparty/dependencies.cmake
 +++ b/thirdparty/dependencies.cmake
-@@ -359,7 +359,7 @@ if(ENABLE_OV_PADDLE_FRONTEND OR ENABLE_OV_ONNX_FRONTEND OR ENABLE_OV_TF_FRONTEND
+@@ -363,7 +363,7 @@ if(ENABLE_OV_PADDLE_FRONTEND OR ENABLE_OV_ONNX_FRONTEND OR ENABLE_OV_TF_FRONTEND
          # try to find newer version first (major is changed)
          # see https://protobuf.dev/support/version-support/ and
          # https://github.com/protocolbuffers/protobuf/commit/d61f75ff6db36b4f9c0765f131f8edc2f86310fa

--- a/ports/openvino/remove-stdext-on-new-msvc.diff
+++ b/ports/openvino/remove-stdext-on-new-msvc.diff
@@ -1,0 +1,26 @@
+diff --git a/src/plugins/intel_gpu/include/intel_gpu/runtime/compounds.hpp b/src/plugins/intel_gpu/include/intel_gpu/runtime/compounds.hpp
+index 0554b0fd..f07e4c82 100644
+--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/compounds.hpp
++++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/compounds.hpp
+@@ -50,7 +50,7 @@ public:
+     size_t size() const { return _size; }
+     bool empty() const { return _size == 0; }
+ 
+-#if defined(_SECURE_SCL) && (_SECURE_SCL > 0)
++#if defined(_SECURE_SCL) && (_SECURE_SCL > 0) && (!defined(_MSC_VER) || _MSC_VER < 1951)
+     typedef stdext::checked_array_iterator<T*> iterator;
+     typedef stdext::checked_array_iterator<const T*> const_iterator;
+     iterator begin() const { return stdext::make_checked_array_iterator(_data, _size); }
+diff --git a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+index ee7dfa1f..91dedccb 100644
+--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
++++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+@@ -186,7 +186,7 @@ struct mem_lock {
+     mem_lock(const mem_lock& other) = delete;
+     mem_lock& operator=(const mem_lock& other) = delete;
+ 
+-#if defined(_SECURE_SCL) && (_SECURE_SCL > 0)
++#if defined(_SECURE_SCL) && (_SECURE_SCL > 0) && (!defined(_MSC_VER) || _MSC_VER < 1951)
+     auto begin() & { return stdext::make_checked_array_iterator(_ptr, size()); }
+     auto end() & { return stdext::make_checked_array_iterator(_ptr, size(), size()); }
+ #else

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2026.1.0",
+  "port-version": 1,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7470,7 +7470,7 @@
     },
     "openvino": {
       "baseline": "2026.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openvpn3": {
       "baseline": "3.10",

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61f1fad46909bd824f7e673dd654d03347d95d58",
+      "version": "2026.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f8b277efe3110779dec42b55a19cdef20722891e",
       "version": "2026.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes build on Visual Studio 2026 18.6.0 / MSVC 19.51.

Renames patches to consistently use -s and repairs CRLF corruption of the "protobuf-6" patch.
