### PR TITLE
[several ports] add download mirrors

### DIFF
--- a/ports/glpk/portfile.cmake
+++ b/ports/glpk/portfile.cmake
@@ -3,7 +3,9 @@ set(DISTFILE_SHA512_HASH 4e92195fa058c707146f2690f3a38b46c33add948c852f67659ca00
 vcpkg_download_distfile(
     DISTFILE
     FILENAME "glpk.tar.gz"
-    URLS "https://ftpmirror.gnu.org/gnu/glpk/glpk-${VERSION}.tar.gz" "https://ftp.gnu.org/gnu/glpk/glpk-${VERSION}.tar.gz"
+    URLS "https://ftpmirror.gnu.org/gnu/glpk/glpk-${VERSION}.tar.gz"
+         "https://ftp.gnu.org/gnu/glpk/glpk-${VERSION}.tar.gz"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/glpk/glpk-${VERSION}.tar.gz"
     SHA512 ${DISTFILE_SHA512_HASH}
 )
 

--- a/ports/glpk/vcpkg.json
+++ b/ports/glpk/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "glpk",
   "version": "5.0",
-  "port-version": 3,
+  "port-version": 4,
   "maintainers": "Fabio A. Correa Duran",
   "description": [
     "The GNU Linear Programming Kit (GLPK) solves large-scale linear programming (LP), mixed integer programming (MIP), and related problems.",

--- a/ports/gperf/portfile.cmake
+++ b/ports/gperf/portfile.cmake
@@ -1,11 +1,13 @@
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 set(VCPKG_BUILD_TYPE release) # tool only
 
+set(filename gperf-${VERSION}.tar.gz)
 vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://ftpmirror.gnu.org/gnu/gperf/gperf-${VERSION}.tar.gz"
-        "https://ftp.gnu.org/pub/gnu/gperf/gperf-${VERSION}.tar.gz"
-    FILENAME gperf-${VERSION}.tar.gz
+        "https://ftpmirror.gnu.org/gnu/gperf/${filename}"
+        "https://ftp.gnu.org/pub/gnu/gperf/${filename}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gperf/${filename}"
+    FILENAME "${filename}"
     SHA512 246b75b8ce7d77d6a8725cd15f1cf2e68da404812573af1d5bf32dbe6ad4228f48757baefc77bcb1f5597c2397043c04d31d8a04ab507bfa7a80f85e1ab6045f
 )
 

--- a/ports/gperf/vcpkg.json
+++ b/ports/gperf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gperf",
   "version": "3.3",
+  "port-version": 1,
   "description": "GNU perfect hash function generator",
   "homepage": "https://www.gnu.org/software/gperf/",
   "license": "GPL-3.0-or-later",

--- a/ports/gsasl/portfile.cmake
+++ b/ports/gsasl/portfile.cmake
@@ -1,8 +1,10 @@
+set(filename gsasl-${VERSION}.tar.gz)
 vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://ftpmirror.gnu.org/gnu/gsasl/gsasl-${VERSION}.tar.gz"
-        "https://ftp.gnu.org/gnu/gsasl/gsasl-${VERSION}.tar.gz"
-    FILENAME "gsasl-${VERSION}.tar.gz"
+        "https://ftpmirror.gnu.org/gnu/gsasl/${filename}"
+        "https://ftp.gnu.org/gnu/gsasl/${filename}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsasl/${filename}"
+    FILENAME "${filename}"
     SHA512 62fb4a9383392e4816a036f3e8f408c5161a10723e59f0a8f6df5f72101e0b644787f3b07a71c772628fc4f4050960c842c7500736edacd24313ef654e703bc9
 )
 

--- a/ports/gsasl/vcpkg.json
+++ b/ports/gsasl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gsasl",
   "version": "2.2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simple Authentication and Security Layer framework and a few common SASL mechanisms",
   "homepage": "https://www.gnu.org/software/gsasl/",
   "license": "LGPL-2.1-or-later",

--- a/ports/guile/portfile.cmake
+++ b/ports/guile/portfile.cmake
@@ -1,8 +1,10 @@
-vcpkg_download_distfile(ARCHIVE 
+set(filename guile-${VERSION}.tar.gz)
+vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://ftpmirror.gnu.org/guile/guile-${VERSION}.tar.gz"    
-        "https://ftp.gnu.org/gnu/guile/guile-${VERSION}.tar.gz"
-    FILENAME "guile-${VERSION}.tar.gz"
+        "https://ftpmirror.gnu.org/guile/${filename}"
+        "https://ftp.gnu.org/gnu/guile/${filename}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/guile/${filename}"
+    FILENAME "${filename}"
     SHA512 bf81eca9554d22dcfcff4797739dee18758c257bd2c848fdf508e3fd6e58ffd9754b08a57d8ba31c80a69b0444fff3b045e22ec88fc34ef787cd71f5466fafe8
 )
 

