### PR TITLE
[libfuse] Update to 3.18.2

### DIFF
--- a/ports/libfuse/portfile.cmake
+++ b/ports/libfuse/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libfuse/libfuse
     REF "fuse-${VERSION}"
-    SHA512 a39bb630f8e57a635980e153b9209a4b804569656feddb46fe8bef02c053533a6037fcc767d03efd5f8bebffed1ff55eb5f49b323ab71e8913008f994cffca77
+    SHA512 b870e13d97d62546aab2e29855c775a7492b2b4ad0115bfd0ab68aa5505d6baa071e29e93ed67f7cff16ab71704bb8f9ffe8253c3edc0f9fd396186b1deef6fb
     HEAD_REF master
 )
 

--- a/ports/libfuse/vcpkg.json
+++ b/ports/libfuse/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libfuse",
-  "version": "3.17.3",
+  "version": "3.18.2",
   "description": "The reference implementation of the Linux FUSE (Filesystem in Userspace) interface",
   "homepage": "https://github.com/libfuse/libfuse",
   "license": "LGPL-2.1-only AND GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5025,7 +5025,7 @@
       "port-version": 5
     },
     "libfuse": {
-      "baseline": "3.17.3",
+      "baseline": "3.18.2",
       "port-version": 0
     },
     "libgcrypt": {

--- a/versions/l-/libfuse.json
+++ b/versions/l-/libfuse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83a4c07d44b83a96192b9cd0e18d852221cbb768",
+      "version": "3.18.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb2cff1e30a30666264a3e8f9718776a7fecb59a",
       "version": "3.17.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.