### PR TITLE
[aws-c-cal] Update to 0.9.14

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-cal
     REF "v${VERSION}"
-    SHA512 62b84c3bbe9deb1618c66e29f2211c4462fdd85a1a71d63cc815f57cdbde653e659435630471c067688bf0975825717ee1148ab4e1c25e764e37917fb59dff11
+    SHA512 c78bf0a1bc96eaedc6c5eb93020b2925bf7b7f2c99b3603181381b2e007c0a601e54a2d1bf9a52759150f911a19e60a7b14f286d6dd8acc5ebfb40144db1a9b7
     HEAD_REF master
     PATCHES remove-libcrypto-messages.patch
 )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-cal",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ba27874e26d9f11b9c697f5a1072e75dc64c8be",
+      "version": "0.9.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5b466fcf369984cbffde978f0cf7f93b93b724b",
       "version": "0.9.13",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -457,7 +457,7 @@
       "port-version": 0
     },
     "aws-c-cal": {
-      "baseline": "0.9.13",
+      "baseline": "0.9.14",
       "port-version": 0
     },
     "aws-c-common": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.9.14
