### PR TITLE
Prism: update to 0.16.2

### DIFF
--- a/ports/ethindp-prism/portfile.cmake
+++ b/ports/ethindp-prism/portfile.cmake
@@ -4,8 +4,8 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO ethindp/prism
-  REF v0.16.1
-  SHA512 201ce4218543823b3a36aef6200032bfda816f8dcde495cca43de101415cc643da67a0eb347e5f90eec3d6ca1dcb298d8c1f544933ce2c5edbd44a32e92bd8d2
+  REF v0.16.2
+  SHA512 c18da8d6e0ded885ab55093442eae0bb7c74361441473eff787983050f7483e6455bf284b3ecadc4f2a04e1d41e6bd765e735a90496351365992fb1eb8c9ac88
   HEAD_REF master
 )
 vcpkg_check_features(

--- a/ports/ethindp-prism/vcpkg.json
+++ b/ports/ethindp-prism/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ethindp-prism",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The Platform-agnostic Reader Interface for Speech and Messages",
   "license": "MPL-2.0",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2857,7 +2857,7 @@
       "port-version": 1
     },
     "ethindp-prism": {
-      "baseline": "0.16.1",
+      "baseline": "0.16.2",
       "port-version": 0
     },
     "etl": {

--- a/versions/e-/ethindp-prism.json
+++ b/versions/e-/ethindp-prism.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "498cb4f99913b9e11d5b012279590d9b046249cd",
+      "version": "0.16.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a98bdb1e7d4c67d47c6f462bfc6e85f2a3636773",
       "version": "0.16.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