--- a/ports/guile/vcpkg.json
+++ b/ports/guile/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "guile",
   "version": "3.0.11",
+  "port-version": 1,
   "description": "GNU's programming and extension language",
   "homepage": "https://www.gnu.org/software/guile/",
   "documentation": "https://www.gnu.org/software/guile/manual/",

--- a/ports/libltdl/portfile.cmake
+++ b/ports/libltdl/portfile.cmake
@@ -1,7 +1,9 @@
+set(filename libtool-${VERSION}.tar.xz)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftpmirror.gnu.org/libtool/libtool-${VERSION}.tar.xz"
-         "https://ftp.gnu.org/pub/gnu/libtool/libtool-${VERSION}.tar.xz"
-    FILENAME "gnu-libtool-${VERSION}.tar.xz"
+    URLS "https://ftpmirror.gnu.org/libtool/${filename}"
+         "https://ftp.gnu.org/pub/gnu/libtool/${filename}"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libtool/${filename}"
+    FILENAME "gnu-${filename}"
     SHA512 eed207094bcc444f4bfbb13710e395e062e3f1d312ca8b186ab0cbd22dc92ddef176a0b3ecd43e02676e37bd9e328791c59a38ef15846d4eae15da4f20315724
 )
 

--- a/ports/libltdl/vcpkg.json
+++ b/ports/libltdl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libltdl",
   "version": "2.5.4",
+  "port-version": 1,
   "description": "A system independent dlopen wrapper for GNU libtool",
   "homepage": "https://www.gnu.org/software/libtool/",
   "license": "LGPL-2.1-or-later",

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -1,8 +1,10 @@
+set(filename libmicrohttpd-${VERSION}.tar.gz)
 vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
-        "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
-    FILENAME "libmicrohttpd-${VERSION}.tar.gz"
+        "https://ftpmirror.gnu.org/libmicrohttpd/${filename}"
+        "https://ftp.gnu.org/gnu/libmicrohttpd/${filename}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/${filename}"
+    FILENAME "${filename}"
     SHA512 7ed3e81f0c4253a409f5e825446c8d2d8b975c0eb6f381b6867796bbdcf4890004a24659e95b8ec8c39e8df0a9885cc08a0ba75f953893ee1455ae180dc89391
 )
 
@@ -25,7 +27,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         RELEASE_CONFIGURATION "Release-${CFG_SUFFIX}"
         DEBUG_CONFIGURATION "Debug-${CFG_SUFFIX}"
     )
-    
+
     file(GLOB MICROHTTPD_HEADERS "${SOURCE_PATH}/src/include/microhttpd.h")
     file(COPY ${MICROHTTPD_HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 else()
@@ -54,7 +56,7 @@ else()
 
     vcpkg_make_install()
     vcpkg_fixup_pkgconfig()
-    
+
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 endif()
 

--- a/ports/libmicrohttpd/vcpkg.json
+++ b/ports/libmicrohttpd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmicrohttpd",
   "version": "1.0.5",
+  "port-version": 1,
   "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
   "homepage": "https://www.gnu.org/software/libmicrohttpd/",
   "license": "LGPL-2.1-or-later",

--- a/ports/libosip2/portfile.cmake
+++ b/ports/libosip2/portfile.cmake
@@ -1,8 +1,9 @@
+set(filename libosip2-${VERSION}.tar.gz)
 vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/osip/libosip2-${VERSION}.tar.gz"
-        "https://ftp.gnu.org/gnu/osip/libosip2-${VERSION}.tar.gz"
-    FILENAME "libosip2-${VERSION}.tar.gz"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/osip/${filename}"
+        "https://ftp.gnu.org/gnu/osip/${filename}"
+    FILENAME "${filename}"
     SHA512 cd9db7a736cca90c6862b84c4941ef025f5affab8af9bbc02ce0dd3310a2c555e0922c1bfa72d8ac08791fa1441bbcc30b627d52ca8b51f3471573a10ac82a00
 )
 

--- a/ports/libosip2/vcpkg.json
+++ b/ports/libosip2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libosip2",
   "version": "5.3.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "oSIP is an LGPL implementation of SIP. It's stable, portable, flexible and compliant! -may be more-! It is used mostly with eXosip2 stack (GPL) which provides simpler API for User-Agent implementation.",
   "homepage": "https://www.gnu.org/software/osip/",
   "supports": "!(windows & arm) & !uwp",

--- a/ports/mpc/portfile.cmake
+++ b/ports/mpc/portfile.cmake
@@ -1,8 +1,10 @@
+set(filename mpc-${VERSION}.tar.gz)
 vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://ftpmirror.gnu.org/gnu/mpc/mpc-${VERSION}.tar.gz"
-        "https://ftp.gnu.org/gnu/mpc/mpc-${VERSION}.tar.gz"
-    FILENAME "mpc-${VERSION}.tar.gz"
+        "https://ftpmirror.gnu.org/gnu/mpc/${filename}"
+        "https://ftp.gnu.org/gnu/mpc/${filename}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/mpc/${filename}"
+    FILENAME "${filename}"
     SHA512 4bab4ef6076f8c5dfdc99d810b51108ced61ea2942ba0c1c932d624360a5473df20d32b300fc76f2ba4aa2a97e1f275c9fd494a1ba9f07c4cb2ad7ceaeb1ae97
 )
 

