### PR TITLE
[vtk-m] Avoid stdext::checked_array_iterator.

### DIFF
--- a/ports/vtk-m/avoid-stdext.diff
+++ b/ports/vtk-m/avoid-stdext.diff
@@ -1,0 +1,13 @@
+diff --git a/vtkm/thirdparty/diy/vtkmdiy/include/vtkmdiy/thirdparty/fmt/format.h b/vtkm/thirdparty/diy/vtkmdiy/include/vtkmdiy/thirdparty/fmt/format.h
+index 1de9c38..7caa346 100644
+--- a/vtkm/thirdparty/diy/vtkmdiy/include/vtkmdiy/thirdparty/fmt/format.h
++++ b/vtkm/thirdparty/diy/vtkmdiy/include/vtkmdiy/thirdparty/fmt/format.h
+@@ -356,7 +356,7 @@ inline typename Container::value_type* get_data(Container& c) {
+   return c.data();
+ }
+ 
+-#if defined(_SECURE_SCL) && _SECURE_SCL
++#if defined(_SECURE_SCL) && _SECURE_SCL && (!defined(_MSC_VER) || _MSC_VER < 1951)
+ // Make a checked iterator to avoid MSVC warnings.
+ template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+ template <typename T> checked_ptr<T> make_checked(T* p, size_t size) {

--- a/ports/vtk-m/fix-macos-15-6.patch
+++ b/ports/vtk-m/fix-macos-15-6.patch
@@ -1,8 +1,8 @@
 diff --git a/CMake/VTKmCompilerFlags.cmake b/CMake/VTKmCompilerFlags.cmake
-index 2a7f484..6644468 100644
+index b9be520..d29b672 100644
 --- a/CMake/VTKmCompilerFlags.cmake
 +++ b/CMake/VTKmCompilerFlags.cmake
-@@ -136,6 +136,9 @@ elseif(VTKM_COMPILER_IS_ICC)
+@@ -149,6 +149,9 @@ elseif(VTKM_COMPILER_IS_ICC)
  elseif(VTKM_COMPILER_IS_GNU OR VTKM_COMPILER_IS_CLANG)
    set(cxx_flags -Wall -Wcast-align -Wextra -Wpointer-arith -Wformat -Wformat-security -Wshadow -Wunused -fno-common -Wno-unused-function)
    set(cuda_flags -Xcompiler=-Wall,-Wcast-align,-Wpointer-arith,-Wformat,-Wformat-security,-Wshadow,-fno-common,-Wunused,-Wno-unknown-pragmas,-Wno-unused-local-typedefs,-Wno-unused-function)

--- a/ports/vtk-m/portfile.cmake
+++ b/ports/vtk-m/portfile.cmake
@@ -45,6 +45,7 @@ vcpkg_from_gitlab(GITLAB_URL "https://gitlab.kitware.com"
     PATCHES
         fix-macos-15-6.patch
         pkgconfig.diff
+        avoid-stdext.diff # to avoid removal of stdext::checked_array_iterator
 )
 
 vcpkg_cmake_configure(

--- a/ports/vtk-m/vcpkg.json
+++ b/ports/vtk-m/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vtk-m",
   "version": "2.3.0",
+  "port-version": 1,
   "description": "VTK-m is a toolkit of scientific visualization algorithms for emerging processor architectures.",
   "homepage": "https://gitlab.kitware.com/vtk/vtk-m/",
   "license": null,

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1439,7 +1439,6 @@ vtk-m[cuda]:arm64-osx=cascade
 vtk-m[cuda]:x64-linux=skip
 vtk-m[cuda](arm64 & windows)=cascade # vtk-* cuda[core] only supports (windows & x64 & !xbox) | (linux & x64) | (linux & arm64)
 vtk-m[cuda](windows & !arm64)=feature-fails
-vtk-m[mpi]:arm64-linux=cascade
 vtk-m[omp]:arm64-osx=feature-fails # no openmp on default osx toolchain
 vtk-m[omp](windows)=feature-fails # needs openmp 4.0, msvc has openmp 2.0
 vulkan[tools]:arm64-osx=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10702,7 +10702,7 @@
     },
     "vtk-m": {
       "baseline": "2.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vulkan": {
       "baseline": "2023-12-17",

--- a/versions/v-/vtk-m.json
+++ b/versions/v-/vtk-m.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd74370319fc683d5c2502e749b25ba4ce625366",
+      "version": "2.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ec733e84d62125dfb9747c32219283339afedd6c",
       "version": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
Necessary to build with Visual Studio 2026 18.6.0 / MSVC 19.51.
