### PR TITLE
[cesnet-ndk-sw] Add new port

### DIFF
--- a/ports/cesnet-ndk-sw/0001-disable-cpack.patch
+++ b/ports/cesnet-ndk-sw/0001-disable-cpack.patch
@@ -1,0 +1,169 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5323cbb..286ce3f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,34 +12,11 @@ cmake_policy(VERSION 3.20)
+ project(nfb-framework LANGUAGES C)
+ include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+ 
+-get_git_version()
+-
+ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "Main")
+ 
+ #check_function_exists(cmake_host_system_information HAVE_HSI)
+ #cmake_host_system_information(RESULT DISTRIB_ID_LIKE QUERY DISTRIB_ID_LIKE)
+ 
+-set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/")
+-
+-if (EXISTS "/etc/debian_version")
+-	set(PLATFORM          "Debian")
+-	set(CPACK_GENERATOR   "DEB" )
+-elseif (EXISTS "/etc/centos-release" OR EXISTS "/etc/sl-release" OR EXISTS "/etc/redhat-release")
+-	set(PLATFORM          "Centos")
+-	set(CPACK_GENERATOR   "RPM")
+-else ()
+-	message(WARNING "Failed to determine platform, using TGZ for packaging")
+-	set(CPACK_GENERATOR   "TGZ")
+-	set(CPACK_ARCHIVE_COMPONENT_INSTALL 1)
+-
+-	set(CPACK_SET_DESTDIR "ON")
+-	unset(CPACK_PACKAGING_INSTALL_PREFIX)
+-endif ()
+-
+-set(PACKAGE_NAME "${PROJECT_NAME}")
+-set(PACKAGE_VERSION "${GIT_VERSION}")
+-set(RELEASE "${GIT_VERSION_RELEASE}")
+-
+ add_subdirectory(drivers)
+ add_subdirectory(libnfb)
+ add_subdirectory(ext)
+@@ -49,129 +26,3 @@ add_subdirectory(tools-misc)
+ add_subdirectory(utils)
+ add_subdirectory(pynfb)
+ add_subdirectory(python/nfb-tools)
+-
+-
+-configure_file(package/preinst.in package/preinst @ONLY)
+-configure_file(package/postinst.in package/postinst @ONLY)
+-configure_file(package/prerm.in package/prerm @ONLY)
+-configure_file(package/postrm.in package/postrm @ONLY)
+-
+-set(RPM_DEP_LIST
+-	dkms gcc kernel-devel libarchive libfdt-devel make numactl ncurses pciutils-libs
+-)
+-set(RPM_PYTHON_DEP_LIST
+-	nfb-framework python3-fdt
+-)
+-
+-set(DEB_DEP_LIST
+-	dkms gcc libarchive-dev libfdt-dev libncurses-dev libnuma-dev linux-headers make libpci3
+-)
+-set(DEB_PYTHON_DEP_LIST
+-	nfb-framework
+-)
+-
+-
+-# Common package settings
+-if(USE_DPDK)
+-	set(CPACK_PACKAGE_NAME                  "temp-${PROJECT_NAME}+ndp_tools_dpdk")
+-elseif(USE_XDP)
+-	set(CPACK_PACKAGE_NAME                  "temp-${PROJECT_NAME}+ndp_tools_xdp")
+-else()
+-	set(CPACK_PACKAGE_NAME                  "${PROJECT_NAME}")
+-endif()
+-set(CPACK_PACKAGE_VENDOR                "CESNET")
+-set(CPACK_PACKAGE_VERSION_MAJOR         ${GIT_VERSION_MAJOR})
+-set(CPACK_PACKAGE_VERSION_MINOR         ${GIT_VERSION_MINOR})
+-set(CPACK_PACKAGE_VERSION_PATCH         ${GIT_VERSION_PATCH})
+-set(CPACK_PACKAGE_VERSION               ${GIT_VERSION})
+-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY   "NDK software library")
+-set(CPACK_PACKAGE_CONTACT               "spinler@cesnet.cz")
+-set(CPACK_PACKAGE_RELOCATABLE           OFF)
+-set(CPACK_PACKAGE_DESCRIPTION_FILE      "${CMAKE_CURRENT_LIST_DIR}/package/description.txt")
+-
+-# RPM (CentOS) package settings
+-set(CPACK_RPM_FILE_NAME                 RPM-DEFAULT)
+-set(CPACK_RPM_Main_PACKAGE_NAME         "${CPACK_PACKAGE_NAME}")
+-set(CPACK_RPM_DebugTools_PACKAGE_NAME   "${CPACK_PACKAGE_NAME}-debug")
+-set(CPACK_RPM_NfbExtGrpc_PACKAGE_NAME   "nfb-ext-grpc")
+-
+-# FIXME: use real Python version
+-set(CPACK_RPM_python_PACKAGE_NAME       "python3-nfb")
+-set(CPACK_RPM_SPEC_MORE_DEFINE "%define __python python3")
+-
+-set(CPACK_RPM_PACKAGE_RELEASE           ${GIT_VERSION_RELEASE})
+-set(CPACK_RPM_PACKAGE_RELEASE_DIST      ON)
+-set(CPACK_RPM_PACKAGE_LICENSE           "BSD and GPLv2")
+-string(JOIN " " CPACK_RPM_PACKAGE_REQUIRES ${RPM_DEP_LIST})
+-string(JOIN " " CPACK_RPM_python_PACKAGE_REQUIRES ${RPM_PYTHON_DEP_LIST})
+-
+-set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
+-	/etc/dracut.conf.d
+-	/etc/udev
+-	/etc/udev/rules.d
+-	/usr/include/linux
+-	/usr/lib/tmpfiles.d
+-	/usr/lib64/pkgconfig
+-	/usr/src
+-)
+-set(CPACK_RPM_COMPONENT_INSTALL          ON)
+-set(CPACK_RPM_CHANGELOG_FILE             "${CMAKE_CURRENT_LIST_DIR}/Changelog")
+-set(CPACK_RPM_Main_PACKAGE_OBSOLETES          "netcope-common")
+-set(CPACK_RPM_DebugTools_PACKAGE_OBSOLETES    "netcope-common-debug")
+-set(CPACK_RPM_Main_PACKAGE_PROVIDES           "netcope-common")
+-set(CPACK_RPM_DebugTools_PACKAGE_PROVIDES     "netcope-common-debug")
+-#set(CPACK_RPM_DebugTools_PACKAGE_REQUIRES "${PACKAGE_NAME} = ${CPACK_PACKAGE_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}")
+-
+-if(USE_DPDK)
+-	set(CPACK_RPM_ndp-tool-dpdk_PACKAGE_NAME "ndp-tool-dpdk")
+-	set(CPACK_RPM_ndp-tool-dpdk_PACKAGE_REQUIRES "nfb-framework, dpdk-nfb, dpdk-nfb-tools")
+-	set (CPACK_RPM_SOURCE_PKG_BUILD_PARAMS "-DUSE_DPDK=true")
+-endif()
+-
+-if(USE_XDP)
+-	set(CPACK_RPM_ndp-tool-xdp_PACKAGE_NAME "ndp-tool-xdp")
+-	set(CPACK_RPM_ndp-tool-xdp_PACKAGE_REQUIRES "nfb-framework, libxdp, libbpf")
+-	set (CPACK_RPM_SOURCE_PKG_BUILD_PARAMS "-DUSE_XDP=true")
+-endif()
+-
+-set(CPACK_RPM_Main_PRE_INSTALL_SCRIPT_FILE    "${CMAKE_CURRENT_BINARY_DIR}/package/preinst")
+-set(CPACK_RPM_Main_PRE_UNINSTALL_SCRIPT_FILE  "${CMAKE_CURRENT_BINARY_DIR}/package/prerm")
+-set(CPACK_RPM_Main_POST_INSTALL_SCRIPT_FILE   "${CMAKE_CURRENT_BINARY_DIR}/package/postinst")
+-set(CPACK_RPM_Main_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/package/postrm")
+-
+-# DEB (Ubuntu) package settings
+-set(CPACK_DEB_COMPONENT_INSTALL         ON)
+-set(CPACK_DEBIAN_PACKAGE_NAME           "${CPACK_PACKAGE_NAME}")
+-set(CPACK_DEBIAN_PACKAGE_VERSION        "${CPACK_PACKAGE_VERSION}")
+-set(CPACK_DEBIAN_PACKAGE_RELEASE        "${GIT_VERSION_DEBRELEASE}")
+-set(CPACK_DEBIAN_FILE_NAME              "${CPACK_DEBIAN_PACKAGE_NAME}-${CPACK_DEBIAN_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}.deb")
+-
+-set(CPACK_DEBIAN_MAIN_PACKAGE_NAME      "${CPACK_PACKAGE_NAME}")
+-set(CPACK_DEBIAN_MAIN_PACKAGE_VERSION   "${CPACK_PACKAGE_VERSION}")
+-set(CPACK_DEBIAN_MAIN_PACKAGE_NAME      "${CPACK_PACKAGE_NAME}")
+-set(CPACK_DEBIAN_MAIN_FILE_NAME         "${CPACK_DEBIAN_PACKAGE_NAME}-${CPACK_DEBIAN_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}.deb")
+-
+-set(CPACK_DEBIAN_DEBUGTOOLS_PACKAGE_NAME "nfb-framework-debug")
+-set(CPACK_DEBIAN_DEBUGTOOLS_FILE_NAME "nfb-framework-debug-${CPACK_DEBIAN_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}.deb")
+-set(CPACK_DEBIAN_PYTHON_PACKAGE_NAME "python3-nfb")
+-set(CPACK_DEBIAN_PYTHON_FILE_NAME "python3-nfb-${CPACK_DEBIAN_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}.deb")
+-string(JOIN ", " CPACK_DEBIAN_PACKAGE_DEPENDS ${DEB_DEP_LIST})
+-string(JOIN ", " CPACK_DEBIAN_PYTHON_PACKAGE_DEPENDS ${DEB_PYTHON_DEP_LIST})
+-
+-if(USE_XDP)
+-	set(CPACK_DEBIAN_NDP-TOOL-XDP_PACKAGE_NAME "ndp-tool-xdp")
+-	set(CPACK_DEBIAN_NDP-TOOL-XDP_FILE_NAME "ndp-tool-xdp-${CPACK_DEBIAN_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}.deb")
+-	set(CPACK_DEBIAN_NDP-TOOL-XDP_PACKAGE_DEPENDS "nfb-framework, libxdp1, libbpf1")
+-endif()
+-
+-include(python/nfb-tools/nfb-tools.cmake)
+-
+-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS	"../${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}/${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS      ON)
+-set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+-	"${CMAKE_CURRENT_BINARY_DIR}/package/preinst"
+-	"${CMAKE_CURRENT_BINARY_DIR}/package/postinst"
+-	"${CMAKE_CURRENT_BINARY_DIR}/package/prerm"
+-)
+-
+-include(CPack)

