### PR TITLE
[musdk] Add new port

### DIFF
--- a/ports/musdk/0001-disable-apps.patch
+++ b/ports/musdk/0001-disable-apps.patch
@@ -1,0 +1,10 @@
+diff --git a/Makefile.am b/Makefile.am
+index 1cb44a66..0e31137c 100755
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,4 +1,4 @@
+ ACLOCAL_AMFLAGS = -I m4
+ AUTOMAKE_OPTIONS = foreign
+ AM_MAKEFLAGS = --no-print-directory
+-SUBDIRS = src apps 
++SUBDIRS = src

--- a/ports/musdk/0002-disable-warnings-as-errors.patch
+++ b/ports/musdk/0002-disable-warnings-as-errors.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 2e5a7668..26357a3b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -257,7 +257,6 @@ AC_CHECK_HEADERS([stdlib.h unistd.h])
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ 
+ CFLAGS="$CFLAGS -Wall "
+-CFLAGS+="-Werror "
+ CFLAGS+="-Wstrict-prototypes "
+ CFLAGS+="-Wmissing-prototypes "
+ CFLAGS+="-pthread "

--- a/ports/musdk/portfile.cmake
+++ b/ports/musdk/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO MarvellEmbeddedProcessors/musdk-marvell
+    REF "releasetag-musdk-release-SDK${VERSION}"
+    SHA512 ef944ebe9098d2f495bee10dea250bfb990d0bbc9a2ac49aa62420e27e07d37276078c3e5456b082ab20e3cf5ebf756b5d13aca56b4db5ce4590378a1f2769d5
+    HEAD_REF musdk-release
+    PATCHES
+        0001-disable-apps.patch
+        0002-disable-warnings-as-errors.patch
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    COPY_SOURCE
+    OPTIONS
+        --enable-giu
+        --enable-neta
+        --enable-nmp
+        --enable-pp2
+        --enable-sam
+)
+
+vcpkg_make_install()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/license.txt"
+    "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/musdk/vcpkg.json
+++ b/ports/musdk/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "musdk",
+  "version": "11.22.12",
+  "description": "Marvell User-Space SDK",
+  "license": "BSD-3-Clause",
+  "supports": "linux & arm64",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6804,6 +6804,10 @@
       "baseline": "2016-01-09",
       "port-version": 7
     },
+    "musdk": {
+      "baseline": "11.22.12",
+      "port-version": 0
+    },
     "mvfst": {
       "baseline": "2026.02.23.00",
       "port-version": 0

--- a/versions/m-/musdk.json
+++ b/versions/m-/musdk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "05387aba9e9eb820d93a4101f0c2b85f58b47f71",
+      "version": "11.22.12",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
