### PR TITLE
[serf] Remove hardcoded MSVC verisons.

### DIFF
--- a/ports/serf/hardcoded-msvc-versions.diff
+++ b/ports/serf/hardcoded-msvc-versions.diff
@@ -1,0 +1,28 @@
+diff --git a/SConstruct b/SConstruct
+index 8b53af6..f99f5f7 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -137,21 +137,8 @@ if sys.platform == 'win32':
+                       'X64'  : 'x86_64'
+                      }),
+ 
+-    EnumVariable('MSVC_VERSION',
+-                 "Visual C++ to use for building",
+-                 None,
+-                 allowed_values=('14.3', '14.2', '14.1', '14.0', '12.0',
+-                                 '11.0', '10.0', '9.0', '8.0', '6.0'),
+-                 map={'2005' :  '8.0',
+-                      '2008' :  '9.0',
+-                      '2010' : '10.0',
+-                      '2012' : '11.0',
+-                      '2013' : '12.0',
+-                      '2015' : '14.0',
+-                      '2017' : '14.1',
+-                      '2019' : '14.2',
+-                      '2022' : '14.3',
+-                     }),
++    ('MSVC_VERSION', "Visual C++ to use for building (see " +
++     "https://scons.org/doc/latest/HTML/scons-user.html#cv-MSVC_VERSION)", None),
+ 
+     # We always documented that we handle an install layout, but in fact we
+     # hardcoded source layouts. Allow disabling this behavior.

--- a/ports/serf/portfile.cmake
+++ b/ports/serf/portfile.cmake
@@ -8,22 +8,23 @@ vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
-      dependencies.diff
+        dependencies.diff
+        hardcoded-msvc-versions.diff # ~= https://github.com/apache/serf/commit/57bb8775665a724d6db648ca30689de04103873b
 )
 
 # Note: custom architecture is not supported on Unix.
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-  set(SCONS_ARCH "TARGET_ARCH=x86_64")
+    set(SCONS_ARCH "TARGET_ARCH=x86_64")
 elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-  set(SCONS_ARCH "TARGET_ARCH=x86")
+    set(SCONS_ARCH "TARGET_ARCH=x86")
 else()
-  set(SCONS_ARCH "")
+    set(SCONS_ARCH "")
 endif()
 
 if(EXISTS "${CURRENT_INSTALLED_DIR}/bin/libapr-1.dll")
-  set(APR_STATIC "no")
+    set(APR_STATIC "no")
 else()
-  set(APR_STATIC "yes")
+    set(APR_STATIC "yes")
 endif()
 
 vcpkg_find_acquire_program(SCONS)
@@ -31,112 +32,112 @@ vcpkg_find_acquire_program(SCONS)
 message(STATUS "Building ${TARGET_TRIPLET}-rel")
 
 if(VCPKG_TARGET_IS_WINDOWS)
-  SET(apr_opts
-    "APR=${CURRENT_INSTALLED_DIR}"
-    "APU=${CURRENT_INSTALLED_DIR}"
-    "APR_STATIC=${APR_STATIC}"
-  )
-  if(EXISTS "${CURRENT_INSTALLED_DIR}/lib/zs.lib")
-    set(ENV{ZLIB_BASENAME} "zs")
-  elseif(EXISTS "${CURRENT_INSTALLED_DIR}/lib/z.lib")
-    set(ENV{ZLIB_BASENAME} "z")
-  endif()
+    SET(apr_opts
+        "APR=${CURRENT_INSTALLED_DIR}"
+        "APU=${CURRENT_INSTALLED_DIR}"
+        "APR_STATIC=${APR_STATIC}"
+    )
+    if(EXISTS "${CURRENT_INSTALLED_DIR}/lib/zs.lib")
+        set(ENV{ZLIB_BASENAME} "zs")
+    elseif(EXISTS "${CURRENT_INSTALLED_DIR}/lib/z.lib")
+        set(ENV{ZLIB_BASENAME} "z")
+    endif()
 else()
