### PR TITLE
[sail] Disable self copying dependencies.

### DIFF
--- a/ports/sail/fix-heif.patch
+++ b/ports/sail/fix-heif.patch
@@ -1,5 +1,5 @@
 diff --git a/src/sail-codecs/heif/CMakeLists.txt b/src/sail-codecs/heif/CMakeLists.txt
-index d9c34f85..87981930 100644
+index d9c34f8..8798193 100644
 --- a/src/sail-codecs/heif/CMakeLists.txt
 +++ b/src/sail-codecs/heif/CMakeLists.txt
 @@ -31,7 +31,7 @@ cmake_push_check_state(RESET)

--- a/ports/sail/fix-heif.patch
+++ b/ports/sail/fix-heif.patch
@@ -1,5 +1,5 @@
 diff --git a/src/sail-codecs/heif/CMakeLists.txt b/src/sail-codecs/heif/CMakeLists.txt
-index d9c34f8..8798193 100644
+index d9c34f85..87981930 100644
 --- a/src/sail-codecs/heif/CMakeLists.txt
 +++ b/src/sail-codecs/heif/CMakeLists.txt
 @@ -31,7 +31,7 @@ cmake_push_check_state(RESET)

--- a/ports/sail/fix-include-directory.patch
+++ b/ports/sail/fix-include-directory.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ac81279..cfc2f3b 100644
+index df970d3..7c4df5c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -299,7 +299,7 @@ endif()
+@@ -298,7 +298,7 @@ endif()
  # Common configuration file
  #
  configure_file("${PROJECT_SOURCE_DIR}/src/config.h.in" "${PROJECT_BINARY_DIR}/include/sail-common/config.h" @ONLY)
@@ -12,10 +12,10 @@ index ac81279..cfc2f3b 100644
  # Print configuration statistics
  #
 diff --git a/src/bindings/sail-c++/CMakeLists.txt b/src/bindings/sail-c++/CMakeLists.txt
-index 4b69ad4..f4bac29 100644
+index a4ad915..6806f2f 100644
 --- a/src/bindings/sail-c++/CMakeLists.txt
 +++ b/src/bindings/sail-c++/CMakeLists.txt
