### PR TITLE
[libpg-query] update to 18.0.0

### DIFF
--- a/ports/libpg-query/portfile.cmake
+++ b/ports/libpg-query/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pganalyze/libpg_query
     REF "${VERSION}"
-    SHA512 1570ff2347be48a93d764e2aac19639cef538566ce1c458aa5171698f0b886ca98f1f0e27faa23019b884d956f735f6ac39b71b8af9c4676d6a40d9f669b0ea6
+    SHA512 6b58ba3ac7f8b0cf16baa4bbe0d8184eb727c20b74158013c2f2790521c65e996f6545302d9c7f7dc4edf7ffc4d57657ced3cb5e7b1179696093c94c4e8bf43b
     HEAD_REF master
     PATCHES
         0001-use-system-deps.patch

--- a/ports/libpg-query/vcpkg.json
+++ b/ports/libpg-query/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libpg-query",
-  "version": "17-6.2.2",
+  "version": "18.0.0",
   "description": "C library for accessing the PostgreSQL parser outside of the server",
   "homepage": "https://github.com/pganalyze/libpg_query",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5453,7 +5453,7 @@
       "port-version": 2
     },
     "libpg-query": {
-      "baseline": "17-6.2.2",
+      "baseline": "18.0.0",
       "port-version": 0
     },
     "libphonenumber": {

--- a/versions/l-/libpg-query.json
+++ b/versions/l-/libpg-query.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aeb5100ab7b2d6206d73c45298c7c8c11718dd2e",
+      "version": "18.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "72c93f9acb91786df2d9b6f9e02ef7ab5c94c7a8",
       "version": "17-6.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/pganalyze/libpg_query/releases/tag/18.0.0
