### PR TITLE
[wayland-protocols] fix build

### DIFF
--- a/ports/wayland-protocols/cross-build.diff
+++ b/ports/wayland-protocols/cross-build.diff
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index b9a32c8..1810ed0 100644
+index 414e759..4577953 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,6 +1,6 @@
  project('wayland-protocols',
- 	version: '1.43',
+ 	version: '1.48',
 -	meson_version: '>= 0.58.0',
 +	meson_version: '>= 0.62.0',
  	license: 'MIT/Expat',
@@ -24,10 +24,10 @@ index b9a32c8..1810ed0 100644
  
  stable_protocols = {
  	'linux-dmabuf': ['v1'],
-@@ -123,7 +118,7 @@ foreach protocol_file : protocol_files
- endforeach
+@@ -157,7 +152,7 @@ endforeach
  
  include_dirs = []
+ headers = []
 -if dep_scanner.version().version_compare('>=1.22.90')
 +if true
  	subdir('include/wayland-protocols')

--- a/ports/wayland-protocols/vcpkg.json
+++ b/ports/wayland-protocols/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wayland-protocols",
   "version": "1.48",
+  "port-version": 1,
   "description": "wayland-protocols contains Wayland protocols that add functionality not available in the Wayland core protocol.",
   "homepage": "https://wayland.freedesktop.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10782,7 +10782,7 @@
     },
     "wayland-protocols": {
       "baseline": "1.48",
-      "port-version": 0
+      "port-version": 1
     },
     "wcslib": {
       "baseline": "8.5",

--- a/versions/w-/wayland-protocols.json
+++ b/versions/w-/wayland-protocols.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92ed80e3b0273c98f498f3b7597459bbc5c3bee1",
+      "version": "1.48",
+      "port-version": 1
+    },
+    {
       "git-tree": "5fa30fbeedf5ef0d7e469980095b23aa09cffb08",
       "version": "1.48",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
