### PR TITLE
[aws-c-common] Update to 0.13.0

### DIFF
--- a/ports/aws-c-common/portfile.cmake
+++ b/ports/aws-c-common/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-common
     REF "v${VERSION}"
-    SHA512 577fdea85ea84563e2167d70f0988ceeccc6ab298a2ca034393872d1717237a64be0d0b5e9cd2083c2278b8c294bc4afb8f8d6bcc13e144259fa0e3166af35bb
+    SHA512 7887685d3a54bfc77c3d8f7c3ae6661be01f44640b57fa95d96e615144975c1e63946517574034188fdf57f22d306984bd0caeda217125de75c7296b1987c323
     HEAD_REF master
     PATCHES
         disable-internal-crt-option.patch # Disable internal crt option because vcpkg contains crt processing flow

--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-common",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c55f519af76a10c02c55978df280a4412ba8fb57",
+      "version": "0.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "475281cad4267547a93a03d7a18802007e780b15",
       "version": "0.12.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -461,7 +461,7 @@
       "port-version": 0
     },
     "aws-c-common": {
-      "baseline": "0.12.6",
+      "baseline": "0.13.0",
       "port-version": 0
     },
     "aws-c-compression": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.