--- a/ports/mpc/vcpkg.json
+++ b/ports/mpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpc",
   "version": "1.3.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.",
   "homepage": "https://www.multiprecision.org/mpc/",
   "license": "LGPL-3.0-or-later",

--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -1,8 +1,11 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
+set(filename mpfr-${VERSION}.tar.xz)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.mpfr.org/mpfr-${VERSION}/mpfr-${VERSION}.tar.xz" "https://ftp.gnu.org/gnu/mpfr/mpfr-${VERSION}.tar.xz"
-    FILENAME "mpfr-${VERSION}.tar.xz"
+    URLS "https://www.mpfr.org/mpfr-${VERSION}/${filename}"
+         "https://ftp.gnu.org/gnu/mpfr/${filename}"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/mpfr/${filename}"
+    FILENAME "${filename}"
     SHA512 eb9e7f51b5385fb349cc4fba3a45ffdf0dd53be6dfc74932dc01258158a10514667960c530c47dd9dfc5aa18be2bd94859d80499844c5713710581e6ac6259a9
 )
 

--- a/ports/mpfr/vcpkg.json
+++ b/ports/mpfr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpfr",
   "version": "4.2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
   "homepage": "https://www.mpfr.org",
   "license": "LGPL-3.0-or-later",

--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+set(filename octave-${VERSION}.tar.xz)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftpmirror.gnu.org/octave/octave-${VERSION}.tar.xz"
-         "https://ftp.gnu.org/gnu/octave/octave-${VERSION}.tar.xz"
-    FILENAME "octave-${VERSION}.tar.xz"
+    URLS "https://ftpmirror.gnu.org/octave/${filename}"
+         "https://ftp.gnu.org/gnu/octave/${filename}"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/octave/${filename}"
+    FILENAME "${filename}"
     SHA512 4ba4d65e326ab85ffcf8864b073910b8ec5ecaba96d18cffa2b13e8f38e5382e7a200bd9bc8838c47b947edcf8388ad3dd749e2d4f529f1f110946d99adf188f
 )
 

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "octave",
   "version": "10.2.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "documentation": "https://docs.octave.org/latest/",

--- a/ports/readline-unix/portfile.cmake
+++ b/ports/readline-unix/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_download_distfile(
     URLS
         "https://ftpmirror.gnu.org/gnu/readline/${filename}"
         "https://ftp.gnu.org/gnu/readline/${filename}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/readline/${filename}"
     FILENAME "${filename}"
     SHA512 513002753dcf5db9213dbbb61d51217245f6a40d33b1dd45238e8062dfa8eef0c890b87a5548e11db959e842724fb572c4d3d7fb433773762a63c30efe808344
 )

--- a/ports/readline-unix/vcpkg.json
+++ b/ports/readline-unix/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "readline-unix",
   "version": "8.3",
