### PR TITLE
[xdp-tools] Add new port

### DIFF
--- a/ports/libbpf/0001-enable-static-or-shared.patch
+++ b/ports/libbpf/0001-enable-static-or-shared.patch
@@ -1,0 +1,19 @@
+diff --git a/src/Makefile b/src/Makefile
+index 91cc02a..fe30a96 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -62,12 +62,13 @@ OBJS := bpf.o btf.o libbpf.o libbpf_utils.o netlink.o 			\
+ SHARED_OBJS := $(addprefix $(SHARED_OBJDIR)/,$(OBJS))
+ STATIC_OBJS := $(addprefix $(STATIC_OBJDIR)/,$(OBJS))
+ 
+-STATIC_LIBS := $(OBJDIR)/libbpf.a
+ ifndef BUILD_STATIC_ONLY
+ 	SHARED_LIBS := $(OBJDIR)/libbpf.so \
+ 		       $(OBJDIR)/libbpf.so.$(LIBBPF_MAJOR_VERSION) \
+ 		       $(OBJDIR)/libbpf.so.$(LIBBPF_VERSION)
+ 	VERSION_SCRIPT := libbpf.map
++else
++	STATIC_LIBS := $(OBJDIR)/libbpf.a
+ endif
+ 
+ HEADERS := bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h \

--- a/ports/libbpf/0002-fix-dependency-lookup.patch
+++ b/ports/libbpf/0002-fix-dependency-lookup.patch
@@ -1,0 +1,31 @@
+diff --git a/src/Makefile b/src/Makefile
+index fe30a96..174931f 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -43,15 +43,20 @@ ALL_CFLAGS += $(CFLAGS) 						\
+ ALL_LDFLAGS += $(LDFLAGS) $(EXTRA_LDFLAGS)
+ 
+ ifeq ($(shell command -v $(PKG_CONFIG) 2> /dev/null),)
+-NO_PKG_CONFIG := 1
++$(error pkg-config not found)
+ endif
+-ifdef NO_PKG_CONFIG
+-	ALL_LDFLAGS += -lelf -lz
+-else
+-	ALL_CFLAGS += $(shell $(PKG_CONFIG) --cflags libelf zlib)
+-	ALL_LDFLAGS += $(shell $(PKG_CONFIG) --libs libelf zlib)
++
++ifneq ($(shell $(PKG_CONFIG) --env-only --exists libelf && echo true),true)
++$(error libelf not found)
+ endif
+ 
++ifneq ($(shell $(PKG_CONFIG) --env-only --exists zlib && echo true),true)
++$(error zlib not found)
++endif
++
++ALL_CFLAGS += $(shell $(PKG_CONFIG) --env-only --cflags libelf zlib)
++ALL_LDFLAGS += $(shell $(PKG_CONFIG) --env-only --libs libelf zlib)
++
+ OBJDIR ?= .
+ SHARED_OBJDIR := $(OBJDIR)/sharedobjs
+ STATIC_OBJDIR := $(OBJDIR)/staticobjs

