### PR TITLE
[scripts] Add support for Python 3.13 and 3.14 tools

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program(PYTHON313).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(PYTHON313).cmake
@@ -1,6 +1,6 @@
 if(CMAKE_HOST_WIN32)
     set(program_name python)
-    set(program_version 3.14.5)
+    set(program_version 3.13.13)
     if(DEFINED ENV{PROCESSOR_ARCHITEW6432})
         set(build_arch $ENV{PROCESSOR_ARCHITEW6432})
     else()
@@ -8,26 +8,23 @@ if(CMAKE_HOST_WIN32)
     endif()
     if(build_arch MATCHES "^(ARM|arm)64$")
         set(tool_subdirectory "python-${program_version}-arm64")
-        # https://www.python.org/ftp/python/3.14.5/python-3.14.5-embed-arm64.zip
+        # https://www.python.org/ftp/python/3.13.13/python-3.13.13-embed-arm64.zip
         set(download_urls "https://www.python.org/ftp/python/${program_version}/python-${program_version}-embed-arm64.zip")
         set(download_filename "python-${program_version}-embed-arm64.zip")
-        set(download_sha512 fac1c50a74bd00e3f80f655d1ab2e319a97ba131ee3eaeed37248dacc3ee650561b1acf2df159d9ed984d9bd195a4f238bfea438d7bd156e5e61438073b94c90)
+        set(download_sha512 045925e59e2bffd5edeffc9dd9761eb3c95c7a01231b8b473845bd4592a282aaf44b034cc6fdcb6e1748a7ed2968d127c6270394a154d0ffaf03b0c065234111)
     elseif(build_arch MATCHES "(amd|AMD)64")
         set(tool_subdirectory "python-${program_version}-x64")
-        # https://www.python.org/ftp/python/3.14.5/python-3.14.5-embed-amd64.zip
+        # https://www.python.org/ftp/python/3.13.13/python-3.13.13-embed-amd64.zip
         set(download_urls "https://www.python.org/ftp/python/${program_version}/python-${program_version}-embed-amd64.zip")
         set(download_filename "python-${program_version}-embed-amd64.zip")
-        set(download_sha512 c74f2c52afde12742d914740a25de5f2921474cc3d347d15ff98e9ee55d261516c291d5cc9179d9bcef370a310798ba6254685ae0a6d25a1f6acf12eac01bbde)
+        set(download_sha512 3cbf92268243be18798deb1836650253d98ad260eecebea5c715c1d5b698463027b0e907c73d9b304072808c6cb7bed96f23691e944d969978db92da37e22096)
     else()
         set(tool_subdirectory "python-${program_version}-x86")
-        # https://www.python.org/ftp/python/3.14.5/python-3.14.5-embed-win32.zip
+        # https://www.python.org/ftp/python/3.13.13/python-3.13.13-embed-win32.zip
         set(download_urls "https://www.python.org/ftp/python/${program_version}/python-${program_version}-embed-win32.zip")
         set(download_filename "python-${program_version}-embed-win32.zip")
-        set(download_sha512 71c1ce33aa484935306b1a24c75b26193463bb475aa6e1c0f94767649caa22a862c49b2eb341d21f3d8428ae0e4243d5cae1488a83f9f598e23678ee8c548ad8)
+        set(download_sha512 26854919e3fa6eb190535c0b821fe7eefb6f889e2db57693ff171bcf0fa4687c9a184f83be604e99ff9a885ca704daf22921e0bc1d625a763995e78b3fc86207)
     endif()
-
-    # Remove this after the next update
-    string(APPEND tool_subdirectory "-1")
 
     set(paths_to_search "${DOWNLOADS}/tools/python/${tool_subdirectory}")
 
@@ -35,7 +32,7 @@ if(CMAKE_HOST_WIN32)
         "${CMAKE_COMMAND}" "-DPYTHON_DIR=${paths_to_search}" "-DPYTHON_VERSION=${program_version}" -P "${CMAKE_CURRENT_LIST_DIR}/z_vcpkg_make_python_less_embedded.cmake"
     )
 else()
-    set(program_name python3)
-    set(brew_package_name "python")
-    set(apt_package_name "python3")
+    set(program_name python3.13)
+    set(brew_package_name "python@3.13")
+    set(apt_package_name "python3.13")
 endif()

--- a/scripts/cmake/vcpkg_find_acquire_program(PYTHON314).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(PYTHON314).cmake
@@ -26,16 +26,13 @@ if(CMAKE_HOST_WIN32)
         set(download_sha512 71c1ce33aa484935306b1a24c75b26193463bb475aa6e1c0f94767649caa22a862c49b2eb341d21f3d8428ae0e4243d5cae1488a83f9f598e23678ee8c548ad8)
     endif()
 
-    # Remove this after the next update
-    string(APPEND tool_subdirectory "-1")
-
     set(paths_to_search "${DOWNLOADS}/tools/python/${tool_subdirectory}")
 
     vcpkg_list(SET post_install_command
         "${CMAKE_COMMAND}" "-DPYTHON_DIR=${paths_to_search}" "-DPYTHON_VERSION=${program_version}" -P "${CMAKE_CURRENT_LIST_DIR}/z_vcpkg_make_python_less_embedded.cmake"
     )
 else()
-    set(program_name python3)
-    set(brew_package_name "python")
-    set(apt_package_name "python3")
+    set(program_name python3.14)
+    set(brew_package_name "python@3.14")
+    set(apt_package_name "python3.14")
 endif()

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "635cdf4b95fa484ee934da818500fc3ce361c2d0",
+      "version": "3.14.5",
+      "port-version": 0
+    },
+    {
+      "git-tree": "ad30a984dbbae834c1bb877703482827545d955b",
+      "version": "3.13.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "36787c37e508b45bfa1b6739e68bebdefdbed21b",
       "version": "3.12.13",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #46556 #47791 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
