### PR TITLE
[numkong] Update to 7.7.0

### DIFF
--- a/ports/numkong/portfile.cmake
+++ b/ports/numkong/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/NumKong
     REF "v${VERSION}"
-    SHA512 0454cc0168d3cd3a3d176cdfc879bfa2b4752b036248f7a7445a22dd1bd0c1f1c78a68e50fd15c8d0f0c10d234de28cc3cea906c37d01850e8939aecddd86b91
+    SHA512 3cc697c7b65e65ad9735c3e5211f3b0e7b86df2469dc56dd19be0323b9e22c939ab69d98828c4071c6a4490140cabd56c2765297a7d5a83bf159d4b957b90b34
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/numkong/vcpkg.json
+++ b/ports/numkong/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "numkong",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "NumKong (previously SimSIMD) delivers mixed-precision numerics that are often faster and more accurate than standard BLAS libraries",
   "homepage": "https://github.com/ashvardanian/NumKong",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7121,7 +7121,7 @@
       "port-version": 0
     },
     "numkong": {
-      "baseline": "7.6.0",
+      "baseline": "7.7.0",
       "port-version": 0
     },
     "nuraft": {

--- a/versions/n-/numkong.json
+++ b/versions/n-/numkong.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "535213d45c47da257333827db5f5958454a75f44",
+      "version": "7.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e80b3d4e584e487b26051726e473813384194cc1",
       "version": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 7.7.0