--- a/ports/libbpf/portfile.cmake
+++ b/ports/libbpf/portfile.cmake
@@ -1,0 +1,66 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libbpf/libbpf
+    REF "v${VERSION}"
+    SHA512 29996f76d45222070b7554c1a098d67cf0933876a0fb3965800a304239a7e8dcc4d2ecc3ffe049dfbebe62e29e12cca793c6b22d5845955dd17faff5786691dd
+    HEAD_REF master
+    PATCHES
+        0001-enable-static-or-shared.patch
+        0002-fix-dependency-lookup.patch
+)
+
+find_program(MAKE make REQUIRED)
+
+set(OPTIONS "")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND OPTIONS "BUILD_STATIC_ONLY=y")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(COPY "${SOURCE_PATH}/" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
+    z_vcpkg_setup_pkgconfig_path(CONFIG RELEASE)
+
+    vcpkg_execute_build_process(
+        COMMAND
+            "${MAKE}"
+            "install"
+            "-j${VCPKG_CONCURRENCY}"
+            "PREFIX=${CURRENT_PACKAGES_DIR}"
+            "LIBDIR=${CURRENT_PACKAGES_DIR}/lib"
+            ${OPTIONS}
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src"
+        LOGNAME "make-install-${TARGET_TRIPLET}-rel"
+    )
+
+    z_vcpkg_restore_pkgconfig_path()
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(COPY "${SOURCE_PATH}/" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/")
+    z_vcpkg_setup_pkgconfig_path(CONFIG DEBUG)
+
+    vcpkg_execute_build_process(
+        COMMAND
+            "${MAKE}"
+            "install"
+            "-j${VCPKG_CONCURRENCY}"
+            "PREFIX=${CURRENT_PACKAGES_DIR}/debug"
+            "LIBDIR=${CURRENT_PACKAGES_DIR}/debug/lib"
+            ${OPTIONS}
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src"
+        LOGNAME "make-install-${TARGET_TRIPLET}-dbg"
+    )
+
+    z_vcpkg_restore_pkgconfig_path()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE"
+    "${SOURCE_PATH}/LICENSE.LGPL-2.1"
+    "${SOURCE_PATH}/LICENSE.BSD-2-Clause"
+)
+

--- a/ports/libbpf/vcpkg.json
+++ b/ports/libbpf/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libbpf",
+  "version": "1.7.0",
+  "description": "Supports loading compiled BPF object files into the Linux Kernel",
+  "license": "LGPL-2.1-only OR BSD-2-Clause",
+  "supports": "linux",
+  "dependencies": [
+    "elfutils",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/ports/xdp-tools/0001-disable-unused-deps-check.patch
+++ b/ports/xdp-tools/0001-disable-unused-deps-check.patch
@@ -1,0 +1,20 @@
+diff --git a/configure b/configure
+index d57b2ae..f6230ef 100755
+--- a/configure
++++ b/configure
+@@ -395,15 +395,6 @@ EOF
+     echo 'LDLIBS += -l:libbpf.a' >>$CONFIG
+     echo "OBJECT_LIBBPF = ${OBJECT_LIBBPF}" >>$CONFIG
+ 
+-    echo -n "zlib support: "
+-    check_zlib || exit 1
+-
+-    echo -n "ELF support: "
+-    check_elf || exit 1
+-
+-    echo -n "pcap support: "
+-    check_pcap || exit 1
+-
+ }
+ 
+ check_secure_getenv()

--- a/ports/xdp-tools/0002-enable-static-or-shared.patch
+++ b/ports/xdp-tools/0002-enable-static-or-shared.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 7ea7e7e..3f1eab6 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -13,7 +13,9 @@ XDP_OBJS := xdp-dispatcher.o xsk_def_xdp_prog.o xsk_def_xdp_prog_5.3.o
+ EMBEDDED_XDP_OBJS := $(addsuffix .embed.o,$(basename $(XDP_OBJS)))
+ SHARED_OBJS := $(addprefix $(SHARED_OBJDIR)/,$(OBJS))
+ STATIC_OBJS := $(addprefix $(STATIC_OBJDIR)/,$(OBJS)) $(EMBEDDED_XDP_OBJS)
++ifdef BUILD_STATIC
+ STATIC_LIBS := $(OBJDIR)/libxdp.a
++endif
+ MAN_PAGE := libxdp.3
+ MAN_OBJ := ${MAN_PAGE:.3=.man}
+ MAN_FILES := $(MAN_PAGE)
+@@ -31,7 +33,7 @@ CFLAGS += -I$(HEADER_DIR)
+ BPF_CFLAGS += -I$(HEADER_DIR) $(ARCH_INCLUDES)
+ 
+ 
+-ifndef BUILD_STATIC_ONLY
++ifdef BUILD_SHARED
+ SHARED_LIBS := $(OBJDIR)/libxdp.so \
+ 	       $(OBJDIR)/libxdp.so.$(LIBXDP_MAJOR_VERSION) \
+ 	       $(OBJDIR)/libxdp.so.$(LIBXDP_VERSION)

--- a/ports/xdp-tools/0003-suppress-object-file-install.patch
+++ b/ports/xdp-tools/0003-suppress-object-file-install.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 3f1eab6..4208f23 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -55,11 +55,9 @@ install: all
+ 	$(Q)install -d -m 0755 $(DESTDIR)$(HDRDIR)
+ 	$(Q)install -d -m 0755 $(DESTDIR)$(LIBDIR)
+ 	$(Q)install -d -m 0755 $(DESTDIR)$(LIBDIR)/pkgconfig
+-	$(Q)install -d -m 0755 $(DESTDIR)$(BPF_OBJECT_DIR)
+ 	$(Q)install -m 0644 $(LIB_HEADERS) $(DESTDIR)$(HDRDIR)/
+ 	$(Q)install -m 0644 $(PC_FILE) $(DESTDIR)$(LIBDIR)/pkgconfig/
+ 	$(Q)cp -fpR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
+-	$(Q)install -m 0644 $(XDP_OBJS) $(DESTDIR)$(BPF_OBJECT_DIR)
+ 	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
+ 	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)
+ 	$(Q)$(MAKE) -C $(TEST_DIR) install

