### PR TITLE
[libusb] update to 1.0.30

### DIFF
--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/libusb
     REF "v${VERSION}"
-    SHA512 98c5f7940ff06b25c9aa65aa98e23de4c79a4c1067595f4c73cc145af23a1c286639e1ba11185cd91bab702081f307b973f08a4c9746576dc8d01b3620a3aeb5
+    SHA512 3251c9f41e900efa13caf981483f46886c8434bf4c30f3fd3073921b06be9977cebcf4a18f7bc46db86e33d7f19752296377be9050abfb8d887ffeb377864647
     HEAD_REF master
 )
 
@@ -31,11 +31,11 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
   set(prefix "")
   set(exec_prefix [[${prefix}]])
   set(libdir [[${prefix}/lib]])
-  set(includedir [[${prefix}/include]])  
+  set(includedir [[${prefix}/include]])
   configure_file("${SOURCE_PATH}/libusb-1.0.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libusb-1.0.pc" @ONLY)
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libusb-1.0.pc" " -lusb-1.0" " -llibusb-1.0")
   if(NOT VCPKG_BUILD_TYPE)
-      set(includedir [[${prefix}/../include]])  
+      set(includedir [[${prefix}/../include]])
       configure_file("${SOURCE_PATH}/libusb-1.0.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libusb-1.0.pc" @ONLY)
       vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libusb-1.0.pc" " -lusb-1.0" " -llibusb-1.0")
   endif()
@@ -51,7 +51,7 @@ else()
     vcpkg_make_configure(
         SOURCE_PATH "${SOURCE_PATH}"
         AUTORECONF
-        OPTIONS 
+        OPTIONS
             ${MAKE_OPTIONS}
             "--enable-examples-build=no"
             "--enable-tests-build=no"

--- a/ports/libusb/vcpkg.json
+++ b/ports/libusb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libusb",
-  "version": "1.0.29",
-  "port-version": 1,
+  "version": "1.0.30",
   "description": "a cross-platform library to access USB devices",
   "homepage": "https://github.com/libusb/libusb",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5813,8 +5813,8 @@
       "port-version": 0
     },
     "libusb": {
-      "baseline": "1.0.29",
-      "port-version": 1
+      "baseline": "1.0.30",
+      "port-version": 0
     },
     "libusb-win32": {
       "baseline": "1.4.0.0",

--- a/versions/l-/libusb.json
+++ b/versions/l-/libusb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17ec7e117cae30fe5319152d135a60510341b9ac",
+      "version": "1.0.30",
+      "port-version": 0
+    },
+    {
       "git-tree": "9597176baa90f8f43c1b1b51d4e6822865716bfc",
       "version": "1.0.29",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libusb/libusb/releases/tag/v1.0.30
