### PR TITLE
[wayland-protocols] Update to 1.4.8

### DIFF
--- a/ports/wayland-protocols/portfile.cmake
+++ b/ports/wayland-protocols/portfile.cmake
@@ -20,9 +20,9 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wayland/wayland-protocols
-    REF ${VERSION}
-    SHA512 bcc938a5bac59020ded9c653a4d65cafc42eed7d72518125b6d3d710b468ab3db71d514437cbe80d24821fb65eb2b078cd906c18f35245b0c99ad892b0ba50d0
-    HEAD_REF master
+    REF "${VERSION}"
+    SHA512 f259a42d95cacfa66fbd080aa807af7d4aece3ce32f4cff791f9d550131a2427af4e8d80117dfbd2588d1f003fdd92b23219e6307c163d8ade05093a551cf95a
+    HEAD_REF main
     PATCHES
         cross-build.diff
 )

--- a/ports/wayland-protocols/vcpkg.json
+++ b/ports/wayland-protocols/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wayland-protocols",
-  "version": "1.43",
+  "version": "1.48",
   "description": "wayland-protocols contains Wayland protocols that add functionality not available in the Wayland core protocol.",
   "homepage": "https://wayland.freedesktop.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10781,7 +10781,7 @@
       "port-version": 0
     },
     "wayland-protocols": {
-      "baseline": "1.43",
+      "baseline": "1.48",
       "port-version": 0
     },
     "wcslib": {

--- a/versions/w-/wayland-protocols.json
+++ b/versions/w-/wayland-protocols.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fa30fbeedf5ef0d7e469980095b23aa09cffb08",
+      "version": "1.48",
+      "port-version": 0
+    },
+    {
       "git-tree": "b1cf27f81aea991dd8cd09b425faee8ab8d67598",
       "version": "1.43",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x]  Exactly one version is added in each modified versions file.