### PR TITLE
[systemc] Remove non-standard iostreams opfx/osfx.

### DIFF
--- a/ports/systemc/msvc-opfx-removal.diff
+++ b/ports/systemc/msvc-opfx-removal.diff
@@ -1,0 +1,35 @@
+diff --git a/src/sysc/datatypes/int/sc_int64_io.cpp b/src/sysc/datatypes/int/sc_int64_io.cpp
+index 92148f477..f97b03135 100644
+--- a/src/sysc/datatypes/int/sc_int64_io.cpp
++++ b/src/sysc/datatypes/int/sc_int64_io.cpp
+@@ -151,17 +151,17 @@ write_uint64(::std::ostream& os, uint64 val, int sign)
+                 goto fail;
+         }
+     }
+-    os.osfx();
+     return;
+ fail:
+     //os.set(::std::ios::badbit);
+-    os.osfx();
++    return;
+ }
+ 
+ ::std::ostream&
+ operator << ( ::std::ostream& os, int64 n )
+ {
+-    if (os.opfx()) {
++    ::std::ostream::sentry sentry(os);
++    if (sentry) {
+         int sign = 1;
+         uint64 abs_n = (uint64) n;
+         if (n < 0 && (os.flags() & (::std::ios::oct|::std::ios::hex)) == 0) {
+@@ -176,7 +176,8 @@ operator << ( ::std::ostream& os, int64 n )
+ ::std::ostream&
+ operator << ( ::std::ostream& os, uint64 n )
+ {
+-    if (os.opfx()) {
++    ::std::ostream::sentry sentry(os);
++    if (sentry) {
+         sc_dt::write_uint64(os, n, 0);
+     }
+     return os;

--- a/ports/systemc/portfile.cmake
+++ b/ports/systemc/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         install.patch
+        msvc-opfx-removal.diff # https://github.com/accellera-official/systemc/pull/159
 )
 
 vcpkg_cmake_configure(

--- a/ports/systemc/vcpkg.json
+++ b/ports/systemc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "systemc",
   "version": "3.0.2",
+  "port-version": 1,
   "description": "A set of C++ classes and macros which provide an event-driven simulation kernel in C++",
   "homepage": "https://systemc.org/overview/systemc/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9882,7 +9882,7 @@
     },
     "systemc": {
       "baseline": "3.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "tabulate": {
       "baseline": "1.5",

--- a/versions/s-/systemc.json
+++ b/versions/s-/systemc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a72f96fe4aa97c377c361f4ec5f0c536ff471afe",
+      "version": "3.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "57a72011666c4db8e2108a39d2f4aefe9865d43b",
       "version": "3.0.2",
       "port-version": 0


### PR DESCRIPTION
Submitted upstream as https://github.com/accellera-official/systemc/pull/159

This change is necessary to build systemc with Visual Studio 2026 18.6.0 / MSVC 19.51.