### PR TITLE
[luau] update to 0.721

### DIFF
--- a/ports/luau/include-algorithm.patch
+++ b/ports/luau/include-algorithm.patch
@@ -2,11 +2,10 @@ diff --git a/CodeGen/src/OptimizeDeadStore.cpp b/CodeGen/src/OptimizeDeadStore.c
 index 79ee3fc..ad3978a 100644
 --- a/CodeGen/src/OptimizeDeadStore.cpp
 +++ b/CodeGen/src/OptimizeDeadStore.cpp
-@@ -6,7 +6,7 @@
+@@ -7,6 +7,7 @@
  #include "Luau/IrUtils.h"
  
  #include <array>
--
 +#include <algorithm>
  #include "lobject.h"
  

--- a/ports/luau/include-algorithm.patch
+++ b/ports/luau/include-algorithm.patch
@@ -1,0 +1,13 @@
+diff --git a/CodeGen/src/OptimizeDeadStore.cpp b/CodeGen/src/OptimizeDeadStore.cpp
+index 79ee3fc..ad3978a 100644
+--- a/CodeGen/src/OptimizeDeadStore.cpp
++++ b/CodeGen/src/OptimizeDeadStore.cpp
+@@ -6,7 +6,7 @@
+ #include "Luau/IrUtils.h"
+ 
+ #include <array>
+-
++#include <algorithm>
+ #include "lobject.h"
+ 
+ LUAU_FASTFLAGVARIABLE(LuauCodegenGcoDse2)

--- a/ports/luau/include-algorithm.patch
+++ b/ports/luau/include-algorithm.patch
@@ -1,12 +1,12 @@
 diff --git a/CodeGen/src/OptimizeDeadStore.cpp b/CodeGen/src/OptimizeDeadStore.cpp
-index 79ee3fc..ad3978a 100644
+index 79ee3fc..d1414a4 100644
 --- a/CodeGen/src/OptimizeDeadStore.cpp
 +++ b/CodeGen/src/OptimizeDeadStore.cpp
-@@ -7,6 +7,7 @@
+@@ -6,6 +6,7 @@
  #include "Luau/IrUtils.h"
  
  #include <array>
 +#include <algorithm>
+ 
  #include "lobject.h"
  
- LUAU_FASTFLAGVARIABLE(LuauCodegenGcoDse2)

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,11 +4,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 268841a44b4489c761386e674259ee33f6670e471db6a288ecc482c0828829c35cc70ff84383f751d29d4bb898d38ceb804adc4ddc1efb8eb8a211018b1bce58
+    SHA512 f51b860a2487606842b62bf9923484b8d4c65c1338ed8b0dc91d4c6ee4e44a3b59079e94a688c978de2bc43671dbf7e857501e552adbe1a69e512ce82ea0ed90
     HEAD_REF master
     PATCHES
         cmake-config-export.patch
         fix-unittest.patch
+        include-algorithm.patch
 )
 
 vcpkg_check_features(

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.720",
+  "version": "0.721",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6233,7 +6233,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.720",
+      "baseline": "0.721",
       "port-version": 0
     },
     "lunarg-vulkantools": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "36de184f84bbedd1c2c9ee4011ce4c4d3654454d",
+      "git-tree": "68646ff47b54da8ff882473100293a0a69adee51",
       "version": "0.721",
       "port-version": 0
     },

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "68646ff47b54da8ff882473100293a0a69adee51",
+      "git-tree": "cb01d66a537cc088fd7b12c10a4f22967f4a7afd",
       "version": "0.721",
       "port-version": 0
     },

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c0a961031b20bf3d22ba74f98b148535d28f101",
+      "git-tree": "36de184f84bbedd1c2c9ee4011ce4c4d3654454d",
       "version": "0.721",
       "port-version": 0
     },

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c0a961031b20bf3d22ba74f98b148535d28f101",
+      "version": "0.721",
+      "port-version": 0
+    },
+    {
       "git-tree": "15d7dc86286c4828d0b830ce5247795da8474e0e",
       "version": "0.720",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/luau-lang/luau/releases/tag/0.721
