### PR TITLE
[bento-kit] add port

### DIFF
--- a/ports/bento-kit/portfile.cmake
+++ b/ports/bento-kit/portfile.cmake
@@ -1,0 +1,23 @@
+string(REGEX MATCH "^([0-9]+\\.[0-9]+)" _ "${VERSION}")
+set(BENTO_KIT_RELEASE_REF "release_${CMAKE_MATCH_1}")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO imcooder/bento-kit-cpp
+    REF "${BENTO_KIT_RELEASE_REF}"
+    SHA512 81f1900ce9e2fb691baf47a2eed1f5b65b9a16b2df0e66be41b97eadb7b6b0c9ef274d33ad4a29e878a8d495cfb2703c7e110ca850c5bfc1ef6dd15f0c3afce2
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBENTO_KIT_BUILD_TESTS=OFF
+        -DBENTO_KIT_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "${CMAKE_INSTALL_LIBDIR}/cmake/bento-kit")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bento-kit/vcpkg.json
+++ b/ports/bento-kit/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "bento-kit",
+  "version": "0.1.7",
+  "description": "Header-only C++ utilities: IDs, random helpers, log redaction",
+  "homepage": "https://github.com/imcooder/bento-kit-cpp",
+  "license": "MIT",
+  "supports": "(windows & !uwp) | linux | osx | ios | android | freebsd | emscripten",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/bento-kit.json
+++ b/versions/b-/bento-kit.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fdf4b7e230d5f1e56f0c247b2d46b7a2c6a7de34",
+      "version": "0.1.7",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -680,6 +680,10 @@
       "baseline": "1.9.5",
       "port-version": 0
     },
+    "bento-kit": {
+      "baseline": "0.1.7",
+      "port-version": 0
+    },
     "bento4": {
       "baseline": "1.6.0-641",
       "port-version": 0


### PR DESCRIPTION
Automated sync from [imcooder/bento-kit-cpp](https://github.com/imcooder/bento-kit-cpp) release **0.1.7**.

- **Upstream:** https://github.com/imcooder/bento-kit-cpp
- **Port version:** 0.1.7
- **Local test:** `./vcpkg install bento-kit:x64-linux` (run in CI before push)

```cmake
find_package(bento-kit CONFIG REQUIRED)
target_link_libraries(my_app PRIVATE bento::kit)
```