### PR TITLE
[aws-c-http] update to 0.11.0

### DIFF
--- a/ports/aws-c-http/portfile.cmake
+++ b/ports/aws-c-http/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-http
     REF "v${VERSION}"
-    SHA512 3bbcfabeac784ba97909571aeed2b8b2c2082fbc4f1eebf078f1e2042a042c582c57719393a5ddaeb41826e74aee189b714b684d55981c14a1a9499d10938a9d
+    SHA512 f25bebbcbb5dcc6c996b8f20abfcd1c2bb2bc8f042097f0b81322ff3f83c44fec884a5f145a2bf5253ebb7137b806d28af6a93d46c74c2d865a19a5a97e804af
     HEAD_REF master
 )
 

--- a/ports/aws-c-http/vcpkg.json
+++ b/ports/aws-c-http/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-http",
-  "version": "0.10.15",
+  "version": "0.11.0",
   "description": "C99 implementation of the HTTP/1.1 and HTTP/2 specifications",
   "homepage": "https://github.com/awslabs/aws-c-http",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-http.json
+++ b/versions/a-/aws-c-http.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f49f52b96a237b9a9e1333d717140ee6137eb9a6",
+      "version": "0.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "591505d750730638d991e981c1c9726211f92e97",
       "version": "0.10.15",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -473,7 +473,7 @@
       "port-version": 0
     },
     "aws-c-http": {
-      "baseline": "0.10.15",
+      "baseline": "0.11.0",
       "port-version": 0
     },
     "aws-c-io": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/awslabs/aws-c-http/releases/tag/v0.11.0
