### PR TITLE
libpq: depend on vcpkg-tool-meson >= 1.9.0#7

### DIFF
--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpq",
   "version": "18.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",
@@ -13,7 +13,8 @@
     },
     {
       "name": "vcpkg-tool-meson",
-      "host": true
+      "host": true,
+      "version>=": "1.9.0#7"
     }
   ],
   "default-features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5486,7 +5486,7 @@
     },
     "libpq": {
       "baseline": "18.3",
-      "port-version": 1
+      "port-version": 2
     },
     "libpqxx": {
       "baseline": "8.0.1",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4799c5289cd6e9c35381834ec8137b682614e77",
+      "version": "18.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "07600c753f8d06aa4cba70f08673e23c8b3c4466",
       "version": "18.3",
       "port-version": 1


### PR DESCRIPTION
Without this change, in manifest mode, it is still possible to reproduce the issue in #48024, if `vcpkg-tool-meson` port is not at the latest version.

Fixes #48024