--- a/ports/xdp-tools/0004-disable-tests.patch
+++ b/ports/xdp-tools/0004-disable-tests.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 4208f23..40975ad 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -41,7 +41,7 @@ VERSION_SCRIPT := libxdp.map
+ CHECK_RULES := check_abi
+ endif
+ 
+-all: $(STATIC_LIBS) $(SHARED_LIBS) $(XDP_OBJS) $(PC_FILE) check man build_tests
++all: $(STATIC_LIBS) $(SHARED_LIBS) $(XDP_OBJS) $(PC_FILE) check man
+ 
+ .PHONY: clean
+ clean:
+@@ -60,7 +60,6 @@ install: all
+ 	$(Q)cp -fpR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
+ 	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
+ 	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)
+-	$(Q)$(MAKE) -C $(TEST_DIR) install
+ 
+ 
+ $(OBJDIR)/libxdp.a: $(STATIC_OBJS)

--- a/ports/xdp-tools/0005-disable-docs.patch
+++ b/ports/xdp-tools/0005-disable-docs.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 40975ad..0b34845 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -41,7 +41,7 @@ VERSION_SCRIPT := libxdp.map
+ CHECK_RULES := check_abi
+ endif
+ 
+-all: $(STATIC_LIBS) $(SHARED_LIBS) $(XDP_OBJS) $(PC_FILE) check man
++all: $(STATIC_LIBS) $(SHARED_LIBS) $(XDP_OBJS) $(PC_FILE) check
+ 
+ .PHONY: clean
+ clean:
+@@ -58,8 +58,6 @@ install: all
+ 	$(Q)install -m 0644 $(LIB_HEADERS) $(DESTDIR)$(HDRDIR)/
+ 	$(Q)install -m 0644 $(PC_FILE) $(DESTDIR)$(LIBDIR)/pkgconfig/
+ 	$(Q)cp -fpR $(SHARED_LIBS) $(STATIC_LIBS) $(DESTDIR)$(LIBDIR)
+-	$(if $(MAN_FILES),$(Q)install -m 0755 -d $(DESTDIR)$(MANDIR)/man3)
+-	$(if $(MAN_FILES),$(Q)install -m 0644 $(MAN_FILES) $(DESTDIR)$(MANDIR)/man3)
+ 
+ 
+ $(OBJDIR)/libxdp.a: $(STATIC_OBJS)

--- a/ports/xdp-tools/portfile.cmake
+++ b/ports/xdp-tools/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xdp-project/xdp-tools
+    REF "v${VERSION}"
+    SHA512 13c045af6a039cfcfbd5987a34c613a4f8767a1371d5d954d51fdaeed8dc8649388f87dd209135bfa5d6f759a9ee8316ee2b4e6779c3c16869d9f1d046bb4713
+    HEAD_REF main
+    PATCHES
+        0001-disable-unused-deps-check.patch
+        0002-enable-static-or-shared.patch
+        0003-suppress-object-file-install.patch
+        0004-disable-tests.patch
+        0005-disable-docs.patch
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    COPY_SOURCE
+)
+
+set(OPTIONS "")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND OPTIONS "BUILD_STATIC=True")
+endif()
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    list(APPEND OPTIONS "BUILD_SHARED=True")
+endif()
+
+vcpkg_make_install(
+    TARGETS libxdp_install
+    OPTIONS
+        ${OPTIONS}
+    OPTIONS_DEBUG
+        "PREFIX=${CMAKE_PACKAGES_DIR}/debug"
+    OPTIONS_RELEASE
+        "PREFIX=${CMAKE_PACKAGES_DIR}"
+)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/xdp-tools/vcpkg.json
+++ b/ports/xdp-tools/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "xdp-tools",
+  "version": "1.6.3",
+  "description": "Library for working with the eXpress Data Path facility of the Linux kernel",
+  "supports": "linux",
+  "dependencies": [
+    "libbpf",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4764,6 +4764,10 @@
       "baseline": "1.4.1",
       "port-version": 0
     },
+    "libbpf": {
+      "baseline": "1.7.0",
+      "port-version": 0
+    },
     "libbson": {
       "baseline": "2.3.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11032,6 +11032,10 @@
       "baseline": "0.5.0",
       "port-version": 0
     },
+    "xdp-tools": {
+      "baseline": "1.6.3",
+      "port-version": 0
+    },
     "xerces-c": {
       "baseline": "3.3.0",
       "port-version": 1

--- a/versions/l-/libbpf.json
+++ b/versions/l-/libbpf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aea6aac91b32835628f587b7ec0ea00f0152f35a",
+      "version": "1.7.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/x-/xdp-tools.json
+++ b/versions/x-/xdp-tools.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7ff0541096f6ee8f2e6eef6eb9c9df0f882804ea",
+      "version": "1.6.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.