### PR TITLE
Adding [void-numerics]

### DIFF
--- a/ports/void-numerics/portfile.cmake
+++ b/ports/void-numerics/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nihilai-collective/void-numerics
+    REF "v${VERSION}"    
+    SHA512 3a3cc255271bfd9ba4e8819d2290f8a2482d71316b960b548fde7b51e36dff41d9fcfc7b1e9997f327377c8232e92c24e2ad828dd337b85ec833c2450ed19958
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.md")

--- a/ports/void-numerics/vcpkg.json
+++ b/ports/void-numerics/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "void-numerics",
+  "version": "1.0.0",
+  "description": "The C++ standard library's <charconv> is already fast. void-numerics is faster - substantially so on hot integer-conversion paths - without sacrificing correctness, portability, or API compatibility.",
+  "homepage": "https://github.com/nihilai-collective/void-numerics",
+  "license": "MIT",
+  "supports": "!android & x64",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10648,6 +10648,10 @@
       "baseline": "2.7.0",
       "port-version": 0
     },
+    "void-numerics": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "volk": {
       "baseline": "1.4.341.0",
       "port-version": 0

--- a/versions/v-/void-numerics.json
+++ b/versions/v-/void-numerics.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "883b7199db52d347cad1a9ed1380e313480a2fcf",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Add void-numerics 1.0.0 — SWAR-optimized integer conversion for C++23**

This PR adds `void-numerics`, a header-only library providing drop-in replacements for `std::to_chars` and `std::from_chars` on integer types, engineered for performance without sacrificing correctness, portability, or API compatibility.

**About this library:**

`vn::to_chars` and `vn::from_chars` achieve **perfect sweeps** (48/48 wins) on `str-to-int` benchmarks across Clang/Linux and MSVC/Windows, with dominant performance on `int-to-str` (39-43 wins out of 46-48 tests per platform). On 64-bit integers, throughput reaches **2.6+ GB/s** — over **50% faster** than stdlib and jeaiii on hot conversion paths.

**Project details:**

- **Header-only** — single include, zero build dependencies
- **C++23** — concepts-based type dispatch
- **Exhaustively tested** — passes LLVM libc++ `<charconv>` test suite, value enumeration on 8/16-bit types, ASAN/UBSAN clean
- **Cross-platform CI** — Ubuntu (Clang/GCC), macOS (Clang/GCC), Windows (MSVC)
- **MIT licensed**
- **API-compatible** with stdlib — returns `std::to_chars_result` / `std::from_chars_result`

**Checklist:**

- [x] Changes comply with the maintainer guide
- [x] Project shows strong association with port name (`nihilai-collective/void-numerics` on GitHub)
- [x] No optional dependencies (header-only)
- [x] Versioning scheme matches upstream (semantic versioning)
- [x] License declaration matches upstream (MIT)
- [x] Copyright file installed correctly
- [x] Source from authoritative origin (GitHub releases)
- [x] Version database updated via `vcpkg x-add-version --all`
- [x] Exactly one version added

**Full benchmark results:** https://github.com/nihilai-collective/void-numerics/blob/main/Benchmarks.md