### PR TITLE
[stescobedo92-azdash] Add new port

### DIFF
--- a/ports/stescobedo92-azdash/portfile.cmake
+++ b/ports/stescobedo92-azdash/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO stescobedo92/az-dashboard
+    REF v0.1.0
+    SHA512 bee34cfb8db6591f8eca7bd442dba8db9f04c9bec222cf54590c8d9aff4001e047d0e5dbf6b96527ec8a28be0565ab31605b54bb80f9f84b7030c4be9ff9c304
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAZ_DASHBOARD_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME az-dashboard CONFIG_PATH lib/cmake/az-dashboard)
+vcpkg_copy_tools(TOOL_NAMES azdash AUTO_CLEAN)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/stescobedo92-azdash/vcpkg.json
+++ b/ports/stescobedo92-azdash/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "stescobedo92-azdash",
+  "version": "0.1.0",
+  "description": "azdash is an Azure-focused C++23 CLI for Azure spending, six-month cost trends, and waste signals, rendered with FTXUI tables, JSON, CSV, or PDF reports.",
+  "homepage": "https://github.com/stescobedo92/az-dashboard",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "ftxui",
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9676,6 +9676,10 @@
       "baseline": "0.0.1",
       "port-version": 1
     },
+    "stescobedo92-azdash": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "stescobedo92-stellar": {
       "baseline": "0.1.0",
       "port-version": 0

--- a/versions/s-/stescobedo92-azdash.json
+++ b/versions/s-/stescobedo92-azdash.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "91e3ac5ae068b7eb6d9966a752531409a3a3f7b1",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds the `stescobedo92-azdash` port for the `azdash` CLI.

`azdash` is an Azure-focused C++23 command-line tool for Azure spending, six-month cost trends, and waste signals, with FTXUI table output plus JSON, CSV, and PDF report formats.

Validation performed:
- Generated the vcpkg version database entry with `vcpkg x-add-version stescobedo92-azdash --overwrite-version`.
- Verified the release archive SHA512 from `stescobedo92/az-dashboard` tag `v0.1.0`.
- Installed the port locally with `vcpkg install --classic --vcpkg-root /Users/stescobedo/vcpkg --overlay-ports=/tmp/azdash-vcpkg/ports --triplet=arm64-osx stescobedo92-azdash`.

Note: this port installs the `azdash` CLI tool and exposes the generated CMake package from the upstream project.