### PR TITLE
[libgit2] update to 1.9.4

### DIFF
--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libgit2/libgit2
     REF "v${VERSION}"
-    SHA512 5359d07b85b691b92784d5ef52825be2c1f1616bab8e969e51177bf8f5e767edbaf267943296407f62df1f3d7fa08e48c802374289046b71da2cc1ac7d43a15f
+    SHA512 85036ade3aca33c5283605ae9de21a7948ec5952bc8cd468aa024ca873851a56ab0ebe62f95c0da109df9163875e9687a377d3df69728d434cc258b3f845ef0c
     HEAD_REF main
     PATCHES
         c-standard.diff # for 'inline' in system headers

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgit2",
-  "version-semver": "1.9.3",
+  "version-semver": "1.9.4",
   "description": "A C library implementing the Git core methods with a solid API",
   "homepage": "https://github.com/libgit2/libgit2",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5045,7 +5045,7 @@
       "port-version": 0
     },
     "libgit2": {
-      "baseline": "1.9.3",
+      "baseline": "1.9.4",
       "port-version": 0
     },
     "libgme": {

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec1fe1faf133c35900f219d53c40e9eef8e16208",
+      "version-semver": "1.9.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "8edcfd58769b34a0911a9515a5b64841ce6c31ca",
       "version-semver": "1.9.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libgit2/libgit2/releases/tag/v1.9.4
