### PR TITLE
[tesults-cpp] Add tesults-cpp v1.0.1

### DIFF
--- a/ports/tesults-cpp/portfile.cmake
+++ b/ports/tesults-cpp/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tesults/cpp
+    REF "v${VERSION}"
+    SHA512 961d7f69fb00b57deceb4f2660394229437c63f4b4e23f266b6db8abe5183ff84e996312bd005ff22c496499269e81508faacc1119fd2394613a1a51d601bdaf
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tesults)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tesults-cpp/vcpkg.json
+++ b/ports/tesults-cpp/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "tesults-cpp",
+  "version": "1.0.2",
+  "description": "C++ library for uploading test results to Tesults",
+  "homepage": "https://github.com/tesults/cpp",
+  "license": "MIT",
+  "dependencies": [
+    "curl",
+    "nlohmann-json",
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9988,6 +9988,10 @@
       "baseline": "5.5.2",
       "port-version": 0
     },
+    "tesults-cpp": {
+      "baseline": "1.0.2",
+      "port-version": 0
+    },
     "tevclient": {
       "baseline": "2023-12-04",
       "port-version": 0

--- a/versions/t-/tesults-cpp.json
+++ b/versions/t-/tesults-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bd723848ce64e75c910207fd5eba7c08102fea02",
+      "version": "1.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the `tesults-cpp` port — a C++ library for uploading test results to [Tesults](https://www.tesults.com).

- **Homepage**: https://github.com/tesults/cpp
- **License**: MIT
- **Version**: 1.0.0

### Port details

| Field | Value |
|---|---|
| Name | `tesults-cpp` |
| Version | `1.0.0` |
| Dependencies | `curl`, `nlohmann-json`, `openssl` |

### Testing

Port was tested locally on macOS (Apple Silicon) with:
- CMake 3.14+
- AppleClang 21
- `vcpkg install tesults-cpp`

The example in the upstream repo builds and links correctly against the installed library.

### Checklist

- [x] Port files follow vcpkg conventions
- [x] `vcpkg x-add-version` run and versioning files committed
- [x] SHA512 verified against GitHub archive
- [x] `vcpkg_install_copyright` included
- [x] `file(REMOVE_RECURSE ...)` removes debug/include duplicates