### PR TITLE
[ocilib] update to 4.9.0

### DIFF
--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vrogier/ocilib
     REF "v${VERSION}"
-    SHA512 1205f333fa7fa6c813dfbb93fefcec5203110ee0dc1c5d52b4f67df9e8fd5894b94e1f0f87cff79f6ad1d33dffbc9faa6535b7bf81ab36bb742cb4fd2dc5d966
+    SHA512 16ac093a07fdea00c36f3f768f7dc26c77090701ed6cdae4c037cb5080cc3f4cb91be494ec985bb9d2556fdf96c1743d4588a3e4b15f3e9b78540961f43b9dd3
     HEAD_REF master
     PATCHES fix-DisableWC4191.patch
 )

--- a/ports/ocilib/vcpkg.json
+++ b/ports/ocilib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ocilib",
-  "version": "4.8.0",
-  "port-version": 1,
+  "version": "4.9.0",
   "description": "OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.",
   "homepage": "https://vrogier.github.io/ocilib/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7213,8 +7213,8 @@
       "port-version": 3
     },
     "ocilib": {
-      "baseline": "4.8.0",
-      "port-version": 1
+      "baseline": "4.9.0",
+      "port-version": 0
     },
     "octave": {
       "baseline": "10.2.0",

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43b6aa850503e57383b5b4a6c83e4d5a99694050",
+      "version": "4.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d5ccf5917db59576853cd6e19f48284c95b0ccc",
       "version": "4.8.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://vrogier.github.io/ocilib/blog/2026/ocilib-v4-9-0-now-available-for-download
