### PR TITLE
[assimp] Support VS 2026/MSVC 19.51.

### DIFF
--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -51,7 +51,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/assimp")
 vcpkg_copy_pdbs()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    set(VCVER vc140 vc141 vc142 vc143)
+    set(VCVER vc140 vc141 vc142 vc143 vc145)
     set(CRT mt md)
     set(DBG_NAMES)
     set(REL_NAMES)

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "assimp",
   "version": "6.0.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a600c955b1da1116c67b00634170deb90c0dd2e",
+      "version": "6.0.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "534707328f097e773a0de049e8de9bd0f8a620ee",
       "version": "6.0.4",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -338,7 +338,7 @@
     },
     "assimp": {
       "baseline": "6.0.4",
-      "port-version": 1
+      "port-version": 2
     },
     "astr": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Fixes

REGRESSION: qt5-3d:x64-windows failed with BUILD_FAILED.

on Visual Studio 2026 18.6.0 / MSVC 19.51.