+  "port-version": 1,
   "description": "The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in.",
   "homepage": "https://tiswww.case.edu/php/chet/readline/rltop.html",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3482,7 +3482,7 @@
     },
     "glpk": {
       "baseline": "5.0",
-      "port-version": 3
+      "port-version": 4
     },
     "glslang": {
       "baseline": "16.3.0",
@@ -3526,7 +3526,7 @@
     },
     "gperf": {
       "baseline": "3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "gperftools": {
       "baseline": "2.18.1",
@@ -3586,7 +3586,7 @@
     },
     "gsasl": {
       "baseline": "2.2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "gsl": {
       "baseline": "2.8",
@@ -3642,7 +3642,7 @@
     },
     "guile": {
       "baseline": "3.0.11",
-      "port-version": 0
+      "port-version": 1
     },
     "guilite": {
       "baseline": "2022-05-05",
@@ -5230,7 +5230,7 @@
     },
     "libltdl": {
       "baseline": "2.5.4",
-      "port-version": 0
+      "port-version": 1
     },
     "liblttng-ust": {
       "baseline": "2.15.0",
@@ -5282,7 +5282,7 @@
     },
     "libmicrohttpd": {
       "baseline": "1.0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libmidi2": {
       "baseline": "0.16",
@@ -5434,7 +5434,7 @@
     },
     "libosip2": {
       "baseline": "5.3.1",
-      "port-version": 3
+      "port-version": 4
     },
     "libosmium": {
       "baseline": "2.23.0",
@@ -6686,11 +6686,11 @@
     },
     "mpc": {
       "baseline": "1.3.1",
-      "port-version": 3
+      "port-version": 4
     },
     "mpfr": {
       "baseline": "4.2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "mpg123": {
       "baseline": "1.33.4",
@@ -7222,7 +7222,7 @@
     },
     "octave": {
       "baseline": "10.2.0",
-      "port-version": 2
+      "port-version": 3
     },
     "octomap": {
       "baseline": "1.10.0",
@@ -8682,7 +8682,7 @@
     },
     "readline-unix": {
       "baseline": "8.3",
-      "port-version": 0
+      "port-version": 1
     },
     "readline-win32": {
       "baseline": "5.0",

--- a/versions/g-/glpk.json
+++ b/versions/g-/glpk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63cffc379bcfd8c685a072b5f15775bcec982654",
+      "version": "5.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "00933f2c7f77149899b7c69c6d09410fca7f5b1d",
       "version": "5.0",
       "port-version": 3

--- a/versions/g-/gperf.json
+++ b/versions/g-/gperf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06407ced9ffcd08454a99758383d81824bb3c5a6",
+      "version": "3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "d5c53333d7745d56f06cb3e014c7c424a66ef4a7",
       "version": "3.3",
       "port-version": 0

--- a/versions/g-/gsasl.json
+++ b/versions/g-/gsasl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e156f1e804a222afc14a5dadf7f771caa4267997",
+      "version": "2.2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "18fe18bbc9a1426b7257d67c2ab4c909169969ea",
       "version": "2.2.2",
       "port-version": 1

--- a/versions/g-/guile.json
+++ b/versions/g-/guile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d02b2a2754551bce020b52905300e33aa3fb15b",
+      "version": "3.0.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "06121df6c331708a9b5c44bcbff82df32315f035",
       "version": "3.0.11",
       "port-version": 0

--- a/versions/l-/libltdl.json
+++ b/versions/l-/libltdl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82ea67660028264120397a4b64f0463df516b3f9",
+      "version": "2.5.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "2c97575fd1ac927693c5f780cdb4b3da22c25c2d",
       "version": "2.5.4",
       "port-version": 0

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6885231e5172652436cfb292b064bcf1627f568",
+      "version": "1.0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "15f73d666ad6d3b7c887e57a21ed2dd0dcb6ac50",
       "version": "1.0.5",
       "port-version": 0

--- a/versions/l-/libosip2.json
+++ b/versions/l-/libosip2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26fbc93b93187b3d8a00a01d54970e7413d1ea10",
+      "version": "5.3.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "c3cb7d81a6653ad44831fc347d79cb76c68b2fd6",
       "version": "5.3.1",
       "port-version": 3

--- a/versions/m-/mpc.json
+++ b/versions/m-/mpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cf67aa8681165fdf146d027d220d97332130305",
+      "version": "1.3.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "e7d70a0d67f2f806baaa55bcce2be90d39454349",
       "version": "1.3.1",
       "port-version": 3

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e29edb599d6d20546d0af3690fd2232c9277a776",
+      "version": "4.2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "8ba45f432d750cfba4c8d7e1f29cf8d04bbc9cb1",
       "version": "4.2.2",
       "port-version": 1

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e20de05994523b64a05845f6b87eb1157ab5101",
+      "version": "10.2.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "d01ab9834167b73a40ae78f75faffbd185006798",
       "version": "10.2.0",
       "port-version": 2

--- a/versions/r-/readline-unix.json
+++ b/versions/r-/readline-unix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7990e6b79b04507beaf9823143cf77813e1092b",
+      "version": "8.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "89a451cc17912d991349b6fb5efdaa3be65e8c08",
       "version": "8.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
