### PR TITLE
[capstone] update to 5.0.8

### DIFF
--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "capstone-engine/capstone"
     REF "${VERSION}"
-    SHA512 e09788d7dfca281f8f3773323d72e1157df777878d59ace6a8996495d505dec10051ce002f473fa5ff8aa60d5e6bb4cff5e55faffb074643cae7c4515e324994
+    SHA512 f02204de6976bdfa9c356fa81ed6324ac51fcf5337b3e2ee4d4eaa40bf472b5fa048c62451d0ef834e8513c8c29e7577d825492fba39c6c3d10e9525a4154500
     HEAD_REF next
     PATCHES
         001-silence-windows-crt-secure-warnings.patch

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "capstone",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1609,7 +1609,7 @@
       "port-version": 0
     },
     "capstone": {
-      "baseline": "5.0.7",
+      "baseline": "5.0.8",
       "port-version": 0
     },
     "cargs": {

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17906cd31b1bf986b95e8ea3433f42e62790d5d8",
+      "version": "5.0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "1aa8b5740e1d6d47b0d2fb9f2af708593939f99f",
       "version": "5.0.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/capstone-engine/capstone/releases/tag/5.0.8
