### PR TITLE
[faiss] Update to 1.14.2

### DIFF
--- a/ports/faiss/msvc-arm64-simd.diff
+++ b/ports/faiss/msvc-arm64-simd.diff
@@ -1,0 +1,13 @@
+diff --git a/faiss/impl/simdlib/simdlib_dispatch.h b/faiss/impl/simdlib/simdlib_dispatch.h
+index 374a365..934a47f 100644
+--- a/faiss/impl/simdlib/simdlib_dispatch.h
++++ b/faiss/impl/simdlib/simdlib_dispatch.h
+@@ -32,7 +32,7 @@
+ 
+ #include <faiss/impl/simdlib/simdlib_avx2.h>
+ 
+-#elif defined(COMPILE_SIMD_ARM_NEON) && defined(__aarch64__)
++#elif defined(COMPILE_SIMD_ARM_NEON) && (defined(__aarch64__) || defined(_M_ARM64))
+ 
+ #include <faiss/impl/simdlib/simdlib_neon.h>
+ 

--- a/ports/faiss/portfile.cmake
+++ b/ports/faiss/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookresearch/faiss
     REF "v${VERSION}"
-    SHA512 f4f1e392a3b25d5523cd1f4a6293f13018703687aeb609fafc93e2d99b3c8bba1d7a2ae300ec9ceea7750d66517c688d1a2b1160f98edfea37b78d218804f9ed
+    SHA512 863784dbc2837f42c0803b47e435ffdf0fc46c820924a03174267ccc2472aa182c6d6a074e4e8b8240ca71ec81be940d9d7554d1487dfe3c98ce7d444dcd9d9b
     HEAD_REF master
     PATCHES
         msvc-template.diff

--- a/ports/faiss/portfile.cmake
+++ b/ports/faiss/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         msvc-template.diff
         undef-small.diff
+        msvc-arm64-simd.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -20,6 +21,9 @@ if ("gpu" IN_LIST FEATURES)
         "-DCMAKE_CUDA_COMPILER=${NVCC}"
         "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
     )
+    if(VCPKG_TARGET_IS_WINDOWS)
+        list(APPEND FEATURE_OPTIONS "-DCMAKE_CUDA_FLAGS=-Xcompiler=/Zc:preprocessor")
+    endif()
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faiss",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://faiss.ai/",
   "license": "MIT",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -280,7 +280,6 @@ ensmallen[openmp]:arm64-osx=feature-fails # No openmp on default osx toolchain
 entt[experimental]=skip # required head build
 f3d:arm64-linux=cascade
 faad2:arm64-linux=fail
-faiss:arm64-linux=cascade
 faiss:arm64-osx=fail # No openmp on default osx toolchain
 faiss[gpu](!(windows & x64) & !(linux & x64))=cascade
 fbgemm:arm64-osx=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2913,7 +2913,7 @@
       "port-version": 3
     },
     "faiss": {
-      "baseline": "1.14.1",
+      "baseline": "1.14.2",
       "port-version": 0
     },
     "fakeit": {

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19b364f3c56397315f98eec4bd78b6172969c977",
+      "version": "1.14.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e0d08130d2f86a9e82fab9c4ad6c9006460816f",
       "version": "1.14.1",
       "port-version": 0

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "19b364f3c56397315f98eec4bd78b6172969c977",
+      "git-tree": "262b02f67926e6ab1613a3d7f2ce154cc1d9d906",
       "version": "1.14.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.14.2
