### PR TITLE
[vtk] Avoid stdext::checked_array_iterator.

### DIFF
--- a/ports/vtk/diy2-fmt-remove-stdext-checked-array-iterator.patch
+++ b/ports/vtk/diy2-fmt-remove-stdext-checked-array-iterator.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Oleg Odalovic <olegodalovic@gmail.com>
+Date: Fri, 15 May 2026 12:00:00 +0200
+Subject: [PATCH] [diy2/fmt] Remove uses of `stdext::checked_array_iterator`
+
+`stdext::checked_array_iterator` is a long-deprecated MSVC extension
+that has been removed from the standard library in MSVC 14.51 (VS 2026
+Preview).  The bundled (pre-7.0) copy of fmtlib shipped inside VTK's
+ThirdParty/diy2 still references it under `#ifdef _SECURE_SCL`, which
+breaks the build under that toolchain with:
+
+    error C2653: 'stdext': is not a class or namespace name
+    error C2061: syntax error: identifier 'checked_array_iterator'
+
+Drop the `_SECURE_SCL` branch and keep only the raw-pointer fallback.
+This matches the resolution adopted in vcpkg for cpprestsdk (PR #51750),
+breakpad (PR #51774), duckdb (PR #51749), ampl-mp (PR #51753) and
+luminoengine (PR #51785).
+
+Fixes microsoft/vcpkg#51766.
+---
+ .../diy2/vtkdiy2/include/vtkdiy2/fmt/format.h        | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/ThirdParty/diy2/vtkdiy2/include/vtkdiy2/fmt/format.h b/ThirdParty/diy2/vtkdiy2/include/vtkdiy2/fmt/format.h
+index dcf4a39..20908c0 100644
+--- a/ThirdParty/diy2/vtkdiy2/include/vtkdiy2/fmt/format.h
++++ b/ThirdParty/diy2/vtkdiy2/include/vtkdiy2/fmt/format.h
+@@ -265,16 +265,8 @@ inline typename Container::value_type* get_data(Container& c) {
+   return c.data();
+ }
+
+-#ifdef _SECURE_SCL
+-// Make a checked iterator to avoid MSVC warnings.
+-template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+-template <typename T> checked_ptr<T> make_checked(T* p, std::size_t size) {
+-  return {p, size};
+-}
+-#else
+ template <typename T> using checked_ptr = T*;
+ template <typename T> inline T* make_checked(T* p, std::size_t) { return p; }
+-#endif
+
+ template <typename Container, FMT_ENABLE_IF(is_contiguous<Container>::value)>
+ inline checked_ptr<typename Container::value_type> reserve(

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -49,6 +49,7 @@ vcpkg_from_github(
         zspace.diff # https://gitlab.kitware.com/vtk/vtk/-/commit/01a8bd7a917d33892f67a8d76ce7fc4b524d56b4
         mpi-language.diff
         fix-eigen3.patch
+        diy2-fmt-remove-stdext-checked-array-iterator.patch # https://github.com/microsoft/vcpkg/issues/51766
 )
 
 # =============================================================================

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.1",
-  "port-version": 15,
+  "port-version": 16,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10694,7 +10694,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.1",
-      "port-version": 15
+      "port-version": 16
     },
     "vtk-compile-tools": {
       "baseline": "9.3.0-pv5.12.1",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "adabe5a1b8bb71119326e2f5efd26a0bc32aac75",
+      "version-semver": "9.3.0-pv5.12.1",
+      "port-version": 16
+    },
+    {
       "git-tree": "f43aef42d15eb58999113bc644364720ca24fe46",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 15


### PR DESCRIPTION
<!-- Pull request guidance: https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md -->

Fixes #51766.

## What this fixes

VTK's bundled (pre-7.0) copy of fmtlib at `ThirdParty/diy2/vtkdiy2/include/vtkdiy2/fmt/format.h` references `stdext::checked_array_iterator` under `#ifdef _SECURE_SCL`.  This extension has been removed from the MSVC standard library in MSVC 14.51 (VS 2026 Preview), so the build fails with:

```
error C2653: 'stdext': is not a class or namespace name
error C2061: syntax error: identifier 'checked_array_iterator'
```

(full failure log in #51766)

## Resolution

Drop the `_SECURE_SCL` branch and keep only the raw-pointer fallback. The patched `make_checked` / `checked_ptr` aliases become unconditional pass-throughs.  This is the same approach already accepted in vcpkg for the same removal across five other ports:

| PR | Port |
|---|---|
| #51750 | cpprestsdk |
| #51774 | breakpad |
| #51749 | duckdb |
| #51753 | ampl-mp |
| #51785 | luminoengine |

## Files

- `ports/vtk/diy2-fmt-remove-stdext-checked-array-iterator.patch` — the source patch
- `ports/vtk/portfile.cmake` — register the patch
- `ports/vtk/vcpkg.json` — port-version 15 → 16
- `versions/v-/vtk.json`, `versions/baseline.json` — version DB bump (via `vcpkg x-add-version vtk`)

## Local verification

Built `vtk[core]:x64-windows` against this overlay port using MSVC 14.51.36231 (VS 2026 Preview, generator `Visual Studio 18 2026`).  The failing `vtkDIYDataExchanger.cxx` translation unit now compiles cleanly.

## Manifest

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. *(no source changes)*
- [x] The "supports" clause reflects platforms that may be built. *(unchanged)*
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. *(none applicable)*
- [x] Any patches that are no longer applied are deleted from the port's directory. *(none)*
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
