### PR TITLE
[libsigcpp] Update to 3.8.1

### DIFF
--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsigcplusplus/libsigcplusplus
     REF "${VERSION}"
-    SHA512 8fc90594fe161a4fd82b88fe4b0cb5b667d61712dae47982ba569775b4a855e03d4b30d3ba232f96e6a98f87473f7c9d4948b7a17a3f9ca2da547f95b6f91a40
+    SHA512 39c63131fdde701c08accc0bc318435fba65a01593f97d6fa61ad356a6a3441610810107fb7aded7b3ef48e34a603e513a43cf8c36a57d2286f54d41ead412c6
     HEAD_REF master
     PATCHES
         disable_tests_enable_static_build.patch

--- a/ports/libsigcpp/vcpkg.json
+++ b/ports/libsigcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libsigcpp",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Typesafe callback framework for C++",
   "homepage": "https://libsigcplusplus.github.io/libsigcplusplus/",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5609,7 +5609,7 @@
       "port-version": 0
     },
     "libsigcpp": {
-      "baseline": "3.8.0",
+      "baseline": "3.8.1",
       "port-version": 0
     },
     "libslirp": {

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "123e064e4cdd79ba500422c0117971bcf812edb3",
+      "version": "3.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ba1c1f9f00c4a0051889a9584c442251c2134dd0",
       "version": "3.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 3.8.1
