### PR TITLE
[rego-cpp] Add /bigobj.

### DIFF
--- a/ports/rego-cpp/add-bigobj.diff
+++ b/ports/rego-cpp/add-bigobj.diff
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c916c90..6e77a58 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -66,7 +66,7 @@ target_link_libraries(rego
+ )
+ 
+ if(MSVC)
+-  target_compile_options(rego PUBLIC "/Zc:__cplusplus")
++  target_compile_options(rego PUBLIC "/Zc:__cplusplus" "/bigobj")
+   target_compile_definitions(rego PUBLIC "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" "DATE_BUILD_LIB")
+ endif()
+ 

--- a/ports/rego-cpp/portfile.cmake
+++ b/ports/rego-cpp/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 a9e7b6202fdc7b7168433227c7bc67492d52bdf10c5d9b2c0954aa66a9eb5a16a9b4de7eb7385a335c6685111393aad6840c171ab12b3e6b2fd493b5bffea21c
     HEAD_REF main
+    PATCHES
+      add-bigobj.diff # src\rego_to_bundle.cc : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
 )
 
 # NOTE: The CI overlay port (see .github/workflows/pr_gate.yml,

--- a/ports/rego-cpp/vcpkg.json
+++ b/ports/rego-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rego-cpp",
   "version": "1.4.1",
+  "port-version": 1,
   "description": "A C++ interpreter for the OPA Rego policy language",
   "homepage": "https://github.com/microsoft/rego-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8730,7 +8730,7 @@
     },
     "rego-cpp": {
       "baseline": "1.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "rendergraph": {
       "baseline": "2.1.0",

--- a/versions/r-/rego-cpp.json
+++ b/versions/r-/rego-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4eba4aa2840ed4827eec9fa1da81228400300bcb",
+      "version": "1.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "71925bf69323a0a51e027f46a4049ac8faca103a",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
This fixes a build failure in Visual Studio 2026 18.6.0 / MSVC 19.51 when targeting arm64.