### PR TITLE
[ryml] update to 0.13.0

### DIFF
--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 e4a66a13b68808048ba3354c19556fd9df567be94325f9ee4010cf722cc6c637fb5296a08bdc584bd8dc1a362ee5fe1697efcf2e979227e622d0b1c1b60265a3
+    SHA512 cd5013cf7328dfc51718546b728efa0dc1dad3b62ca881f5c21f615c3d8a069201179569bc27b520dcd818fa5fc2ea423a9b9d6c938f8cf31ec056d37ec89441
     HEAD_REF master
     PATCHES
         cmake-fix.patch

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8949,7 +8949,7 @@
       "port-version": 2
     },
     "ryml": {
-      "baseline": "0.12.1",
+      "baseline": "0.13.0",
       "port-version": 0
     },
     "ryu": {

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5314fb34c5058d6a9b8a7317919ded3f26caa87",
+      "version": "0.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ade2d54fbeca8d4679c0927a43c77c1f0d91154",
       "version": "0.12.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/biojppm/rapidyaml/releases/tag/v0.13.0
