### PR TITLE
[aws-c-auth] Update to 0.12.4

### DIFF
--- a/ports/aws-c-auth/portfile.cmake
+++ b/ports/aws-c-auth/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-auth
     REF "v${VERSION}"
-    SHA512 a11faa06f7bd12751b123e8aff9af5bdca87d916dc2f277b46b9acb2b159fd1ab07de93670b7d64b159aa94448d5d1a8b9f20216a8cad4387fcd0f4bc47c0be5
+    SHA512 55e29a077ed24657d01ca4646a46463823cdaaa619a890a8c1919dfef224ae8f80b78f0096ef95907c53c6ab7f426662d0f376f6ef814babb7331f1da72a264d
     HEAD_REF main
 )
 

--- a/ports/aws-c-auth/vcpkg.json
+++ b/ports/aws-c-auth/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-auth",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "C99 library implementation of AWS client-side authentication: standard credentials providers and signing.",
   "homepage": "https://github.com/awslabs/aws-c-auth",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-auth.json
+++ b/versions/a-/aws-c-auth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de39b700c29fb353048990f3871a1685e6cd5b79",
+      "version": "0.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6eb027329aa9349a82b21af20f526a6476f1520b",
       "version": "0.10.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -453,7 +453,7 @@
       "port-version": 2
     },
     "aws-c-auth": {
-      "baseline": "0.10.1",
+      "baseline": "0.10.2",
       "port-version": 0
     },
     "aws-c-cal": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