-  SET(apr_opts
-    "APR=${CURRENT_INSTALLED_DIR}/tools/apr/bin/apr-1-config"
-    "APU=${CURRENT_INSTALLED_DIR}/tools/apr-util/bin/apu-1-config"
-  )
+    SET(apr_opts
+        "APR=${CURRENT_INSTALLED_DIR}/tools/apr/bin/apr-1-config"
+        "APU=${CURRENT_INSTALLED_DIR}/tools/apr-util/bin/apu-1-config"
+    )
 endif()
 
 vcpkg_execute_build_process(
-  COMMAND ${SCONS}
-      "SOURCE_LAYOUT=no"
-      "PREFIX=${CURRENT_PACKAGES_DIR}"
-      "LIBDIR=${CURRENT_PACKAGES_DIR}/lib"
-      "OPENSSL=${CURRENT_INSTALLED_DIR}"
-      "ZLIB=${CURRENT_INSTALLED_DIR}"
-      ${apr_opts}
-      "${SCONS_ARCH}"
-      "DEBUG=no"
-      "install-lib" "install-inc" "install-pc"
-  WORKING_DIRECTORY "${SOURCE_PATH}"
-  LOGNAME "scons-rel"
+    COMMAND ${SCONS}
+        "SOURCE_LAYOUT=no"
+        "PREFIX=${CURRENT_PACKAGES_DIR}"
+        "LIBDIR=${CURRENT_PACKAGES_DIR}/lib"
+        "OPENSSL=${CURRENT_INSTALLED_DIR}"
+        "ZLIB=${CURRENT_INSTALLED_DIR}"
+        ${apr_opts}
+        "${SCONS_ARCH}"
+        "DEBUG=no"
+        "install-lib" "install-inc" "install-pc"
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME "scons-rel"
 )
 
 # Fixup installed files.
 if(VCPKG_TARGET_IS_WINDOWS)
-  if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-    file(RENAME
-      "${CURRENT_PACKAGES_DIR}/lib/libserf-1.dll"
-      "${CURRENT_PACKAGES_DIR}/bin/libserf-1.dll"
-    )
-    file(RENAME
-      "${CURRENT_PACKAGES_DIR}/lib/libserf-1.pdb"
-      "${CURRENT_PACKAGES_DIR}/bin/libserf-1.pdb"
-    )
-  else()
-    file(REMOVE
-      "${CURRENT_PACKAGES_DIR}/lib/libserf-1.dll"
-      "${CURRENT_PACKAGES_DIR}/lib/libserf-1.pdb"
-      "${CURRENT_PACKAGES_DIR}/lib/libserf-1.lib"
-    )
-  endif()
-  file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/libserf-1.exp")
+    if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+        file(RENAME
+            "${CURRENT_PACKAGES_DIR}/lib/libserf-1.dll"
+            "${CURRENT_PACKAGES_DIR}/bin/libserf-1.dll"
+        )
+        file(RENAME
+            "${CURRENT_PACKAGES_DIR}/lib/libserf-1.pdb"
+            "${CURRENT_PACKAGES_DIR}/bin/libserf-1.pdb"
+        )
+    else()
+        file(REMOVE
+            "${CURRENT_PACKAGES_DIR}/lib/libserf-1.dll"
+            "${CURRENT_PACKAGES_DIR}/lib/libserf-1.pdb"
+            "${CURRENT_PACKAGES_DIR}/lib/libserf-1.lib"
+        )
+    endif()
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/libserf-1.exp")
 endif()
 
 if(NOT VCPKG_BUILD_TYPE)
-  message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+    message(STATUS "Building ${TARGET_TRIPLET}-dbg")
 
