### PR TITLE
[libpqxx] Disable compilation of examples

### DIFF
--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_cmake_configure(
     OPTIONS
         "-DPython3_EXECUTABLE=${PYTHON3}"
         -DSKIP_BUILD_TEST=ON
+        -DBUILD_EXAMPLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpqxx",
   "version": "8.0.1",
+  "port-version": 1,
   "description": [
     "The official* C++ client API for PostgreSQL.",
     "*) NB https://pqxx.org/libpqxx/faq/"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5486,7 +5486,7 @@
     },
     "libpqxx": {
       "baseline": "8.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.5",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4acff3715077a84300d1f8ecc518d5730197c461",
+      "version": "8.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "34aa140ff7106f394d32178da58963c9de1ec5ee",
       "version": "8.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This patch disables the compilation of the included examples. Compiling the examples causes issues when using any of the `-static` triplets due to a lack of `-lpthread`. Since the examples aren't really useful in the context of vcpkg anyway, disabling the option not only removes the problem with static triplets, but also speeds up build times.