### PR TITLE
[materialx] update to 1.39.5

### DIFF
--- a/ports/materialx/portfile.cmake
+++ b/ports/materialx/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         osl-generator  MATERIALX_BUILD_GEN_OSL
         render         MATERIALX_BUILD_RENDER
 )
-if ((VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_LINUX) AND MATERIALX_BUILD_RENDER)
+if (VCPKG_TARGET_IS_LINUX AND MATERIALX_BUILD_RENDER)
     message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libx11-dev\n\nThese can be installed on Ubuntu systems via apt-get install libx11-dev.")
 endif()
 

--- a/ports/materialx/portfile.cmake
+++ b/ports/materialx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/MaterialX
     REF "v${VERSION}"
-    SHA512 ca743e619f51bddd67419c79a31e9fb92dd7883e8c182897c1d8cea2e5dc51cddf13ac8cc798cfa0f022dacf4fd77881aefc24f3184f8b7273651ba55c7df400
+    SHA512 a9af568dd2918a2679de1727295178a3155cb63a1b1a58eec0ff2bf804031e716918c036546916cfdab2ef1fcbe3cc2edc34037a082f7a50f0c6852236b8e449
     HEAD_REF main
 )
 

--- a/ports/materialx/vcpkg.json
+++ b/ports/materialx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "materialx",
-  "version": "1.39.1",
-  "port-version": 2,
+  "version": "1.39.5",
   "description": "MaterialX is an open standard for the exchange of rich material and look-development content across applications and renderers.",
   "homepage": "https://www.materialx.org/",
   "license": "Apache-2.0",

--- a/ports/materialx/vcpkg.json
+++ b/ports/materialx/vcpkg.json
@@ -26,7 +26,8 @@
       "description": "Build the OSL shader generator back-end."
     },
     "render": {
-      "description": "Build the MaterialX Render library."
+      "description": "Build the MaterialX Render library.",
+      "supports": "!android"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6381,8 +6381,8 @@
       "port-version": 0
     },
     "materialx": {
-      "baseline": "1.39.1",
-      "port-version": 2
+      "baseline": "1.39.5",
+      "port-version": 0
     },
     "mathc": {
       "baseline": "2019-09-29",

--- a/versions/m-/materialx.json
+++ b/versions/m-/materialx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8df7e0815f6d1771b61014cfc9d331069fdbe2bf",
+      "version": "1.39.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a401e399f881b616c7767fc13722ef8c6c40fb14",
       "version": "1.39.1",
       "port-version": 2

--- a/versions/m-/materialx.json
+++ b/versions/m-/materialx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8df7e0815f6d1771b61014cfc9d331069fdbe2bf",
+      "git-tree": "05a53e79f1bb4431e478caca3987c6d6477299e5",
       "version": "1.39.5",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/AcademySoftwareFoundation/MaterialX/releases/tag/v1.39.5
