### PR TITLE
[intrusive-shared-ptr] Update to 1.11

### DIFF
--- a/ports/intrusive-shared-ptr/portfile.cmake
+++ b/ports/intrusive-shared-ptr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gershnik/intrusive_shared_ptr
     REF "v${VERSION}"
-    SHA512 90bbd66365df7d5e4c4ce96a3cd226a77fa224554dba525de9dd7d7aba20c59ef4759286f5f70ffe494144265c318ef0b4646a7f1461d70955cb5a2e80785519
+    SHA512 f4e8ebf58d4a51e04c951cef7f8726094a3f3892df582871c3f44d1b39cb289ccb4d3919e454527fadd5efeb69a186df9de4d0c1746a230cdb44ae7f8380ed4d
     HEAD_REF master
 )
 

--- a/ports/intrusive-shared-ptr/vcpkg.json
+++ b/ports/intrusive-shared-ptr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "intrusive-shared-ptr",
-  "version": "1.10",
+  "version": "1.11",
   "description": "Intrusive reference counting smart pointer, highly configurable reference counted base class and various adapters. Also known as libisptr.",
   "homepage": "https://github.com/gershnik/intrusive_shared_ptr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4049,7 +4049,7 @@
       "port-version": 7
     },
     "intrusive-shared-ptr": {
-      "baseline": "1.10",
+      "baseline": "1.11",
       "port-version": 0
     },
     "intx": {

--- a/versions/i-/intrusive-shared-ptr.json
+++ b/versions/i-/intrusive-shared-ptr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74581785ee94b773e963852f67a995dce2a306cb",
+      "version": "1.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "1443631677a13ca305f112550eae6e356da59870",
       "version": "1.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.11
