### PR TITLE
[vcpkg baseline][gdal] Fix libarchive and zstd import/export

### DIFF
--- a/ports/gdal/libarchive.diff
+++ b/ports/gdal/libarchive.diff
@@ -1,0 +1,29 @@
+diff --git a/cmake/helpers/CheckDependentLibraries.cmake b/cmake/helpers/CheckDependentLibraries.cmake
+index ba99a00a67..d24ece6055 100644
+--- a/cmake/helpers/CheckDependentLibraries.cmake
++++ b/cmake/helpers/CheckDependentLibraries.cmake
+@@ -423,7 +423,10 @@ gdal_check_package(LZ4 "LZ4 compression" CAN_DISABLE)
+ gdal_check_package(Blosc "Blosc compression" CAN_DISABLE)
+ 
+ define_find_package2(ARCHIVE archive.h archive)
+-gdal_check_package(ARCHIVE "Multi-format archive and compression library library (used for /vsi7z/" CAN_DISABLE)
++set(GDAL_USE_LIBARCHIVE "${GDAL_USE_ARCHIVE}" CACHE BOOL "")
++gdal_check_package(LibArchive "Multi-format archive and compression library library (used for /vsi7z/" CAN_DISABLE
++  TARGETS LibArchive::LibArchive
++)
+ 
+ define_find_package2(LIBAEC libaec.h aec)
+ gdal_check_package(LIBAEC "Adaptive Entropy Coding implementing Golomb-Rice algorithm (used by GRIB)" CAN_DISABLE)
+diff --git a/port/CMakeLists.txt b/port/CMakeLists.txt
+index 1f5d653d30..b71ef2fef0 100644
+--- a/port/CMakeLists.txt
++++ b/port/CMakeLists.txt
+@@ -209,7 +209,7 @@ endif ()
+ 
+ if (GDAL_USE_ARCHIVE)
+   target_compile_definitions(cpl PRIVATE -DHAVE_LIBARCHIVE)
+-  gdal_target_link_libraries(cpl PRIVATE ARCHIVE::ARCHIVE)
++  gdal_target_link_libraries(cpl PRIVATE LibArchive::LibArchive)
+ endif ()
+ 
+ if (GDAL_USE_CURL)

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         find-link-libraries.patch
         iconv.diff
+        libarchive.diff
         libkml.patch
         sqlite3.diff
         target-is-valid.patch

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -12,8 +12,8 @@ vcpkg_from_github(
         sqlite3.diff
         target-is-valid.patch
 )
-
 file(REMOVE "${SOURCE_PATH}/cmake/modules/packages/FindIconv.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/modules/packages/FindZSTD.cmake")
 # `vcpkg clean` stumbles over one subdir
 file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")
 

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.12.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3318,7 +3318,7 @@
     },
     "gdal": {
       "baseline": "3.12.4",
-      "port-version": 1
+      "port-version": 2
     },
     "gdbm": {
       "baseline": "1.24",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43f35109fc4af90ce240609f24532ba0aaff6455",
+      "version-semver": "3.12.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "464231a52207efb8065e11adc072063556201e76",
       "version-semver": "3.12.4",
       "port-version": 1

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "43f35109fc4af90ce240609f24532ba0aaff6455",
+      "git-tree": "8d51b5a24e3e607f5ea0f9085f6a0a1fe599df9a",
       "version-semver": "3.12.4",
       "port-version": 2
     },


### PR DESCRIPTION
Trying to fix downstream regressions, e.g. in pdal, in vcpkg ci and in #51761.
- Engage libarchive cmake wrapper.
- Avoid vendored FindZSTD in favor of CMake config.