### PR TITLE
[bit7z] update to 4.0.12

### DIFF
--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rikyoz/bit7z
     REF "v${VERSION}"
-    SHA512 63683be54d3c8b4b328501f55de49584ad7913f41f9b5f20cfc825bac45fe079efac4aaedb16a0fecc21d045e3a33dbc9a9b53a1ce43da541a2ae8042c91095f
+    SHA512 57727b2f4906802e1b5b07b8e8741da8e162d4491fa1ba59b9e7ec61f8b405654872c46184e7c83660cb9dbb61bbebc88787715fbcac1251de799ad157738358
     HEAD_REF master
     PATCHES
       fix_install.patch

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bit7z",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries.",
   "homepage": "https://github.com/rikyoz/bit7z",
   "license": "MPL-2.0",

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d58d639b9def3a5199444a1b3ad1c46af61901a",
+      "version": "4.0.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "c981943b56e0bf3cdd005a500c8c5d7cb7acd40c",
       "version": "4.0.11",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -741,7 +741,7 @@
       "port-version": 3
     },
     "bit7z": {
-      "baseline": "4.0.11",
+      "baseline": "4.0.12",
       "port-version": 0
     },
     "bitmagic": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/rikyoz/bit7z/releases/tag/v4.0.12
