### PR TITLE
[ada-idna] Update to 0.5.5

### DIFF
--- a/ports/ada-idna/portfile.cmake
+++ b/ports/ada-idna/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/idna
     REF "${VERSION}"
-    SHA512 55ddf9799c81ee8a50be591db9858dca3db507a12c7b9c9387e8171ccb38e61416344da9abe86979a35158b196ea8980cbba798720ae8ab630e4efce612a8e38
+    SHA512 2ac71b37b71a3335fe11fd24b3e734447ff939d9c3ec502580e089b6b604f64f0744da1d059f1ee205bbdbccaf0756df3bd4f345dbe95908f6e4c54ce09b234c
     HEAD_REF main
     PATCHES
         install.patch

--- a/ports/ada-idna/vcpkg.json
+++ b/ports/ada-idna/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-idna",
-  "version": "0.5.2",
+  "version": "0.5.5",
   "description": "C++ library implementing the to_ascii and to_unicode functions from the Unicode Technical Standard.",
   "homepage": "https://github.com/ada-url/idna",
   "license": "Apache-2.0 AND MIT",

--- a/versions/a-/ada-idna.json
+++ b/versions/a-/ada-idna.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "961ff63aab1baf70a370b6dad650d4a938574f2a",
+      "version": "0.5.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "762b193dbd00ff145a0eff5f1d17f9b61536b23f",
       "version": "0.5.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,7 +41,7 @@
       "port-version": 18
     },
     "ada-idna": {
-      "baseline": "0.5.2",
+      "baseline": "0.5.5",
       "port-version": 0
     },
     "ada-url": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.5.5