### PR TITLE
Prism: update to 0.16.1

### DIFF
--- a/ports/ethindp-prism/portfile.cmake
+++ b/ports/ethindp-prism/portfile.cmake
@@ -4,8 +4,8 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO ethindp/prism
-  REF v0.15.0
-  SHA512 b83b7b46414e7750c11666b7ce4639dffe6776c985b6f22eb31251246a5ecf67c89196f6f8c8215498e7c3acbe9259cf901028aa3521c63f9291ce0d70a0bd11
+  REF v0.16.1
+  SHA512 201ce4218543823b3a36aef6200032bfda816f8dcde495cca43de101415cc643da67a0eb347e5f90eec3d6ca1dcb298d8c1f544933ce2c5edbd44a32e92bd8d2
   HEAD_REF master
 )
 vcpkg_check_features(

--- a/ports/ethindp-prism/vcpkg.json
+++ b/ports/ethindp-prism/vcpkg.json
@@ -1,10 +1,14 @@
 {
   "name": "ethindp-prism",
-  "version": "0.15.0",
+  "version": "0.16.1",
   "description": "The Platform-agnostic Reader Interface for Speech and Messages",
   "license": "MPL-2.0",
   "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "pkgconf",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -19,18 +23,14 @@
       "description": "Enable the Orca backend",
       "supports": "(linux | freebsd | openbsd) & !android & !emscripten",
       "dependencies": [
-        "glib"
+        "glibmm"
       ]
     },
     "speech-dispatcher": {
       "description": "Enable the speech-dispatcher backend (requires libspeechd to be installed)",
       "supports": "(linux | freebsd | openbsd) & !android & !emscripten",
       "dependencies": [
-        "libspeechd",
-        {
-          "name": "pkgconf",
-          "host": true
-        }
+        "libspeechd"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2857,7 +2857,7 @@
       "port-version": 1
     },
     "ethindp-prism": {
-      "baseline": "0.15.0",
+      "baseline": "0.16.1",
       "port-version": 0
     },
     "etl": {

--- a/versions/e-/ethindp-prism.json
+++ b/versions/e-/ethindp-prism.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a98bdb1e7d4c67d47c6f462bfc6e85f2a3636773",
+      "version": "0.16.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "86b388df96fac63b9ecd141558c5cef7827ab442",
       "version": "0.15.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

It's worth noting that there is a feature that is explicitly disabled (the spiel backend) because libspiel is not in vcpkg and building it isn't exactly a trivial effort (it requires python, compilation of glib schemas and all that). Thus for now we keep it off.