-  if(VCPKG_TARGET_IS_WINDOWS)
-    SET(apr_opts
-      "APR=${CURRENT_INSTALLED_DIR}/debug"
-      "APU=${CURRENT_INSTALLED_DIR}/debug"
-      "APR_STATIC=${APR_STATIC}"
-    )
-  else()
-    SET(apr_opts
-      "APR=${CURRENT_INSTALLED_DIR}/tools/apr/debug/bin/apr-1-config"
-      "APU=${CURRENT_INSTALLED_DIR}/tools/apr-util/debug/bin/apu-1-config"
-    )
-  endif()
-
-  vcpkg_execute_build_process(
-      COMMAND ${SCONS}
-          "SOURCE_LAYOUT=no"
-          "PREFIX=${CURRENT_PACKAGES_DIR}/debug"
-          "LIBDIR=${CURRENT_PACKAGES_DIR}/debug/lib"
-          "OPENSSL=${CURRENT_INSTALLED_DIR}/debug"
-          "ZLIB=${CURRENT_INSTALLED_DIR}/debug"
-          ${apr_opts}
-          "${SCONS_ARCH}"
-          "DEBUG=yes"
-          "install-lib" "install-pc"
-      WORKING_DIRECTORY "${SOURCE_PATH}"
-      LOGNAME "scons-dbg"
-  )
-
-  # Fixup installed files.
-  if(VCPKG_TARGET_IS_WINDOWS)
-    if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic")
-      file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-      file(RENAME
-        "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.dll"
-        "${CURRENT_PACKAGES_DIR}/debug/bin/libserf-1.dll"
-      )
-      file(RENAME
-        "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.pdb"
-        "${CURRENT_PACKAGES_DIR}/debug/bin/libserf-1.pdb"
-      )
+    if(VCPKG_TARGET_IS_WINDOWS)
+        SET(apr_opts
+            "APR=${CURRENT_INSTALLED_DIR}/debug"
+            "APU=${CURRENT_INSTALLED_DIR}/debug"
+            "APR_STATIC=${APR_STATIC}"
+        )
     else()
-      file(REMOVE
-        "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.dll"
-        "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.pdb"
-        "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.lib"
-      )
+        SET(apr_opts
+            "APR=${CURRENT_INSTALLED_DIR}/tools/apr/debug/bin/apr-1-config"
+            "APU=${CURRENT_INSTALLED_DIR}/tools/apr-util/debug/bin/apu-1-config"
+        )
     endif()
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.exp")
-  endif()
+
+    vcpkg_execute_build_process(
+        COMMAND ${SCONS}
+            "SOURCE_LAYOUT=no"
+            "PREFIX=${CURRENT_PACKAGES_DIR}/debug"
+            "LIBDIR=${CURRENT_PACKAGES_DIR}/debug/lib"
+            "OPENSSL=${CURRENT_INSTALLED_DIR}/debug"
+            "ZLIB=${CURRENT_INSTALLED_DIR}/debug"
+            ${apr_opts}
+            "${SCONS_ARCH}"
+            "DEBUG=yes"
+            "install-lib" "install-pc"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "scons-dbg"
+    )
+
+    # Fixup installed files.
+    if(VCPKG_TARGET_IS_WINDOWS)
+      if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(RENAME
+            "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.dll"
+            "${CURRENT_PACKAGES_DIR}/debug/bin/libserf-1.dll"
+        )
+        file(RENAME
+            "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.pdb"
+            "${CURRENT_PACKAGES_DIR}/debug/bin/libserf-1.pdb"
+        )
+        else()
+        file(REMOVE
+            "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.dll"
+            "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.pdb"
+            "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.lib"
+        )
+        endif()
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/libserf-1.exp")
+    endif()
 endif()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/serf/vcpkg.json
+++ b/ports/serf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "serf",
   "version": "1.3.10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The serf library is a high performance C-based HTTP client library built upon the Apache Portable Runtime (APR) library. It is permissively licensed under the Apache License, v2.",
   "homepage": "https://serf.apache.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9178,7 +9178,7 @@
     },
     "serf": {
       "baseline": "1.3.10",
-      "port-version": 1
+      "port-version": 2
     },
     "sese": {
       "baseline": "2.3.0",

--- a/versions/s-/serf.json
+++ b/versions/s-/serf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07afe7a02c42c83d95825176b71f3ca1669cd172",
+      "version": "1.3.10",
+      "port-version": 2
+    },
+    {
       "git-tree": "b6de178033cf4863ae254effe4d99276f66eb14e",
       "version": "1.3.10",
       "port-version": 1


### PR DESCRIPTION
Also reindent portfile to consistently use 4 spaces, and LFize.

Fixes build in Visual Studio 2026 18.6.0 / MSVC 19.51.
