### PR TITLE
zlib: use system zlib on OHOS

### DIFF
--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -1,3 +1,13 @@
+if(VCPKG_TARGET_IS_OHOS)
+    # OHOS provides libz.so in its SDK sysroot. find_package(ZLIB) locates
+    # it via CMAKE_SYSROOT, so vcpkg must not build its own: a vcpkg-built
+    # libz.so carries GNU symbol versioning that the OHOS musl dynamic
+    # linker cannot resolve, while the SDK's libz.so is unversioned.
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+    return()
+endif()
+
 # When this port is updated, the minizip port should be updated at the same time
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/zlib/vcpkg.json
+++ b/ports/zlib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zlib",
   "version": "1.3.2",
+  "port-version": 1,
   "description": "A compression library",
   "homepage": "https://www.zlib.net/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11206,7 +11206,7 @@
     },
     "zlib": {
       "baseline": "1.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "zlib-ng": {
       "baseline": "2.3.3",

--- a/versions/z-/zlib.json
+++ b/versions/z-/zlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6287d4464ffe21ca8788b8ef70adcada905ea38d",
+      "version": "1.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e2a9ce8cf8f5d07e489e14c256eefdd58cd535c1",
       "version": "1.3.2",
       "port-version": 0


### PR DESCRIPTION
OHOS ships libz.so in the SDK sysroot, and find_package(ZLIB) locates it through CMAKE_SYSROOT. A vcpkg-built libz.so on OHOS additionally carries GNU symbol versioning (zlib's CMakeLists.txt applies -Wl,--version-script=zlib.map on Unix), which the OHOS musl dynamic linker cannot resolve at load time (SIGSEGV in do_relocs).

Mark the OHOS build as an empty package so dependents resolve to the SDK's unversioned libz.so via the toolchain sysroot, the same approach already used for pthreads on Unix and gettext-libintl on Linux.

Fixes #51895

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.
