### PR TITLE
[Libaec] Change in repo

### DIFF
--- a/ports/libaec/portfile.cmake
+++ b/ports/libaec/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     GITLAB_URL https://gitlab.dkrz.de
-    REPO k202009/libaec
+    REPO dkrz-sw/libaec
     REF "v${VERSION}"
     SHA512 c1023328895b5dfdd1831d9edeeaaafe2b3083cdf42a1b76358319b7afd552e1eeb389e8d2668eb2d5f43a07542ade1914a4db1b9095b3d901559826a9c91eba
 )

--- a/ports/libaec/vcpkg.json
+++ b/ports/libaec/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "libaec",
   "version": "1.1.6",
   "description": "Adaptive Entropy Coding library",
-  "homepage": "https://gitlab.dkrz.de/k202009/libaec",
+  "homepage": "https://gitlab.dkrz.de/dkrz-sw/libaec",
   "license": "BSD-2-Clause",
   "dependencies": [
     {


### PR DESCRIPTION
Changing the repository of libaec. 
from the gitlab page https://gitlab.dkrz.de/dkrz-sw/libaec
`Project 'k202009/libaec' was moved to 'dkrz-sw/libaec'. Please update any links and bookmarks that may still have the old path.`