### PR TITLE
[linux-dfl-uapi-headers] Add new port

### DIFF
--- a/ports/linux-dfl-uapi-headers/portfile.cmake
+++ b/ports/linux-dfl-uapi-headers/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO OFS/linux-dfl-backport
+    REF "${VERSION}"
+    SHA512 b32bd170853e69f95748c041a61809d947de40a0ba9b97f528c5878e427e49f631aee056e838d95191cbfe183f602a081ebd966dc6f52aae029302dfbdf04499
+    HEAD_REF intel/fpga-ofs-dev-6.6-lts
+)
+
+file(INSTALL "${SOURCE_PATH}/include/uapi/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/uapi")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/linux-dfl-uapi-headers/vcpkg.json
+++ b/ports/linux-dfl-uapi-headers/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "linux-dfl-uapi-headers",
+  "version-string": "intel-1.12.0-3",
+  "description": "User space API headers of the linux-dfl (Device Feature List) kernel driver for FPGA devices",
+  "license": "GPL-2.0 WITH Linux-syscall-note AND GPL-2.0-only",
+  "supports": "linux"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6084,6 +6084,10 @@
       "baseline": "2022-07-30",
       "port-version": 0
     },
+    "linux-dfl-uapi-headers": {
+      "baseline": "intel-1.12.0-3",
+      "port-version": 0
+    },
     "lionkor-commandline": {
       "baseline": "2.4.2",
       "port-version": 0

--- a/versions/l-/linux-dfl-uapi-headers.json
+++ b/versions/l-/linux-dfl-uapi-headers.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c8627c3934b251089ae58a48e5586b6d9d390914",
+      "version-string": "intel-1.12.0-3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
