### PR TITLE
[tdlib]: update to 1.8.64

### DIFF
--- a/ports/tdlib/portfile.cmake
+++ b/ports/tdlib/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tdlib/td
-    REF f06b0bac65278b03d26414c096080e7bfecfef52
+    REF 7f163d850abbebecf749e99fb412271cc1f4e805
     HEAD_REF master
-    SHA512 91967a24eee9f1491b780ce72a1323aa99e228c10ecd588979e325d57417c6897eeebf375c609c99b2fd0d6137bcb950628a30f5cfc2e6838fb14d2803d02b7a
+    SHA512 6cebc7f655267abbbdfca1717c36004c2ae11626420fe0ce748e402ca53e972b6cbad2ca34607d04e66e28cd740a5faf215505273845adb06075db4d09cd8e46
     PATCHES
         fix-pc.patch
         fix-cross-compile.patch

--- a/ports/tdlib/portfile.cmake
+++ b/ports/tdlib/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(FIX_TDCORE_PATCH
+    URLS https://github.com/tdlib/td/commit/49b3bcbb6bfebf2ed44dd9f25102d2e1a94a58c4.diff?full_index=1
+    FILENAME tdlib-fix-tdcore-49b3bcbb6bfebf2ed44dd9f25102d2e1a94a58c4.diff
+    SHA512 ef8b69e68830474a9af0b9f3d2d13eaf8c0383d1d74bc123e4b6f68c398d400b73f1154b0c1264c8ce99eb20a0ee392336306e5de12fed759a5bac184a6cca74
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tdlib/td

--- a/ports/tdlib/portfile.cmake
+++ b/ports/tdlib/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         fix-pc.patch
         fix-cross-compile.patch
+        "${FIX_TDCORE_PATCH}"
 )
 
 vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")

--- a/ports/tdlib/vcpkg.json
+++ b/ports/tdlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tdlib",
-  "version": "1.8.63",
+  "version": "1.8.64",
   "maintainers": "luadebug <lin@sz.cn.eu.org>",
   "description": "Cross-platform library for building Telegram clients",
   "homepage": "https://github.com/tdlib/td",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9937,7 +9937,7 @@
       "port-version": 0
     },
     "tdlib": {
-      "baseline": "1.8.63",
+      "baseline": "1.8.64",
       "port-version": 0
     },
     "tdscpp": {

--- a/versions/t-/tdlib.json
+++ b/versions/t-/tdlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da93d24ede46b5d6ab17f80dafd738dcb956a5c8",
+      "version": "1.8.64",
+      "port-version": 0
+    },
+    {
       "git-tree": "03dfd6eb011175d663fae646126921debc482261",
       "version": "1.8.63",
       "port-version": 0

--- a/versions/t-/tdlib.json
+++ b/versions/t-/tdlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "da93d24ede46b5d6ab17f80dafd738dcb956a5c8",
+      "git-tree": "05503694855ee9d5adbef42b16e010265219653c",
       "version": "1.8.64",
       "port-version": 0
     },

--- a/versions/t-/tdlib.json
+++ b/versions/t-/tdlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "05503694855ee9d5adbef42b16e010265219653c",
+      "git-tree": "72e5ab1e006da346e7e36e2cc8ce8dba2c7eef27",
       "version": "1.8.64",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