--- a/ports/cesnet-ndk-sw/0002-disable-drivers.patch
+++ b/ports/cesnet-ndk-sw/0002-disable-drivers.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 286ce3f..4e875d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,7 +17,6 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "Main")
+ #check_function_exists(cmake_host_system_information HAVE_HSI)
+ #cmake_host_system_information(RESULT DISTRIB_ID_LIKE QUERY DISTRIB_ID_LIKE)
+ 
+-add_subdirectory(drivers)
+ add_subdirectory(libnfb)
+ add_subdirectory(ext)
+ add_subdirectory(tools)

--- a/ports/cesnet-ndk-sw/0003-disable-optional-deps.patch
+++ b/ports/cesnet-ndk-sw/0003-disable-optional-deps.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4e875d3..005044e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,7 +18,6 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "Main")
+ #cmake_host_system_information(RESULT DISTRIB_ID_LIKE QUERY DISTRIB_ID_LIKE)
+ 
+ add_subdirectory(libnfb)
+-add_subdirectory(ext)
+ add_subdirectory(tools)
+ add_subdirectory(tools-debug)
+ add_subdirectory(tools-misc)

--- a/ports/cesnet-ndk-sw/0004-disable-tools.patch
+++ b/ports/cesnet-ndk-sw/0004-disable-tools.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 005044e..9b8b22c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,9 +18,4 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "Main")
+ #cmake_host_system_information(RESULT DISTRIB_ID_LIKE QUERY DISTRIB_ID_LIKE)
+ 
+ add_subdirectory(libnfb)
+-add_subdirectory(tools)
+-add_subdirectory(tools-debug)
+-add_subdirectory(tools-misc)
+ add_subdirectory(utils)
+-add_subdirectory(pynfb)
+-add_subdirectory(python/nfb-tools)

