### PR TITLE
[llfio] Fix build with [status-code] feature enabled.

### DIFF
--- a/ports/llfio/fix-status-code-system-code.patch
+++ b/ports/llfio/fix-status-code-system-code.patch
@@ -1,0 +1,13 @@
+diff --git a/include/llfio/v2.0/status_code.hpp b/include/llfio/v2.0/status_code.hpp
+index 2d38d9e..f6bb2cc 100644
+--- a/include/llfio/v2.0/status_code.hpp
++++ b/include/llfio/v2.0/status_code.hpp
+@@ -398,7 +398,7 @@ namespace detail
+ }  // namespace detail
+ inline file_io_error
+ error_from_exception(std::exception_ptr &&ep = std::current_exception(),
+-                     SYSTEM_ERROR2_NAMESPACE::system_code not_matched = errc::resource_unavailable_try_again) noexcept
++                     SYSTEM_ERROR2_NAMESPACE::system_code not_matched = SYSTEM_ERROR2_NAMESPACE::generic_code(errc::resource_unavailable_try_again)) noexcept
+ {
+ #ifdef __cpp_exceptions
+   return SYSTEM_ERROR2_NAMESPACE::system_code_from_exception(

--- a/ports/llfio/portfile.cmake
+++ b/ports/llfio/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
     REF 20260506
     SHA512 d565298a7709a34482977406a7290cf109d44a428eb96c1ab788ceb8529ee4aa5736a8db9f51b0aeedb90c54bea00615038d24d0b26336aa6959fc11b8835ff6
     HEAD_REF develop
+    PATCHES
+        fix-status-code-system-code.patch # https://github.com/ned14/llfio/pull/175
 )
 
 vcpkg_from_github(

--- a/ports/llfio/vcpkg.json
+++ b/ports/llfio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llfio",
   "version-date": "2026-05-06",
+  "port-version": 1,
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6110,7 +6110,7 @@
     },
     "llfio": {
       "baseline": "2026-05-06",
-      "port-version": 0
+      "port-version": 1
     },
     "llgi": {
       "baseline": "2023-12-19",

--- a/versions/l-/llfio.json
+++ b/versions/l-/llfio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a599d1ffde2c72da326208b487edb1a47266c9c",
+      "version-date": "2026-05-06",
+      "port-version": 1
+    },
+    {
       "git-tree": "fc8c04f44e5edb5f72d6d1b4c23f5612bde29a0e",
       "version-date": "2026-05-06",
       "port-version": 0


### PR DESCRIPTION
https://github.com/ned14/llfio/pull/175

This cast is necessary to build on Visual Studio 2026 18.6.0 / MSVC 19.51 when `llfio[status-code]` is turned on

```console
C:\Dev\vcpkg2\buildtrees\llfio\src\20260506-b0cb791d93.clean\include\llfio\v2.0\status_code.hpp(401,79): error C2440: 'default argument': cannot convert from 'system_error2::errc' to 'system_error2::system_code'
                     SYSTEM_ERROR2_NAMESPACE::system_code not_matched = errc::resource_unavailable_try_again) noexcept
                                                                              ^
C:\Dev\vcpkg2\buildtrees\llfio\src\20260506-b0cb791d93.clean\include\llfio\v2.0\status_code.hpp(401,79): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
```

I'm not sure exactly why the implicit conversion isn't working on the default argument here :/