### PR TITLE
[pagmo2] Avoid stdext::checked_array_iterator.

### DIFF
--- a/ports/pagmo2/0001-doxygen.patch
+++ b/ports/pagmo2/0001-doxygen.patch
@@ -1,15 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 34bad69..dfb942d 100644
+index 43eeac5..d601487 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -398,8 +398,8 @@ endif()
+@@ -411,8 +411,6 @@ endif()
  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in" "${CMAKE_CURRENT_BINARY_DIR}/include/pagmo/config.hpp" @ONLY)
  
  # Configure the doc files.
 -configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/Doxyfile.in" "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/Doxyfile" @ONLY)
 -configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doc/sphinx/conf.py.in" "${CMAKE_CURRENT_SOURCE_DIR}/doc/sphinx/conf.py" @ONLY)
-+# configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/Doxyfile.in" "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen/Doxyfile" @ONLY)
-+# configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doc/sphinx/conf.py.in" "${CMAKE_CURRENT_SOURCE_DIR}/doc/sphinx/conf.py" @ONLY)
  
  # This is just a simple counter variable, internal use only.
  set(_PAGMO_TEST_NUM "0")

--- a/ports/pagmo2/0003-disable-werror.patch
+++ b/ports/pagmo2/0003-disable-werror.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake_modules/yacma/YACMACompilerLinkerSettings.cmake b/cmake_modules/yacma/YACMACompilerLinkerSettings.cmake
-index 7d7aa1b..81c8bf6 100644
+index edafe6d..0b18c5d 100644
 --- a/cmake_modules/yacma/YACMACompilerLinkerSettings.cmake
 +++ b/cmake_modules/yacma/YACMACompilerLinkerSettings.cmake
 @@ -95,7 +95,6 @@ if(NOT _YACMACompilerLinkerSettingsRun)
@@ -10,7 +10,7 @@ index 7d7aa1b..81c8bf6 100644
          # New warnings in clang 8.
          # NOTE: a few issues with macros here, let's disable for now.
          # _YACMA_CHECK_ENABLE_DEBUG_CXX_FLAG(-Wextra-semi-stmt)
-@@ -180,7 +179,6 @@ if(NOT _YACMACompilerLinkerSettingsRun)
+@@ -191,7 +190,6 @@ if(NOT _YACMACompilerLinkerSettingsRun)
          # Enable higher warning level than usual.
          _YACMA_CHECK_ENABLE_DEBUG_CXX_FLAG(/W4)
          # Treat warnings as errors.

--- a/ports/pagmo2/0004-support-eigen3-5.patch
+++ b/ports/pagmo2/0004-support-eigen3-5.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e422554..984ae24 100644
+index d601487..610f968 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -163,7 +163,7 @@ endif()
@@ -7,16 +7,16 @@ index e422554..984ae24 100644
  # Eigen3
  if(PAGMO_WITH_EIGEN3)
 -    find_package(Eigen3 3.3 REQUIRED NO_MODULE)
-+    find_package(Eigen3 3.3...5 REQUIRED NO_MODULE)
++    find_package(Eigen3 REQUIRED NO_MODULE)
  endif()
  
  # NLopt
