### PR TITLE
[sdl3-net] Add new port

### DIFF
--- a/ports/sdl3-net/portfile.cmake
+++ b/ports/sdl3-net/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL_net
+    REF "${VERSION}"
+    SHA512 591d8e31acb08bc6b838e61803329d62e232fdc09defabaf3c737aadeab07b7c479ead59979a7224c0c061a6a8377878b7f8c25411d5a6929f1cd33dbee30751
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_net CONFIG_PATH cmake)
+else()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_net CONFIG_PATH lib/cmake/SDL3_net)
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sdl3-net/portfile.cmake
+++ b/ports/sdl3-net/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=OFF
+        -DSDLNET_SAMPLES=OFF
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/sdl3-net/usage
+++ b/ports/sdl3-net/usage
@@ -1,0 +1,4 @@
+sdl3-net provides CMake targets:
+
+  find_package(SDL3_net CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL3_net::SDL3_net>,SDL3_net::SDL3_net,SDL3_net::SDL3_net-static>)

--- a/ports/sdl3-net/vcpkg.json
+++ b/ports/sdl3-net/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "sdl3-net",
+  "version-string": "prerelease-3.1.0",
+  "description": "A simple, cross-platform wrapper over TCP/IP sockets.",
+  "homepage": "https://github.com/libsdl-org/SDL_net",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "sdl3",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9112,6 +9112,10 @@
       "baseline": "3.2.2",
       "port-version": 0
     },
+    "sdl3-net": {
+      "baseline": "prerelease-3.1.0",
+      "port-version": 0
+    },
     "sdl3-shadercross": {
       "baseline": "3.0.0-preview2",
       "port-version": 0

--- a/versions/s-/sdl3-net.json
+++ b/versions/s-/sdl3-net.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae379e871c27b5666e2276ba8794bef69999fbdf",
+      "git-tree": "538b82d7e25f265b21fbc9fe821d598c7531a3e5",
       "version-string": "prerelease-3.1.0",
       "port-version": 0
     }

--- a/versions/s-/sdl3-net.json
+++ b/versions/s-/sdl3-net.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ae379e871c27b5666e2276ba8794bef69999fbdf",
+      "version-string": "prerelease-3.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add new port sdl3-net: https://github.com/libsdl-org/SDL_net/releases/tag/prerelease-3.1.0

<img width="925" height="405" alt="Screenshot (70)" src="https://github.com/user-attachments/assets/72ab35ff-5004-4114-acea-55f876173a51" />

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/sdl-net/versions
    - [x] The project is amongst the first web search results for "sdl3-net" or "sdl3-net C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.