### PR TITLE
[mysql-connector-cpp] upgrade 9.7

### DIFF
--- a/ports/mysql-connector-cpp/portfile.cmake
+++ b/ports/mysql-connector-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mysql/mysql-connector-cpp
     REF "${VERSION}"
-    SHA512 aa432822d4c9d7f1328bf59e261c362570f6b2237a5a9f730f96f079aba14bdc689f400ab2857c4cdd1dca025eb09eaaf2b26328f3b42d117f24b9182dc2cc0a
+    SHA512 85907f4c506dea15fd8c7eb203c1f434929a7c47d3a3e10cc1574e9bc31ceb11d373e7f513e98419d7714e905969377de83e62cf87f6fd3e18071bfd563fc9ac
     HEAD_REF master
     PATCHES
         depfindprotobuf.diff

--- a/ports/mysql-connector-cpp/vcpkg.json
+++ b/ports/mysql-connector-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mysql-connector-cpp",
   "version": "9.7.0",
-  "port-version": 4,
   "description": "This is a release of MySQL Connector/C++, the C++ interface for communicating with MySQL servers.",
   "homepage": "https://github.com/mysql/mysql-connector-cpp",
   "license": null,

--- a/ports/mysql-connector-cpp/vcpkg.json
+++ b/ports/mysql-connector-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql-connector-cpp",
-  "version": "9.1.0",
+  "version": "9.7.0",
   "port-version": 4,
   "description": "This is a release of MySQL Connector/C++, the C++ interface for communicating with MySQL servers.",
   "homepage": "https://github.com/mysql/mysql-connector-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6821,8 +6821,8 @@
       "port-version": 0
     },
     "mysql-connector-cpp": {
-      "baseline": "9.1.0",
-      "port-version": 4
+      "baseline": "9.7.0",
+      "port-version": 0
     },
     "mysvac-jsonlib": {
       "baseline": "3.0.0",

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "872c933c6f211c3bc0d40d74ff8590a45cd59c9a",
+      "version": "9.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d3925e7700df18139d037cc12c6a2083b78fb42",
       "version": "9.1.0",
       "port-version": 4


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
