### PR TITLE
[libbpf] Add new port

### DIFF
--- a/ports/libbpf/0001-enable-static-or-shared.patch
+++ b/ports/libbpf/0001-enable-static-or-shared.patch
@@ -1,0 +1,19 @@
+diff --git a/src/Makefile b/src/Makefile
+index 91cc02a..fe30a96 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -62,12 +62,13 @@ OBJS := bpf.o btf.o libbpf.o libbpf_utils.o netlink.o 			\
+ SHARED_OBJS := $(addprefix $(SHARED_OBJDIR)/,$(OBJS))
+ STATIC_OBJS := $(addprefix $(STATIC_OBJDIR)/,$(OBJS))
+ 
+-STATIC_LIBS := $(OBJDIR)/libbpf.a
+ ifndef BUILD_STATIC_ONLY
+ 	SHARED_LIBS := $(OBJDIR)/libbpf.so \
+ 		       $(OBJDIR)/libbpf.so.$(LIBBPF_MAJOR_VERSION) \
+ 		       $(OBJDIR)/libbpf.so.$(LIBBPF_VERSION)
+ 	VERSION_SCRIPT := libbpf.map
++else
++	STATIC_LIBS := $(OBJDIR)/libbpf.a
+ endif
+ 
+ HEADERS := bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h \

--- a/ports/libbpf/0002-fix-dependency-lookup.patch
+++ b/ports/libbpf/0002-fix-dependency-lookup.patch
@@ -1,0 +1,31 @@
+diff --git a/src/Makefile b/src/Makefile
+index fe30a96..174931f 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -43,15 +43,20 @@ ALL_CFLAGS += $(CFLAGS) 						\
+ ALL_LDFLAGS += $(LDFLAGS) $(EXTRA_LDFLAGS)
+ 
+ ifeq ($(shell command -v $(PKG_CONFIG) 2> /dev/null),)
+-NO_PKG_CONFIG := 1
++$(error pkg-config not found)
+ endif
+-ifdef NO_PKG_CONFIG
+-	ALL_LDFLAGS += -lelf -lz
+-else
+-	ALL_CFLAGS += $(shell $(PKG_CONFIG) --cflags libelf zlib)
+-	ALL_LDFLAGS += $(shell $(PKG_CONFIG) --libs libelf zlib)
++
++ifneq ($(shell $(PKG_CONFIG) --env-only --exists libelf && echo true),true)
++$(error libelf not found)
+ endif
+ 
++ifneq ($(shell $(PKG_CONFIG) --env-only --exists zlib && echo true),true)
++$(error zlib not found)
++endif
++
++ALL_CFLAGS += $(shell $(PKG_CONFIG) --env-only --cflags libelf zlib)
++ALL_LDFLAGS += $(shell $(PKG_CONFIG) --env-only --libs libelf zlib)
++
+ OBJDIR ?= .
+ SHARED_OBJDIR := $(OBJDIR)/sharedobjs
+ STATIC_OBJDIR := $(OBJDIR)/staticobjs

--- a/ports/libbpf/portfile.cmake
+++ b/ports/libbpf/portfile.cmake
@@ -1,0 +1,66 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libbpf/libbpf
+    REF "v${VERSION}"
+    SHA512 29996f76d45222070b7554c1a098d67cf0933876a0fb3965800a304239a7e8dcc4d2ecc3ffe049dfbebe62e29e12cca793c6b22d5845955dd17faff5786691dd
+    HEAD_REF master
+    PATCHES
+        0001-enable-static-or-shared.patch
+        0002-fix-dependency-lookup.patch
+)
+
+find_program(MAKE make REQUIRED)
+
+set(OPTIONS "")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND OPTIONS "BUILD_STATIC_ONLY=y")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(COPY "${SOURCE_PATH}/" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
+    z_vcpkg_setup_pkgconfig_path(CONFIG RELEASE)
+
+    vcpkg_execute_build_process(
+        COMMAND
+            "${MAKE}"
+            "install"
+            "-j${VCPKG_CONCURRENCY}"
+            "PREFIX=${CURRENT_PACKAGES_DIR}"
+            "LIBDIR=${CURRENT_PACKAGES_DIR}/lib"
+            ${OPTIONS}
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src"
+        LOGNAME "make-install-${TARGET_TRIPLET}-rel"
+    )
+
+    z_vcpkg_restore_pkgconfig_path()
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(COPY "${SOURCE_PATH}/" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/")
+    z_vcpkg_setup_pkgconfig_path(CONFIG DEBUG)
+
+    vcpkg_execute_build_process(
+        COMMAND
+            "${MAKE}"
+            "install"
+            "-j${VCPKG_CONCURRENCY}"
+            "PREFIX=${CURRENT_PACKAGES_DIR}/debug"
+            "LIBDIR=${CURRENT_PACKAGES_DIR}/debug/lib"
+            ${OPTIONS}
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src"
+        LOGNAME "make-install-${TARGET_TRIPLET}-dbg"
+    )
+
+    z_vcpkg_restore_pkgconfig_path()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE"
+    "${SOURCE_PATH}/LICENSE.LGPL-2.1"
+    "${SOURCE_PATH}/LICENSE.BSD-2-Clause"
+)
+

--- a/ports/libbpf/vcpkg.json
+++ b/ports/libbpf/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libbpf",
+  "version": "1.7.0",
+  "description": "Supports loading compiled BPF object files into the Linux Kernel",
+  "license": "LGPL-2.1-only OR BSD-2-Clause",
+  "supports": "linux",
+  "dependencies": [
+    "elfutils",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4764,6 +4764,10 @@
       "baseline": "1.4.1",
       "port-version": 0
     },
+    "libbpf": {
+      "baseline": "1.7.0",
+      "port-version": 0
+    },
     "libbson": {
       "baseline": "2.3.0",
       "port-version": 0

--- a/versions/l-/libbpf.json
+++ b/versions/l-/libbpf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aea6aac91b32835628f587b7ec0ea00f0152f35a",
+      "version": "1.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/libbpf/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
