### PR TITLE
[simpleble] Use C++20 on Windows.

### DIFF
--- a/ports/simpleble/devendor.diff
+++ b/ports/simpleble/devendor.diff
@@ -1,8 +1,8 @@
 diff --git a/simpleble/CMakeLists.txt b/simpleble/CMakeLists.txt
-index a416c54..a78e345 100644
+index 1c2cd5c..367672f 100644
 --- a/simpleble/CMakeLists.txt
 +++ b/simpleble/CMakeLists.txt
-@@ -158,15 +158,16 @@ set(SIMPLEBLE_DONGL_SOURCES
+@@ -157,15 +157,16 @@ set(SIMPLEBLE_DONGL_SOURCES
      ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/dongl/serial/ProtocolBase.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/src/backends/dongl/serial/Wire.cpp
  

--- a/ports/simpleble/portfile.cmake
+++ b/ports/simpleble/portfile.cmake
@@ -7,7 +7,9 @@ vcpkg_from_github(
     PATCHES
         devendor.diff
         use-std-localtime.patch
+        use-cpp20-on-windows.diff
 )
+
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/cmake/find/Findfmt.cmake"
     "${SOURCE_PATH}/dependencies/internal/include/fmt"

--- a/ports/simpleble/use-cpp20-on-windows.diff
+++ b/ports/simpleble/use-cpp20-on-windows.diff
@@ -1,0 +1,16 @@
+diff --git a/simpleble/CMakeLists.txt b/simpleble/CMakeLists.txt
+index 367672f..0a1d973 100644
+--- a/simpleble/CMakeLists.txt
++++ b/simpleble/CMakeLists.txt
+@@ -75,6 +75,11 @@ set_target_properties(simpleble PROPERTIES
+     MINSIZEREL_POSTFIX "-minsizerel"
+     DEBUG_POSTFIX "-debug")
+ 
++if(MSVC)
++    # avoid <experimental/coroutine> being triggered by winrt/base.h which fails for MSVC 19.51+`
++    set_target_properties(simpleble PROPERTIES CXX_STANDARD 20)
++endif()
++
+ generate_export_header(
+     simpleble
+     BASE_NAME simpleble

--- a/ports/simpleble/vcpkg.json
+++ b/ports/simpleble/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simpleble",
   "version": "0.14.0",
+  "port-version": 1,
   "description": "The ultimate fully-fledged cross-platform library and bindings for Bluetooth Low Energy (BLE).",
   "homepage": "https://github.com/OpenBluetoothToolbox/SimpleBLE",
   "license": "BUSL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9302,7 +9302,7 @@
     },
     "simpleble": {
       "baseline": "0.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "simpleini": {
       "baseline": "4.25",

--- a/versions/s-/simpleble.json
+++ b/versions/s-/simpleble.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7d9f188fadbedc1f10aca07fe2a8f70ee51802d",
+      "version": "0.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b1f1ad70e35a7326faab2eac08e8384342a910ab",
       "version": "0.14.0",
       "port-version": 0


### PR DESCRIPTION
Avoids `<winrt/base.h>` dragging in `<experimental/coroutine>` which emits errors on MSVC 19.51+ because `<experimental/coroutine>` has been deprecated in favor of C++20 coroutines.
