### PR TITLE
[stillwater-universal] update to 4.7.0

### DIFF
--- a/ports/stillwater-universal/portfile.cmake
+++ b/ports/stillwater-universal/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stillwater-sc/universal
     REF "v${VERSION}"
-    SHA512 cf29c15ef945695dfbf3cd044e0e4e9c5ccc4e592a9df6bd5d8f004a272a402baa9571c059dffb8ed923274e1fb1e51d3062d91162b58db88fffea0631bb4ab6
+    SHA512 3dd4ff0d1b3f9f4d1b049e00e809311c59eb07b5e93032d212d1a7c59a1122fdbb84d56c9d889523afb34896d247a76d8c8317e6a472d1ed473d57401f573cdc
     HEAD_REF master
     PATCHES
         fix-install-path.patch

--- a/ports/stillwater-universal/vcpkg.json
+++ b/ports/stillwater-universal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stillwater-universal",
-  "version": "4.6.16",
+  "version": "4.7.0",
   "description": "A header-only C++ library for plug-in replacement number systems for native types",
   "homepage": "https://github.com/stillwater-sc/universal",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9685,7 +9685,7 @@
       "port-version": 0
     },
     "stillwater-universal": {
-      "baseline": "4.6.16",
+      "baseline": "4.7.0",
       "port-version": 0
     },
     "stlab": {

--- a/versions/s-/stillwater-universal.json
+++ b/versions/s-/stillwater-universal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6658f1892a00de944522e436cbb2b46309a0d906",
+      "version": "4.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "288422b06cd0c130b391c77d99f43d99c24a2529",
       "version": "4.6.16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stillwater-sc/universal/releases/tag/v4.7.0
