### PR TITLE
[reflectcpp] update to 0.25.0

### DIFF
--- a/ports/reflectcpp/fix-bson.patch
+++ b/ports/reflectcpp/fix-bson.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fb1069f..070d6d1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -311,10 +311,10 @@ if (REFLECTCPP_BSON OR REFLECTCPP_CHECK_HEADERS)
+     list(APPEND REFLECT_CPP_SOURCES
+         src/reflectcpp_bson.cpp
+     )
+-    if (NOT TARGET mongo::bson_static AND NOT TARGET mongo::bson_shared)
+-        find_package(bson-1.0 CONFIG REQUIRED)
++    if (NOT TARGET bson::static AND NOT TARGET bson::shared)
++        find_package(bson CONFIG REQUIRED)
+     endif ()
+-    target_link_libraries(reflectcpp PUBLIC $<IF:$<TARGET_EXISTS:mongo::bson_static>,mongo::bson_static,mongo::bson_shared>)
++    target_link_libraries(reflectcpp PUBLIC $<IF:$<TARGET_EXISTS:bson::static>,bson::static,bson::shared>)
+ endif ()
+ 
+ if (REFLECTCPP_CAPNPROTO OR REFLECTCPP_CHECK_HEADERS)
+diff --git a/reflectcpp-config.cmake.in b/reflectcpp-config.cmake.in
+index a1ba068..4e9c66c 100644
+--- a/reflectcpp-config.cmake.in
++++ b/reflectcpp-config.cmake.in
+@@ -36,7 +36,7 @@ if (REFLECTCPP_BOOST_SERIALIZATION)
+ endif ()
+ 
+ if (REFLECTCPP_BSON)  
+-  find_dependency(bson-1.0)
++  find_dependency(bson)
+ endif ()
+ 
+ if (REFLECTCPP_CAPNPROTO)  

--- a/ports/reflectcpp/portfile.cmake
+++ b/ports/reflectcpp/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 527b8962754b2a5c48e63df72fe5030bceaa40c10762c4fd2ec1d084d9ced5726129cac9f1045fd818888e8468283f6867a5cbdd11bae290a4111b4a67eb573f
     HEAD_REF main
+    PATCHES
+        fix-bson.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/reflectcpp/portfile.cmake
+++ b/ports/reflectcpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO getml/reflect-cpp
     REF "v${VERSION}"
-    SHA512 4be84fc69efd6f4ce766d38cedc8b1d0fd0fa8170e69293383f7dbd59c6bce45797f0e7cf653ef9c839b15fd7da702c9daf30efd34c779555fe4e5bd5eb29481 
+    SHA512 527b8962754b2a5c48e63df72fe5030bceaa40c10762c4fd2ec1d084d9ced5726129cac9f1045fd818888e8468283f6867a5cbdd11bae290a4111b4a67eb573f
     HEAD_REF main
 )
 

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectcpp",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "A C++ library for serialization and deserialization using reflection. Supports JSON, Avro, BSON, Cap'n Proto, CBOR, CSV, flexbuffers, msgpack, parquet, TOML, UBJSON, XML, YAML.",
   "homepage": "https://github.com/getml/reflect-cpp/",
   "license": "MIT",
@@ -23,6 +23,15 @@
     }
   ],
   "features": {
+    "boost-serialization": {
+      "description": "Enable Boost.Serialization support",
+      "dependencies": [
+        {
+          "name": "boost-serialization",
+          "version>=": "1.74.0"
+        }
+      ]
+    },
     "bson": {
       "description": "Support for the BSON format",
       "dependencies": [
@@ -47,6 +56,15 @@
         {
           "name": "jsoncons",
           "version>=": "1.4.0"
+        }
+      ]
+    },
+    "cereal": {
+      "description": "Enable Cereal support",
+      "dependencies": [
+        {
+          "name": "cereal",
+          "version>=": "1.3.2"
         }
       ]
     },
@@ -125,6 +143,15 @@
         {
           "name": "yaml-cpp",
           "version>=": "0.8.0#1"
+        }
+      ]
+    },
+    "yas": {
+      "description": "Enable yas support",
+      "dependencies": [
+        {
+          "name": "yas",
+          "version>=": "7.1.0"
         }
       ]
     }

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1271,7 +1271,6 @@ realm-core:arm-neon-android=fail # https://github.com/realm/realm-core/issues/80
 realm-core:arm64-android=fail
 realm-core:x64-android=fail
 realsense2:arm64-linux=cascade
-reflectcpp[bson]:arm64-linux=feature-fails
 rendergraph:arm64-linux=fail
 restbed:arm64-linux=fail
 restbed:x64-linux=fail # requires c++23

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8721,7 +8721,7 @@
       "port-version": 0
     },
     "reflectcpp": {
-      "baseline": "0.24.0",
+      "baseline": "0.25.0",
       "port-version": 0
     },
     "refprop-headers": {

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5acc5d96d32aba0ed8a7e158b63b008262299a21",
+      "git-tree": "8d4fdf84eaab50298da6c1265bd53277e10fba1f",
       "version": "0.25.0",
       "port-version": 0
     },

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5acc5d96d32aba0ed8a7e158b63b008262299a21",
+      "version": "0.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "676a7e3342491691580364d104c87aaf06c08a79",
       "version": "0.24.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/getml/reflect-cpp/releases/tag/v0.25.0