--- a/ports/cesnet-ndk-sw/0005-fix-pkgconfig-version.patch
+++ b/ports/cesnet-ndk-sw/0005-fix-pkgconfig-version.patch
@@ -1,0 +1,20 @@
+diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
+index 4ba5041..a453c1a 100644
+--- a/utils/CMakeLists.txt
++++ b/utils/CMakeLists.txt
+@@ -15,14 +15,12 @@ set(UDEV_NAME 80-nfb.rules)
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/../functions.cmake)
+ 
+-get_git_version()
+-
+ set(prefix          "/usr")
+ set(includedir      "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ set(libdir          "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+ set(datarootdir     "\${prefix}/${CMAKE_INSTALL_DATAROOTDIR}")
+ set(datadir         "\${datarootdir}")
+-set(PACKAGE_VERSION "${GIT_VERSION}")
++set(PACKAGE_VERSION "${VERSION}")
+ 
+ configure_file(nfb-framework.pc.in nfb-framework.pc @ONLY)
+ configure_file(netcope-common.pc.in netcope-common.pc @ONLY)

--- a/ports/cesnet-ndk-sw/0006-nfb-static-or-shared.patch
+++ b/ports/cesnet-ndk-sw/0006-nfb-static-or-shared.patch
@@ -1,0 +1,59 @@
+diff --git a/libnfb/CMakeLists.txt b/libnfb/CMakeLists.txt
+index d37bb70..3c64d30 100644
+--- a/libnfb/CMakeLists.txt
++++ b/libnfb/CMakeLists.txt
+@@ -19,7 +19,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/../functions.cmake)
+ find_package(PkgConfig)
+ 
+ nfb_cmake_env()
+-get_git_version()
+ 
+ set(CMAKE_REQUIRED_LIBRARIES "numa")
+ 
+@@ -47,27 +46,26 @@ set(LIBNFB_SOURCES
+ 	src/boot/mtd.c src/boot/boot.c src/boot/filetype_mcs.c src/boot/filetype_bit.c src/boot/filetype_rpd.c src/boot/bit_reverse_table.c
+ )
+ 
+-add_library(nfb SHARED ${LIBNFB_SOURCES})
+-add_library(nfb_static STATIC ${LIBNFB_SOURCES})
+-foreach(NFB IN ITEMS nfb nfb_static)
+-	target_link_libraries(${NFB}
+-		PRIVATE ${FDT_LIBRARIES} ${NUMA_LIBRARIES} dl
+-	)
+-	target_include_directories(${NFB}
+-		PUBLIC include
+-		PRIVATE src ${NFB_DRIVER_INCLUDE_DIRS}/../..
+-	)
+-	set_target_properties(${NFB} PROPERTIES
+-		OUTPUT_NAME nfb
+-		VERSION ${GIT_VERSION}
+-		SOVERSION ${GIT_VERSION_MAJOR}
+-	)
+-	if (${CONFIG_HAVE_MAVX2})
+-		set_source_files_properties(src/bus/mi.c PROPERTIES COMPILE_FLAGS -mavx2)
+-	endif()
+-endforeach()
++add_library(nfb ${LIBNFB_SOURCES})
++target_link_libraries(nfb
++	PRIVATE ${FDT_LIBRARIES} ${NUMA_LIBRARIES} dl
++)
++target_include_directories(nfb
++	PUBLIC include
++	PRIVATE src ${NFB_DRIVER_INCLUDE_DIRS}/../..
++		${FDT_INCLUDE_DIRS}
++		${NUMA_INCLUDE_DIRS}
++)
++set_target_properties(nfb PROPERTIES
++	OUTPUT_NAME nfb
++	VERSION "${VERSION}"
++	SOVERSION "${VERSION_MAJOR}"
++)
++if (${CONFIG_HAVE_MAVX2})
++	set_source_files_properties(src/bus/mi.c PROPERTIES COMPILE_FLAGS -mavx2)
++endif()
+ 
+-install(TARGETS nfb nfb_static
++install(TARGETS nfb
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ )

--- a/ports/cesnet-ndk-sw/0007-fpga-image-load.patch
+++ b/ports/cesnet-ndk-sw/0007-fpga-image-load.patch
@@ -1,0 +1,38 @@
+diff --git a/libnfb/CMakeLists.txt b/libnfb/CMakeLists.txt
+index 3c64d30..b78ece9 100644
+--- a/libnfb/CMakeLists.txt
++++ b/libnfb/CMakeLists.txt
+@@ -41,6 +41,12 @@ if (NOT NFB_DRIVER_INCLUDE_DIRS)
+ 	message(FATAL_ERROR "NFB driver headers not found, cannot continue")
+ endif ()
+ 
++find_path(FPGA_IMAGE_LOAD_INCLUDE_DIRS
++    NAMES fpga-image-load.h
++	 PATH_SUFFIXES uapi/linux
++	 REQUIRED
++)
++
+ set(LIBNFB_SOURCES
+ 	src/bus/mi.c src/nfb.c src/ndp/ndp.c src/info.c
+ 	src/boot/mtd.c src/boot/boot.c src/boot/filetype_mcs.c src/boot/filetype_bit.c src/boot/filetype_rpd.c src/boot/bit_reverse_table.c
+@@ -55,6 +61,7 @@ target_include_directories(nfb
+ 	PRIVATE src ${NFB_DRIVER_INCLUDE_DIRS}/../..
+ 		${FDT_INCLUDE_DIRS}
+ 		${NUMA_INCLUDE_DIRS}
++		${FPGA_IMAGE_LOAD_INCLUDE_DIRS}
+ )
+ set_target_properties(nfb PROPERTIES
+ 	OUTPUT_NAME nfb
+diff --git a/libnfb/src/boot/boot.c b/libnfb/src/boot/boot.c
+index 3f26187..b7769e8 100644
+--- a/libnfb/src/boot/boot.c
++++ b/libnfb/src/boot/boot.c
+@@ -19,7 +19,7 @@
+ 
+ #include <libfdt.h>
+ 
+-#include <uapi/linux/nfb-fpga-image-load.h>
++#include <uapi/linux/fpga-image-load.h>
+ 
+ #include <linux/nfb/boot.h>
+ #include <nfb/nfb.h>

--- a/ports/cesnet-ndk-sw/0008-fix-install-location.patch
+++ b/ports/cesnet-ndk-sw/0008-fix-install-location.patch
@@ -1,0 +1,22 @@
+diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
+index a453c1a..4a8edcb 100644
+--- a/utils/CMakeLists.txt
++++ b/utils/CMakeLists.txt
+@@ -15,7 +15,7 @@ set(UDEV_NAME 80-nfb.rules)
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/../functions.cmake)
+ 
+-set(prefix          "/usr")
++set(prefix          "${CMAKE_INSTALL_PREFIX}")
+ set(includedir      "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ set(libdir          "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+ set(datarootdir     "\${prefix}/${CMAKE_INSTALL_DATAROOTDIR}")
+@@ -27,7 +27,7 @@ configure_file(netcope-common.pc.in netcope-common.pc @ONLY)
+ 
+ install(
+ 	FILES nfb.udev.rules
+-	DESTINATION /etc/udev/rules.d
++	DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/udev/rules.d"
+ 	RENAME ${UDEV_NAME}
+ )
+ 

--- a/ports/cesnet-ndk-sw/portfile.cmake
+++ b/ports/cesnet-ndk-sw/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO CESNET/ndk-sw
+    REF "v${VERSION}"
+    SHA512 d2cba5d8ee77cecb6874e964ee63086a8ac45530654d444ed49281e774b36a27364067076a836caf04e93371678db8ba0b3849700a1176b0256ad9b8490b06a7
+    HEAD_REF main
+    PATCHES
+        0001-disable-cpack.patch
+        0002-disable-drivers.patch
+        0003-disable-optional-deps.patch
+        0004-disable-tools.patch
+        0005-fix-pkgconfig-version.patch
+        0006-nfb-static-or-shared.patch
+        0007-fpga-image-load.patch
+        0008-fix-install-location.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DVERSION=${VERSION}"
+        "-DVERSION_MAJOR=${VERSION_MAJOR}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/etc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cesnet-ndk-sw/vcpkg.json
+++ b/ports/cesnet-ndk-sw/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "cesnet-ndk-sw",
+  "version": "6.30.3",
+  "description": "The NDK (Network Development Kit) software framework",
+  "license": "BSD-3-Clause",
+  "supports": "linux",
+  "dependencies": [
+    "dtc",
+    "linux-dfl-uapi-headers",
+    "numactl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1676,6 +1676,10 @@
       "baseline": "2.2.0",
       "port-version": 6
     },
+    "cesnet-ndk-sw": {
+      "baseline": "6.30.3",
+      "port-version": 0
+    },
     "cfitsio": {
       "baseline": "4.6.4",
       "port-version": 0

--- a/versions/c-/cesnet-ndk-sw.json
+++ b/versions/c-/cesnet-ndk-sw.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b4c2275db71861963094813da2c482a19038ec4a",
+      "version": "6.30.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.