### PR TITLE
[pe-parse] Remove /WX.

### DIFF
--- a/ports/pe-parse/arm64-windows-fix.patch
+++ b/ports/pe-parse/arm64-windows-fix.patch
@@ -1,12 +1,13 @@
-find_package(Filesystem) fails on arm64 Windows.
-We can remove it as it is only used for tests which are not built in vcpkg.
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb6600c..51eb37f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -15,7 +15,6 @@ endif ()
+@@ -13,9 +13,6 @@ if (NOT CMAKE_BUILD_TYPE)
+ endif ()
+ 
  include(cmake/compilation_flags.cmake)
- # Greater c++17 filesystem compatibility (like with experimental)
- list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+-# Greater c++17 filesystem compatibility (like with experimental)
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 -find_package(Filesystem COMPONENTS Experimental Final REQUIRED)
  list(APPEND GLOBAL_CXXFLAGS ${DEFAULT_CXX_FLAGS})
  

--- a/ports/pe-parse/no-werror.patch
+++ b/ports/pe-parse/no-werror.patch
@@ -1,8 +1,16 @@
 diff --git a/cmake/compilation_flags.cmake b/cmake/compilation_flags.cmake
-index 395f1b5..bb10165 100644
+index 395f1b5..f55db79 100644
 --- a/cmake/compilation_flags.cmake
 +++ b/cmake/compilation_flags.cmake
-@@ -26,7 +26,7 @@ else ()
+@@ -13,7 +13,6 @@ if (MSVC)
+   endif ()
+ 
+   if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+-    list(APPEND DEFAULT_CXX_FLAGS /WX)
+   endif ()
+ 
+ else ()
+@@ -26,7 +25,7 @@ else ()
      -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization
      -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment
      -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion
@@ -12,9 +20,18 @@ index 395f1b5..bb10165 100644
    )
  
 diff --git a/examples/peaddrconv/CMakeLists.txt b/examples/peaddrconv/CMakeLists.txt
-index fbad06a..02c8bcf 100644
+index fbad06a..bac7e06 100644
 --- a/examples/peaddrconv/CMakeLists.txt
 +++ b/examples/peaddrconv/CMakeLists.txt
+@@ -12,7 +12,7 @@ if (MSVC)
+   # directory on Windows its not found by CMake when performing its search.
+   list(APPEND CMAKE_PREFIX_PATH /usr/lib/cmake)
+ 
+-  list(APPEND PEADDRCONV_CXXFLAGS /W4 /WX /analyze)
++  list(APPEND PEADDRCONV_CXXFLAGS /W4 /analyze)
+ 
+   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+     list(APPEND PEADDRCONV_CXXFLAGS /Zi)
 @@ -26,7 +26,7 @@ else ()
      -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization
      -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment

--- a/ports/pe-parse/vcpkg.json
+++ b/ports/pe-parse/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pe-parse",
   "version": "2.1.1",
+  "port-version": 1,
   "description": "pe-parse is a principled, lightweight C/C++ PE parser",
   "homepage": "https://github.com/trailofbits/pe-parse",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7686,7 +7686,7 @@
     },
     "pe-parse": {
       "baseline": "2.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "pegtl": {
       "baseline": "3.2.8",

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bdd85cc115d86b0fc3dc0a0550a2e2496bb16fb",
+      "version": "2.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "20bff5e992991e9824bfbcd42ea6a52313cb5446",
       "version": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
Fixes build in Visual Studio 2026 18.6.0 / MSVC 19.51.
