### PR TITLE
[cxxmcp] Add new port

### DIFF
--- a/ports/cxxmcp/portfile.cmake
+++ b/ports/cxxmcp/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO caomengxuan666/cxxmcp
+    REF "v${VERSION}"
+    SHA512 e40c49977533fa0d4cef3b5d6eaef5f25bf71743f38942f993fcf19dac3dbf199d0b656d1b9fac2e2d13dfc5b887e6028845d4080cef8a837c133aa77dd62de6
+    HEAD_REF master
+)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCXXMCP_BUILD_SDK=ON
+        -DCXXMCP_BUILD_RUNTIME=OFF
+        -DCXXMCP_BUILD_APP=OFF
+        -DCXXMCP_BUILD_GATEWAY=OFF
+        -DCXXMCP_BUILD_CLI=OFF
+        -DCXXMCP_BUILD_EXAMPLES=OFF
+        -DCXXMCP_BUILD_TESTS=OFF
+        -DCXXMCP_BUILD_DOCS=OFF
+        -DCXXMCP_USE_SYSTEM_DEPS=ON
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME cxxmcp CONFIG_PATH lib/cmake/cxxmcp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cxxmcp/usage
+++ b/ports/cxxmcp/usage
@@ -1,0 +1,14 @@
+cxxmcp provides CMake targets:
+
+  find_package(cxxmcp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE cxxmcp::sdk)
+
+Narrow targets are also available:
+
+  cxxmcp::protocol
+  cxxmcp::transport
+  cxxmcp::handler
+  cxxmcp::peer
+  cxxmcp::service
+  cxxmcp::client
+  cxxmcp::server

--- a/ports/cxxmcp/vcpkg.json
+++ b/ports/cxxmcp/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "cxxmcp",
+  "version-semver": "2.0.2",
+  "description": "C++ MCP SDK for protocol, client, server, transport, peer, and handler APIs.",
+  "homepage": "https://github.com/caomengxuan666/cxxmcp",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "cpp-httplib",
+      "default-features": false
+    },
+    "nlohmann-json",
+    "tl-expected",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2340,6 +2340,10 @@
       "baseline": "4.1.0",
       "port-version": 0
     },
+    "cxxmcp": {
+      "baseline": "2.0.2",
+      "port-version": 0
+    },
     "cxxopts": {
       "baseline": "3.3.1",
       "port-version": 1

--- a/versions/c-/cxxmcp.json
+++ b/versions/c-/cxxmcp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "355237577782d56f047098d0674d4ca6fdaf030c",
+      "version-semver": "2.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds the cxxmcp v2.0.2 port.

Validation performed locally:
- `vcpkg format-manifest ports/cxxmcp/vcpkg.json`
- `vcpkg x-add-version cxxmcp --overwrite-version`
- `vcpkg install cxxmcp:x64-windows-static`