### PR TITLE
[llvm] Fix GCC15 build

### DIFF
--- a/ports/llvm/0007-fix-missing-includes.patch
+++ b/ports/llvm/0007-fix-missing-includes.patch
@@ -1,0 +1,24 @@
+diff --git a/llvm/include/llvm/ADT/SmallVector.h b/llvm/include/llvm/ADT/SmallVector.h
+index 09676d792..17444147b 100644
+--- a/llvm/include/llvm/ADT/SmallVector.h
++++ b/llvm/include/llvm/ADT/SmallVector.h
+@@ -19,6 +19,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>
+diff --git a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+index 437a7bd6f..fd7d79484 100644
+--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -13,6 +13,7 @@
+ #ifndef LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         0004-disable-libomp-aliases.patch
         0005-remove-numpy.patch
         0006-create-destination-mlir-directory.patch
+        0007-fix-missing-includes.patch
         75711.patch # [clang] Add intrin0.h header to mimic intrin0.h used by MSVC STL for clang-cl #75711
         79694.patch # [SEH] Ignore EH pad check for internal intrinsics #79694
         82407.patch # [Clang][Sema] Fix incorrect rejection default construction of union with nontrivial member #82407

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "18.1.6",
-  "port-version": 5,
+  "port-version": 6,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0 WITH LLVM-exception",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6134,7 +6134,7 @@
     },
     "llvm": {
       "baseline": "18.1.6",
-      "port-version": 5
+      "port-version": 6
     },
     "lmdb": {
       "baseline": "0.9.35",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2b6e11b439fb46388c88f81793fb09cc3b045a0",
+      "version": "18.1.6",
+      "port-version": 6
+    },
+    {
       "git-tree": "680d20d34077e7f0937b68f8f9bcd22fac6bd11e",
       "version": "18.1.6",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
