### PR TITLE
Llvm

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -1,5 +1,12 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+# [ADT] Add <cstdint> to SmallVector #101761
+vcpkg_download_distfile(PATCH_101761
+    URLS https://github.com/llvm/llvm-project/commit/7e44305041d96b064c197216b931ae3917a34ac1.diff?full_index=1
+    SHA512 cf65b28bd40418d713a8f5a7fe97fc22d96e6031523dbf060b49e7bac1a6f86e597ca66c03d2435ed3e8a2f8eadb5c800804cc20a2b8f16c2b0070684952053d
+    FILENAME llvm_101761.patch 
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llvm/llvm-project
@@ -18,6 +25,7 @@ vcpkg_from_github(
         82407.patch # [Clang][Sema] Fix incorrect rejection default construction of union with nontrivial member #82407
         add-include-chrono.patch # https://github.com/llvm/llvm-project/pull/118059
         cmake4.patch
+        "${PATCH_101761}"
 )
 
 vcpkg_check_features(

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "18.1.6",
-  "port-version": 5,
+  "port-version": 6,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0 WITH LLVM-exception",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6134,7 +6134,7 @@
     },
     "llvm": {
       "baseline": "18.1.6",
-      "port-version": 5
+      "port-version": 6
     },
     "lmdb": {
       "baseline": "0.9.35",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46451897df11095a01d24be776d9b0ad16f02250",
+      "version": "18.1.6",
+      "port-version": 6
+    },
+    {
       "git-tree": "680d20d34077e7f0937b68f8f9bcd22fac6bd11e",
       "version": "18.1.6",
       "port-version": 5


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.