### PR TITLE
[h3] update to 4.5.0

### DIFF
--- a/ports/h3/portfile.cmake
+++ b/ports/h3/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uber/h3
     REF "v${VERSION}"
-    SHA512 e8a87c109ba917887483c73b0410bfd11f9259815ba7f9b967779963c9a7a5c208d70f0d6f6ae586ff371feeab3e19d96273137b42fd03a84ae08965bb8ea643
+    SHA512 8b74989632e2f23ecd26098d1accf6289ab0aac025ed695eafc0919e450090f935990518d26cb5b2f01df180e60f1bf3896607bc39771808b63ffc87a18921e4
     HEAD_REF master
 )
 
@@ -25,6 +25,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()
 

--- a/ports/h3/vcpkg.json
+++ b/ports/h3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "h3",
-  "version-semver": "4.4.1",
-  "port-version": 1,
+  "version-semver": "4.5.0",
   "description": "A Hexagonal Hierarchical Geospatial Indexing System",
   "homepage": "https://github.com/uber/h3",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3721,8 +3721,8 @@
       "port-version": 2
     },
     "h3": {
-      "baseline": "4.4.1",
-      "port-version": 1
+      "baseline": "4.5.0",
+      "port-version": 0
     },
     "h5py-lzf": {
       "baseline": "3.15.1",

--- a/versions/h-/h3.json
+++ b/versions/h-/h3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "004be5f19af823bbc3595c86f0b38263115e2ccd",
+      "version-semver": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b7a13926003f83b9c13c75564684e58842c97479",
       "version-semver": "4.4.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/uber/h3/releases/tag/v4.5.0
