### PR TITLE
[webrtc] Use vcpkg selected Visual Studio settings.

### DIFF
--- a/ports/webrtc/build-0009-disable-copying-msvc-dlls.patch
+++ b/ports/webrtc/build-0009-disable-copying-msvc-dlls.patch
@@ -1,0 +1,13 @@
+diff --git a/toolchain/win/BUILD.gn b/toolchain/win/BUILD.gn
+index 87d1e4a..c3a47ea 100644
+--- a/toolchain/win/BUILD.gn
++++ b/toolchain/win/BUILD.gn
+@@ -15,7 +15,7 @@ assert(is_win, "Should only be running on Windows")
+ 
+ # Copy the VS runtime DLL for the default toolchain to the root build directory
+ # so things will run.
+-if (current_toolchain == default_toolchain) {
++if (false) {
+   if (is_debug) {
+     configuration_name = "Debug"
+   } else {

--- a/ports/webrtc/build-0010-use-none.patch
+++ b/ports/webrtc/build-0010-use-none.patch
@@ -1,0 +1,13 @@
+diff --git a/config/win/visual_studio_version.gni b/config/win/visual_studio_version.gni
+index bd41166..003a6ac 100644
+--- a/config/win/visual_studio_version.gni
++++ b/config/win/visual_studio_version.gni
+@@ -40,7 +40,7 @@ if (visual_studio_path == "") {
+          "You must set the windows_sdk_version if you set the path")
+   assert(wdk_path != "",
+          "You must set the wdk_path if you set the visual studio path")
+-  visual_studio_runtime_dirs = []
++  visual_studio_runtime_dirs = "None"
+ }
+ 
+ visual_studio_version_logs = [ "windows_sdk_version=${windows_sdk_version}" ]

--- a/ports/webrtc/build-0011-do-not-detect-vs-path.patch
+++ b/ports/webrtc/build-0011-do-not-detect-vs-path.patch
@@ -1,0 +1,13 @@
+diff --git a/toolchain/win/setup_toolchain.py b/toolchain/win/setup_toolchain.py
+index e0b7c03..64e112c 100644
+--- a/toolchain/win/setup_toolchain.py
++++ b/toolchain/win/setup_toolchain.py
+@@ -148,7 +148,7 @@ def _LoadToolchainEnv(cpu, toolchain_root, sdk_dir, target_store):
+       assert _LowercaseDict(json_env) == _LowercaseDict(cmd_env)
+   else:
+     if 'GYP_MSVS_OVERRIDE_PATH' not in os.environ:
+-      os.environ['GYP_MSVS_OVERRIDE_PATH'] = _DetectVisualStudioPath()
++      os.environ['GYP_MSVS_OVERRIDE_PATH'] = toolchain_root
+     # We only support x64-hosted tools.
+     script_path = os.path.normpath(
+         os.path.join(os.environ['GYP_MSVS_OVERRIDE_PATH'], 'VC/vcvarsall.bat'))

--- a/ports/webrtc/portfile.cmake
+++ b/ports/webrtc/portfile.cmake
@@ -33,6 +33,13 @@ set(BUILD_PATCHES
     build-0006-skip-local-vs-debugger-copy.patch
     build-0007-fix-windows-pdb-commands.patch
     build-0008-disable-crel-on-linux-arm64.patch
+    build-0009-disable-copying-msvc-dlls.patch
+    # ERROR at //build/toolchain/win/win_toolchain_data.gni:13:21: This is not a string.
+    #                     visual_studio_runtime_dirs,
+    #                     ^-------------------------
+    # Instead I see a list = []
+    build-0010-use-none.patch
+    build-0011-do-not-detect-vs-path.patch
 )
 
 set(WEBRTC_SOURCE_URL "https://webrtc.googlesource.com/src")
@@ -196,6 +203,38 @@ function(setup_webrtc_windows_toolchain build_config)
     vcpkg_cmake_get_vars(cmake_vars_file)
     include("${cmake_vars_file}")
 
+    string(REGEX REPLACE "/VC/Tools/MSVC/.*" "" WEBRTC_VISUAL_STUDIO_PATH "${VCPKG_DETECTED_CMAKE_CXX_COMPILER}")
+    if(WEBRTC_VISUAL_STUDIO_PATH STREQUAL VCPKG_DETECTED_CMAKE_CXX_COMPILER OR NOT EXISTS "${WEBRTC_VISUAL_STUDIO_PATH}/VC/Auxiliary/Build/vcvarsall.bat")
+        message(FATAL_ERROR "Failed to derive Visual Studio installation path from '${VCPKG_DETECTED_CMAKE_CXX_COMPILER}'.")
+    endif()
+
+    string(REGEX REPLACE "/bin/([^/]+)/[^/]+/rc\\.exe$" "/include/\\1" WEBRTC_WINDOWS_SDK_INCLUDE_PATH "${VCPKG_DETECTED_CMAKE_RC_COMPILER}")
+    if(WEBRTC_WINDOWS_SDK_INCLUDE_PATH STREQUAL VCPKG_DETECTED_CMAKE_RC_COMPILER OR NOT EXISTS "${WEBRTC_WINDOWS_SDK_INCLUDE_PATH}")
+        message(FATAL_ERROR "Failed to derive Windows SDK include path from '${VCPKG_DETECTED_CMAKE_RC_COMPILER}'.")
+    endif()
+    get_filename_component(WEBRTC_WINDOWS_SDK_VERSION "${WEBRTC_WINDOWS_SDK_INCLUDE_PATH}" NAME)
+    get_filename_component(WEBRTC_WINDOWS_SDK_PATH "${WEBRTC_WINDOWS_SDK_INCLUDE_PATH}" DIRECTORY)
+    get_filename_component(WEBRTC_WINDOWS_SDK_PATH "${WEBRTC_WINDOWS_SDK_PATH}" DIRECTORY)
+
+    vcpkg_replace_string(
+        "${SOURCE_PATH}/build/toolchain/win/setup_toolchain.py"
+        "SDK_VERSION = '10.0.26100.0'"
+        "SDK_VERSION = '${WEBRTC_WINDOWS_SDK_VERSION}'"
+        IGNORE_UNCHANGED # if non release only, the second replacement is a no-op
+    )
+
+    if(VCPKG_DETECTED_MSVC_VERSION GREATER_EQUAL 1950)
+        set(WEBRTC_VISUAL_STUDIO_VERSION "2026")
+    elseif(VCPKG_DETECTED_MSVC_VERSION GREATER_EQUAL 1930)
+        set(WEBRTC_VISUAL_STUDIO_VERSION "2022")
+    elseif(VCPKG_DETECTED_MSVC_VERSION GREATER_EQUAL 1920)
+        set(WEBRTC_VISUAL_STUDIO_VERSION "2019")
+    elseif(VCPKG_DETECTED_MSVC_VERSION GREATER_EQUAL 1910)
+        set(WEBRTC_VISUAL_STUDIO_VERSION "2017")
+    else()
+        message(FATAL_ERROR "Unsupported MSVC version '${VCPKG_DETECTED_MSVC_VERSION}'.")
+    endif()
+
     if("${build_config}" STREQUAL "debug")
         set(WEBRTC_EXTRA_CFLAGS_C "${VCPKG_COMBINED_C_FLAGS_DEBUG}" PARENT_SCOPE)
         set(WEBRTC_EXTRA_CFLAGS_CC "${VCPKG_COMBINED_CXX_FLAGS_DEBUG}" PARENT_SCOPE)
@@ -207,6 +246,10 @@ function(setup_webrtc_windows_toolchain build_config)
         set(WEBRTC_EXTRA_LDFLAGS "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE}" PARENT_SCOPE)
         set(WEBRTC_EXTRA_ARFLAGS "${VCPKG_COMBINED_STATIC_LINKER_FLAGS_RELEASE}" PARENT_SCOPE)
     endif()
+    set(WEBRTC_VISUAL_STUDIO_PATH "${WEBRTC_VISUAL_STUDIO_PATH}" PARENT_SCOPE)
+    set(WEBRTC_VISUAL_STUDIO_VERSION "${WEBRTC_VISUAL_STUDIO_VERSION}" PARENT_SCOPE)
+    set(WEBRTC_WINDOWS_SDK_PATH "${WEBRTC_WINDOWS_SDK_PATH}" PARENT_SCOPE)
+    set(WEBRTC_WINDOWS_SDK_VERSION "${WEBRTC_WINDOWS_SDK_VERSION}" PARENT_SCOPE)
 endfunction()
 
 function(setup_webrtc_host_xcode_toolchain)
@@ -499,6 +542,12 @@ foreach(BUILD_CONFIG IN ITEMS debug release)
             "extra_cflags_cc=\"${WEBRTC_EXTRA_CFLAGS_CC}\""
             "extra_ldflags=\"${WEBRTC_EXTRA_LDFLAGS}\""
             "extra_arflags=\"${WEBRTC_EXTRA_ARFLAGS}\""
+            "visual_studio_path=\"${WEBRTC_VISUAL_STUDIO_PATH}\""
+            "visual_studio_version=\"${WEBRTC_VISUAL_STUDIO_VERSION}\""
+            "visual_studio_runtime_dirs=\"None\""
+            "windows_sdk_path=\"${WEBRTC_WINDOWS_SDK_PATH}\""
+            "windows_sdk_version=\"${WEBRTC_WINDOWS_SDK_VERSION}\""
+            "wdk_path=\"${WEBRTC_WINDOWS_SDK_PATH}\""
         )
         if("${BUILD_CONFIG}" STREQUAL "debug")
             list(APPEND WEBRTC_GN_ARGS "enable_iterator_debugging=true")

--- a/ports/webrtc/vcpkg.json
+++ b/ports/webrtc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "webrtc",
   "version-date": "2026-03-17",
+  "port-version": 1,
   "description": "WebRTC real-time communication library",
   "homepage": "https://webrtc.googlesource.com/src",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10794,7 +10794,7 @@
     },
     "webrtc": {
       "baseline": "2026-03-17",
-      "port-version": 0
+      "port-version": 1
     },
     "webthing-cpp": {
       "baseline": "1.2.0",

--- a/versions/w-/webrtc.json
+++ b/versions/w-/webrtc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc451e2a9de306d0d259c7dc6b8808fea8b1d94f",
+      "version-date": "2026-03-17",
+      "port-version": 1
+    },
+    {
       "git-tree": "cef33e288ddedf719feb03fc55040774d6edea39",
       "version-date": "2026-03-17",
       "port-version": 0


### PR DESCRIPTION
This is needed for the update to Visual Studio 2026 19.6.0 / MSVC 19.51.

/cc @bc-lee

Most of this change was written by GPT 5.5; I changed some of the bits it did with vcpkg_replace_string into patches instead.
