### PR TITLE
[winsparkle] Update to version 0.9.3

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/vslavik/winsparkle/releases/download/v${VERSION}/WinSparkle-${VERSION}.zip"
     FILENAME "winsparkle-v${VERSION}.zip"
-    SHA512 73ea15e81a6bffd5268674f633f0aa55660764c8b8f35b7fac073e5f82c85b4e888172b3dfd9c3e71341bd23e5314539dd0f47360f89473f94b39f2352910012
+    SHA512 2a6201c72919142df2dc60a60d2e6721d816688dda401524bfb7cfdb167fadb452c24fd98500c1781e17b0009676345332d1ced94a596150ceb57aff58419c37
 )
 
 vcpkg_extract_source_archive(

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "winsparkle",
-  "version": "0.9.2",
-  "port-version": 1,
+  "version": "0.9.3",
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
   "homepage": "https://winsparkle.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10873,8 +10873,8 @@
       "port-version": 5
     },
     "winsparkle": {
-      "baseline": "0.9.2",
-      "port-version": 1
+      "baseline": "0.9.3",
+      "port-version": 0
     },
     "wintoast": {
       "baseline": "1.3.2",

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cf3f59ac0e714d753ae7ccc7c05bd88fc633b07",
+      "version": "0.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "5ca9e27d0efa996656dac659d0617e194d734998",
       "version": "0.9.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.