### PR TITLE
WIP: [redisx] initial port

### DIFF
--- a/ports/redisx/portfile.cmake
+++ b/ports/redisx/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Sigmyne/redisx
+    REF "v${VERSION}"
+    SHA512 9dbbe4fb4a80c3c9d4ca3f28e11d0403f724bb219099d04bbf49fb78d41fc4f749bc6d77787d5eb1db51ec85898eb4e5eab80603c39e85c70bc02333de160e51
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tls              ENABLE_TLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_CLI=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/redisx" PACKAGE_NAME "redisx")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/redisx/vcpkg.json
+++ b/ports/redisx/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "redisx",
+  "version": "1.0.4-rc2",
+  "description": "A free and independent Redix / Valkey client library for C/C++",
+  "homepage": "https://sigmyne.github.io/redisx/",
+  "documentation": "https://sigmyne.github.io/redisx/doc/html/",
+  "license": "Unlicense",
+  "dependencies": [
+    "libxchange",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tls": {
+      "description": "TLS encryption support",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8716,6 +8716,10 @@
       "baseline": "1.3.15",
       "port-version": 0
     },
+    "redisx": {
+      "baseline": "1.0.4-rc2",
+      "port-version": 0
+    },
     "refl-cpp": {
       "baseline": "0.12.4",
       "port-version": 0

--- a/versions/r-/redisx.json
+++ b/versions/r-/redisx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ea2d965c05a5b49cf17b9aa0d8df3198002f35dd",
+      "version": "1.0.4-rc2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This is a draft PR for a new port of the RedisX library, based on the latest upstream release candidate. The plan is to ensure the port is functional, or to identify any changes needed for upstream to make it functional, before the finalized 1.0.4 release expected in a couple of weeks.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="1300" height="354" alt="image" src="https://github.com/user-attachments/assets/5769a7c2-5926-4976-a054-8bd1b396bd13" />