-@@ -131,7 +131,7 @@ install(TARGETS sail-c++
+@@ -134,7 +134,7 @@ install(TARGETS sail-c++
          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -25,7 +25,7 @@ index 4b69ad4..f4bac29 100644
  # Install development packages
  #
 diff --git a/src/sail-common/CMakeLists.txt b/src/sail-common/CMakeLists.txt
-index 06ce246..c8576e5 100644
+index 5193f90..0e689f7 100644
 --- a/src/sail-common/CMakeLists.txt
 +++ b/src/sail-common/CMakeLists.txt
 @@ -114,7 +114,7 @@ endif()
@@ -47,10 +47,10 @@ index 06ce246..c8576e5 100644
  # Install development packages
  #
 diff --git a/src/sail-manip/CMakeLists.txt b/src/sail-manip/CMakeLists.txt
-index 5740764..47b81bb 100644
+index 334a423..4ad54b2 100644
 --- a/src/sail-manip/CMakeLists.txt
 +++ b/src/sail-manip/CMakeLists.txt
-@@ -59,7 +59,7 @@ install(TARGETS sail-manip
+@@ -67,7 +67,7 @@ install(TARGETS sail-manip
          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -60,10 +60,10 @@ index 5740764..47b81bb 100644
  # Install development packages
  #
 diff --git a/src/sail/CMakeLists.txt b/src/sail/CMakeLists.txt
-index 85590af..2303f63 100644
+index 9fd7119..ec4be36 100644
 --- a/src/sail/CMakeLists.txt
 +++ b/src/sail/CMakeLists.txt
-@@ -118,11 +118,11 @@ install(TARGETS sail
+@@ -125,11 +125,11 @@ install(TARGETS sail
          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/ports/sail/no-binary-dependencies-install.diff
+++ b/ports/sail/no-binary-dependencies-install.diff
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7c4df5c..23ef1e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -277,7 +277,6 @@ if (SAIL_VCPKG AND WIN32)
+         set(SAIL_VCPKG_BIN_PATH "${CMAKE_TOOLCHAIN_FILE}/../../../installed/${VCPKG_TARGET_TRIPLET}/debug/bin")
+     endif()
+     get_filename_component(SAIL_VCPKG_BIN_PATH "${SAIL_VCPKG_BIN_PATH}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+-    install(DIRECTORY "${SAIL_VCPKG_BIN_PATH}/" DESTINATION ${SAIL_EXTRA_LIBS_INSTALL_PATH} OPTIONAL)
+ endif()
+ 
+ if (ENABLED_CODECS)

--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-heif.patch
         fix-include-directory.patch
+        no-binary-dependencies-install.diff
 )
 
 # Enable selected codecs

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sail",
   "version-semver": "0.9.10",
+  "port-version": 1,
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8978,7 +8978,7 @@
     },
     "sail": {
       "baseline": "0.9.10",
-      "port-version": 0
+      "port-version": 1
     },
     "sajson": {
       "baseline": "2018-09-21",

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39087409aa6c9e11596c43a4a45d123d26101e62",
+      "version-semver": "0.9.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "7102d490a2126e7820cc9a15530a57b9fd326aaa",
       "version-semver": "0.9.10",
       "port-version": 0

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39087409aa6c9e11596c43a4a45d123d26101e62",
+      "git-tree": "7a56a45b1fdfd2466df43ac1e4e86b05f45e86cc",
       "version-semver": "0.9.10",
       "port-version": 1
     },


### PR DESCRIPTION
I'm getting errors like this as part of the Visual Studio 2026 19.6.0 / MSVC 19.51 update:

```
-- Performing post-build validation
D:\vcpkg\ports\sail\portfile.cmake: warning: DLLs should not be present in a static build, but the following DLLs were found. To suppress this message, add set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
D:\vcpkg\packages\sail_x64-windows: note: the DLLs are relative to ${CURRENT_PACKAGES_DIR} here
note: debug/bin/gif.dll
note: debug/bin/jpeg62.dll
note: debug/bin/libpng16d.dll
note: debug/bin/libsharpyuv.dll
note: debug/bin/libwebp.dll
note: debug/bin/libwebpdecoder.dll
note: debug/bin/libwebpdemux.dll
note: debug/bin/libwebpmux.dll
note: debug/bin/turbojpeg.dll
note: debug/bin/zd.dll
note: bin/gif.dll
note: bin/jpeg62.dll
note: bin/libpng16.dll
note: bin/libsharpyuv.dll
note: bin/libwebp.dll
note: bin/libwebpdecoder.dll
note: bin/libwebpdemux.dll
note: bin/libwebpmux.dll
note: bin/turbojpeg.dll
note: bin/z.dll
D:\vcpkg\ports\sail\portfile.cmake: warning: ${CURRENT_PACKAGES_DIR}/debug/bin exists but should not in a static build. To suppress this message, add set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
D:\vcpkg\ports\sail\portfile.cmake: warning: ${CURRENT_PACKAGES_DIR}/bin exists but should not in a static build. To suppress this message, add set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
note: if creation of these directories cannot be disabled, you can add the following in portfile.cmake to remove them
if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
endif()
D:\vcpkg\ports\sail\portfile.cmake: warning: Found 3 post-build check problem(s). These are usually caused by bugs in portfile.cmake or the upstream build system. Please correct these before submitting this port to the curated registry.
error: The following files are already installed in D:/vcpkg/installed/x64-windows and are in conflict with sail:x64-windows
Installed by giflib:x64-windows:
  bin/gif.dll
  bin/gif.pdb
  debug/bin/gif.dll
  debug/bin/gif.pdb
Installed by libjpeg-turbo:x64-windows:
  bin/jpeg62.dll
  bin/jpeg62.pdb
  bin/turbojpeg.dll
  bin/turbojpeg.pdb
  debug/bin/jpeg62.dll
  debug/bin/jpeg62.pdb
  debug/bin/turbojpeg.dll
  debug/bin/turbojpeg.pdb
Installed by libpng:x64-windows:
  bin/libpng16.dll
  bin/libpng16.pdb
  debug/bin/libpng16d.dll
  debug/bin/libpng16d.pdb
Installed by libwebp:x64-windows:
  bin/libsharpyuv.dll
  bin/libsharpyuv.pdb
  bin/libwebp.dll
  bin/libwebp.pdb
  bin/libwebpdecoder.dll
  bin/libwebpdecoder.pdb
  bin/libwebpdemux.dll
  bin/libwebpdemux.pdb
  bin/libwebpmux.dll
  bin/libwebpmux.pdb
  debug/bin/libsharpyuv.dll
  debug/bin/libsharpyuv.pdb
  debug/bin/libwebp.dll
  debug/bin/libwebp.pdb
  debug/bin/libwebpdecoder.dll
  debug/bin/libwebpdecoder.pdb
  debug/bin/libwebpdemux.dll
  debug/bin/libwebpdemux.pdb
  debug/bin/libwebpmux.dll
  debug/bin/libwebpmux.pdb
Installed by zlib:x64-windows:
  bin/z.dll
  bin/z.pdb
  debug/bin/zd.dll
  debug/bin/zd.pdb
Starting submission of sail[core,gif,highest-priority-codecs,jpeg,png,svg,webp]:x64-windows@0.9.10 to 1 binary cache(s) in the background
```

Looking at what upstream is doing I have no idea how this is working today.