### PR TITLE
meson: Mark OHOS as cross-compiled platform

### DIFF
--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-tool-meson",
   "version": "1.9.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
@@ -283,6 +283,7 @@ function(z_vcpkg_get_build_and_host_system build_system host_system is_cross) #h
 
     if(NOT build_cpu_fam MATCHES "${host_cpu_fam}"
        OR VCPKG_TARGET_IS_ANDROID
+       OR VCPKG_TARGET_IS_OHOS
        OR (VCPKG_TARGET_IS_APPLE AND NOT VCPKG_TARGET_IS_OSX)
        OR VCPKG_TARGET_IS_UWP
        OR (VCPKG_TARGET_IS_MINGW AND NOT CMAKE_HOST_WIN32))

--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -264,6 +264,7 @@ function(z_vcpkg_get_build_and_host_system build_system host_system is_cross) #h
 
     if(NOT build_cpu_fam MATCHES "${host_cpu_fam}"
        OR VCPKG_TARGET_IS_ANDROID
+       OR VCPKG_TARGET_IS_OHOS
        OR (VCPKG_TARGET_IS_APPLE AND NOT VCPKG_TARGET_IS_OSX)
        OR VCPKG_TARGET_IS_UWP
        OR (VCPKG_TARGET_IS_MINGW AND NOT CMAKE_HOST_WIN32))

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10562,7 +10562,7 @@
     },
     "vcpkg-tool-meson": {
       "baseline": "1.9.0",
-      "port-version": 7
+      "port-version": 8
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ac36671b3020549d60c900eff3140bc36403936",
+      "version": "1.9.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "cf7f8a95eef222e762d63ce7ae0aaa78d834f291",
       "version": "1.9.0",
       "port-version": 7


### PR DESCRIPTION
This matches what's done for Android.

Fixes #51893

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.
