### PR TITLE
[obfuscxx] fix version

### DIFF
--- a/ports/obfuscxx/portfile.cmake
+++ b/ports/obfuscxx/portfile.cmake
@@ -2,11 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nevergiveupcpp/obfuscxx
     REF v${VERSION}
-	SHA512 223461e3bd8b775e2ae525f2ab78e1051906d7aa798bc6c77017cb552c094611443600fa1c7675e4eb34a5d744be3776d363594ebbac2acbde2329c60694d56b
+    SHA512 5dee6c7d257a3bf4fb24e64f9459b4c9dd33f14d9c0c57847bd232d0d896d0c5b886eaaff2af15a9a98b96ae8f40f9c416af9b31a1207513427a42b9e925e892
 )
 
 vcpkg_cmake_configure(
-	SOURCE_PATH "${SOURCE_PATH}"
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()

--- a/ports/obfuscxx/vcpkg.json
+++ b/ports/obfuscxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "obfuscxx",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Header-only compile-time variables obfuscation library for C++20",
   "homepage": "https://github.com/nevergiveupcpp/obfuscxx",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7201,7 +7201,7 @@
       "port-version": 2
     },
     "obfuscxx": {
-      "baseline": "1.3.5",
+      "baseline": "1.3.6",
       "port-version": 0
     },
     "oboe": {

--- a/versions/o-/obfuscxx.json
+++ b/versions/o-/obfuscxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9f0ce490a1c73a1ce9dfc35dbd73d28de2dfaa7",
+      "version": "1.3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "21849017b38751a834e88dff48a7c96d01f1eab8",
       "version": "1.3.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/nevergiveupcpp/obfuscxx/commit/e2cdfb652d42d7a80f454f090e3be2a07bbbbdfd