### PR TITLE
[sdl2-net] update to 2.4.0

### DIFF
--- a/ports/sdl2-net/fix-uwp.patch
+++ b/ports/sdl2-net/fix-uwp.patch
@@ -1,13 +1,13 @@
-diff --git a/SDLnetUDP.c b/SDLnetUDP.c
-index ee4e46b..dc9b4b0 100644
---- a/SDLnetUDP.c
-+++ b/SDLnetUDP.c
+diff --git a/src/SDLnetUDP.c b/src/SDLnetUDP.c
+index 5b58db8..8e21120 100644
+--- a/src/SDLnetUDP.c
++++ b/src/SDLnetUDP.c
 @@ -22,7 +22,7 @@
  #include "SDLnetsys.h"
  #include "SDL_net.h"
  
--#if defined(__WIN32__) || defined(__OS2__)
-+#if defined(_WIN32) || defined(__OS2__)
+-#if defined(__WIN32__) || defined(__WINRT__) || defined(__OS2__)
++#if defined(_WIN32) || defined(__WINRT__) || defined(__OS2__)
  #define srandom srand
  #define random  rand
  #endif

--- a/ports/sdl2-net/portfile.cmake
+++ b/ports/sdl2-net/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_net
-    REF 669e75b84632e2c6cc5c65974ec9e28052cb7a4e # release-2.2.0
-    SHA512 180c757d704c72dc7fcc392c13942214c87b90de22e32045ec9eb6cde5da2b762516e14120d8bee52f7f4a59ad8e30d4f71e313918432ae07ef71df8e9380e4b
+    REF release-${VERSION}
+    SHA512 19681402d41eb24b06296da73d82c5f27d4cbe7f8ec7ae64f6be63d232db99d6def3bd330beef1dcd280a29df419e9d3fdc713d9ef0d7106cc6c95717aa2db43
     HEAD_REF main
     PATCHES
         fix-uwp.patch
@@ -24,7 +24,7 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/lib/pkgconfig"

--- a/ports/sdl2-net/portfile.cmake
+++ b/ports/sdl2-net/portfile.cmake
@@ -23,13 +23,12 @@ else()
 endif()
 
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig"
-    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig"
 )
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+# file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sdl2-net/portfile.cmake
+++ b/ports/sdl2-net/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig"
     "${CURRENT_PACKAGES_DIR}/lib/pkgconfig"
 )
 

--- a/ports/sdl2-net/usage
+++ b/ports/sdl2-net/usage
@@ -2,3 +2,7 @@ sdl2-net provides CMake targets:
 
     find_package(SDL2_net CONFIG REQUIRED)
     target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL2_net::SDL2_net>,SDL2_net::SDL2_net,SDL2_net::SDL2_net-static>)
+
+sdl2-net provides pkg-config modules:
+
+    SDL2_net

--- a/ports/sdl2-net/vcpkg.json
+++ b/ports/sdl2-net/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl2-net",
-  "version": "2.2.0",
-  "port-version": 3,
+  "version": "2.4.0",
   "description": "Networking library for SDL",
   "homepage": "https://github.com/libsdl-org/SDL_net",
   "license": "Zlib",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1308,7 +1308,6 @@ sdl1-net(android | osx)=cascade
 sdl2[dbus]:arm64-linux=cascade
 sdl2-gfx:arm64-linux=cascade
 sdl2-mixer-ext:arm64-linux=cascade
-sdl2-net:arm64-linux=cascade
 sdl2-ttf:arm64-linux=cascade
 sdl2pp:arm64-linux=cascade
 sdl3-shadercross((!windows | arm32 | uwp | xbox) & (!linux | !x64))=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9089,8 +9089,8 @@
       "port-version": 1
     },
     "sdl2-net": {
-      "baseline": "2.2.0",
-      "port-version": 3
+      "baseline": "2.4.0",
+      "port-version": 0
     },
     "sdl2-ttf": {
       "baseline": "2.24.0",

--- a/versions/s-/sdl2-net.json
+++ b/versions/s-/sdl2-net.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b240211ead9d0a296fcae4f4faf22cdccae9f587",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f735d9ac81c56778c5a317db55d1c1f2cce78e87",
       "version": "2.2.0",
       "port-version": 3

--- a/versions/s-/sdl2-net.json
+++ b/versions/s-/sdl2-net.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1447120f18f746d9f004283ac00ec7227d6cf61b",
+      "git-tree": "4778ecb8a9e3058b8056b9ae6e6f6a989f33a90c",
       "version": "2.4.0",
       "port-version": 0
     },

--- a/versions/s-/sdl2-net.json
+++ b/versions/s-/sdl2-net.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b240211ead9d0a296fcae4f4faf22cdccae9f587",
+      "git-tree": "1447120f18f746d9f004283ac00ec7227d6cf61b",
       "version": "2.4.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libsdl-org/SDL_net/releases/tag/release-2.4.0