-@@ -456,7 +456,7 @@ install(TARGETS pagmo
+@@ -454,7 +454,7 @@ install(TARGETS pagmo
  # Setup of the optional deps.
  set(_PAGMO_CONFIG_OPTIONAL_DEPS)
  if(PAGMO_WITH_EIGEN3)
 -    set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(Eigen3 3.3 REQUIRED NO_MODULE)\n")
-+    set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(Eigen3 3.3...5 REQUIRED NO_MODULE)\n")
++    set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(Eigen3 REQUIRED NO_MODULE)\n")
  endif()
  if(PAGMO_WITH_NLOPT)
      set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(NLopt 2.6 REQUIRED NO_MODULE)\n")

--- a/ports/pagmo2/0005-avoid-stdext-checked-array-iterator.diff
+++ b/ports/pagmo2/0005-avoid-stdext-checked-array-iterator.diff
@@ -1,0 +1,46 @@
+diff --git a/src/batch_evaluators/thread_bfe.cpp b/src/batch_evaluators/thread_bfe.cpp
+index db31882..6ad7ae8 100644
+--- a/src/batch_evaluators/thread_bfe.cpp
++++ b/src/batch_evaluators/thread_bfe.cpp
+@@ -103,21 +103,12 @@ vector_double thread_bfe::operator()(problem p, const vector_double &dvs) const
+             auto in_ptr = dvs.data() + begin * n_dim;
+             auto out_ptr = retval.data() + begin * f_dim;
+             std::copy(
+-#if defined(_MSC_VER)
+-                stdext::make_checked_array_iterator(in_ptr, n_dim),
+-                stdext::make_checked_array_iterator(in_ptr, n_dim, n_dim), tmp_dv.begin()
+-#else
+                 in_ptr, in_ptr + n_dim, tmp_dv.begin()
+-#endif
+             );
+             const auto fv = prob.fitness(tmp_dv);
+             assert(fv.size() == f_dim);
+             std::copy(
+-#if defined(_MSC_VER)
+-                fv.begin(), fv.end(), stdext::make_checked_array_iterator(out_ptr, f_dim)
+-#else
+                 fv.begin(), fv.end(), out_ptr
+-#endif
+             );
+         }
+     };
+diff --git a/src/problems/translate.cpp b/src/problems/translate.cpp
+index 2760872..9650708 100644
+--- a/src/problems/translate.cpp
++++ b/src/problems/translate.cpp
+@@ -129,15 +129,8 @@ vector_double translate::batch_fitness(const vector_double &xs) const
+     using range_t = tbb::blocked_range<decltype(xs.size())>;
+     tbb::parallel_for(range_t(0, n_dvs), [&xs, &xs_deshifted, nx, this](const range_t &range) {
+         for (auto i = range.begin(); i != range.end(); ++i) {
+-#if defined(_MSC_VER)
+-            std::transform(stdext::make_unchecked_array_iterator(xs.data() + i * nx),
+-                           stdext::make_unchecked_array_iterator(xs.data() + (i + 1u) * nx),
+-                           stdext::make_unchecked_array_iterator(m_translation.data()),
+-                           stdext::make_unchecked_array_iterator(xs_deshifted.data() + i * nx), std::minus<double>{});
+-#else
+                 std::transform(xs.data() + i * nx, xs.data() + (i + 1u) * nx, m_translation.data(),
+                                xs_deshifted.data() + i * nx, std::minus<double>{});
+-#endif
+         }
+     });
+ 

--- a/ports/pagmo2/portfile.cmake
+++ b/ports/pagmo2/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         0002-find-tbb.patch
         0003-disable-werror.patch
         0004-support-eigen3-5.patch
+        0005-avoid-stdext-checked-array-iterator.diff # ~= https://github.com/esa/pagmo2/commit/d4daedc9f865bf9e926946c21e62c4a4eebf353e
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/pagmo2/vcpkg.json
+++ b/ports/pagmo2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pagmo2",
   "version": "2.19.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C++ platform to perform parallel computations of optimization tasks (global and local) via the asynchronous generalized island model.",
   "homepage": "https://esa.github.io/pagmo2/",
   "license": "GPL-3.0-or-later OR LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7582,7 +7582,7 @@
     },
     "pagmo2": {
       "baseline": "2.19.1",
-      "port-version": 1
+      "port-version": 2
     },
     "paho-mqtt": {
       "baseline": "1.3.16",

--- a/versions/p-/pagmo2.json
+++ b/versions/p-/pagmo2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17bc4e5d8d8c28446f414b23555c22c615b3703a",
+      "version": "2.19.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f38ed65a09e604e74ab96a2877249215af53af63",
       "version": "2.19.1",
       "port-version": 1


### PR DESCRIPTION
Fixes build in Visual Studio 2026 18.6.0 / MSVC 19.51.

Also minimized patches, and changed the Eigen patch to remove version constraints entirely.

Upstream effectively took a similar change in https://github.com/esa/pagmo2/commit/d4daedc9f865bf9e926946c21e62c4a4eebf353e8