### PR TITLE
[level-zero] Update to 1.28.6

### DIFF
--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/level-zero
     REF "v${VERSION}"
-    SHA512 3d97c903c23efccca7c9e2d652db8c0e263be87b1e823b79612effac0432836b1a538b263740fbd464687f88ced5402a6d3883206e30a70375d6ae82fd6da2c3
+    SHA512 ada1978dc80d0e1441fe41faf5cd2ac0bd6ab8dbb4f30745f1686c5c42b425dc47bd7991c6754cb50a52dadb7211245358544157be909a3c968b9e94011c8a2f
     HEAD_REF master
     PATCHES spdlog_include.patch
 )

--- a/ports/level-zero/vcpkg.json
+++ b/ports/level-zero/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "level-zero",
-  "version": "1.28.2",
+  "version": "1.28.6",
   "description": "oneAPI Level Zero Specification Headers and Loader.",
   "homepage": "https://github.com/oneapi-src/level-zero",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4661,7 +4661,7 @@
       "port-version": 0
     },
     "level-zero": {
-      "baseline": "1.28.2",
+      "baseline": "1.28.6",
       "port-version": 0
     },
     "leveldb": {

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "741b2224a777dd365dc67a01704759565a9ce9f5",
+      "version": "1.28.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "515603661d309acd2df3edf8286dfdfab43f238c",
       "version": "1.28.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.28.6
