### PR TITLE
[minizip-ng] Update to 4.2.1

### DIFF
--- a/ports/minizip-ng/dependencies.diff
+++ b/ports/minizip-ng/dependencies.diff
@@ -1,69 +1,31 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c684e3e..c3b6fff 100644
+index 1cf379c..19329e3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -254,7 +254,7 @@ if(MZ_BZIP2)
-         list(APPEND MINIZIP_LIB ${BZIP2_LIBRARIES})
-         list(APPEND MINIZIP_LBD ${BZIP2_LIBRARY_DIRS})
+@@ -282,7 +282,7 @@ if(MZ_BZIP2)
+ 
+         list(APPEND MINIZIP_LIB BZip2::BZip2)
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lbz2")
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} bzip2")
++        string(APPEND PC_PRIVATE_DEPS " bzip2")
      elseif(MZ_FETCH_LIBS)
          clone_repo(bzip2 https://sourceware.org/git/bzip2.git master)
  
-@@ -298,7 +298,6 @@ if(MZ_LZMA)
-     if(NOT MZ_FORCE_FETCH_LIBS)
-         find_package(PkgConfig QUIET)
-         if(PKGCONFIG_FOUND)
--            pkg_check_modules(LIBLZMA liblzma)
-         endif()
-         if(NOT LIBLZMA_FOUND)
-             find_package(LibLZMA QUIET)
-@@ -313,7 +312,7 @@ if(MZ_LZMA)
-         list(APPEND MINIZIP_LIB ${LIBLZMA_LIBRARIES})
-         list(APPEND MINIZIP_LBD ${LIBLZMA_LIBRARY_DIRS})
+@@ -334,7 +334,7 @@ if(MZ_LZMA)
+ 
+         list(APPEND MINIZIP_LIB LibLZMA::LibLZMA)
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -llzma")
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} liblzma")
++        string(APPEND PC_PRIVATE_DEPS " liblzma")
      elseif(MZ_FETCH_LIBS)
          set(BUILD_TESTING OFF CACHE BOOL "Build lzma tests" FORCE)
  
-@@ -344,10 +343,9 @@ if(MZ_ZSTD)
-     if(NOT MZ_FORCE_FETCH_LIBS)
-         find_package(PkgConfig QUIET)
-         if(PKGCONFIG_FOUND)
--            pkg_check_modules(ZSTD libzstd)
+@@ -411,7 +411,7 @@ if(MZ_ZSTD)
+             list(APPEND MINIZIP_LIB zstd::libzstd_static)
          endif()
-         if(NOT ZSTD_FOUND)
--            find_package(ZSTD QUIET)
-+            find_package(ZSTD NAMES zstd REQUIRED)
-             if(ZSTD_FOUND)
-                 if(TARGET zstd::libzstd_static)
-                     list(APPEND ZSTD_LIBRARIES zstd::libzstd_static)
-@@ -365,7 +363,7 @@ if(MZ_ZSTD)
-         list(APPEND MINIZIP_LIB ${ZSTD_LIBRARIES})
-         list(APPEND MINIZIP_LBD ${ZSTD_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lzstd")
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} libzstd")
++        string(APPEND PC_PRIVATE_DEPS " libzstd")
      elseif(MZ_FETCH_LIBS)
          set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "Build zstd programs")
- 
-@@ -405,7 +403,6 @@ if(MZ_OPENSSL)
-     # Check to see if openssl installation is present
-     find_package(PkgConfig)
-     if(PKGCONFIG_FOUND)
--        pkg_check_modules(OPENSSL openssl)
-     endif()
-     if(NOT OPENSSL_FOUND)
-         find_package(OpenSSL)
-@@ -426,8 +423,8 @@ if(MZ_OPENSSL)
-         endif()
- 
-         foreach(i ${OPENSSL_LIBRARIES})
--            set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -l${i}")
-         endforeach()
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} openssl")
-     else()
-         message(STATUS "OpenSSL library not found")
  

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DMZ_PPMD=OFF
         -DMZ_FETCH_LIBS=OFF
         -DMZ_LIB_SUFFIX=-ng
         -DMZ_ICONV=OFF

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
     REF "${VERSION}"
-    SHA512 9ea5dde14acd2f7d1efd0e38b11017b679d3aaabac61552f9c5f4c7f45f2563543e0fbb2d74429c6b1b9c37d8728ebc4f1cf0efad5f71807c11bb8a2a681a556
+    SHA512 606962a5939103d6045e05742f56d7a000708ee41a021dcd2583c534ab5944eb5d81c09bde37d891eaed8bdd6263513e94e73f89628225a68e36675342eb70d8
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "minizip-ng",
-  "version": "4.1.0",
+  "version": "4.2.1",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6585,7 +6585,7 @@
       "port-version": 1
     },
     "minizip-ng": {
-      "baseline": "4.1.0",
+      "baseline": "4.2.1",
       "port-version": 0
     },
     "mio": {

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "31fffe371e0dfb188da59bb63ebea71d8182f3de",
+      "git-tree": "7602a024afb146da268992dc25d4ff5b6c13f8bb",
       "version": "4.2.1",
       "port-version": 0
     },

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ca5a2cf474e23e0049a9e733315638ce8a6d1072",
+      "git-tree": "31fffe371e0dfb188da59bb63ebea71d8182f3de",
       "version": "4.2.1",
       "port-version": 0
     },

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca5a2cf474e23e0049a9e733315638ce8a6d1072",
+      "version": "4.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b6677369c4d8c677604963a4f97f075db0d18948",
       "version": "4.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 4.2.1
