### PR TITLE
[aws-c-mqtt] Update to 0.16.0

### DIFF
--- a/ports/aws-c-mqtt/portfile.cmake
+++ b/ports/aws-c-mqtt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-mqtt
     REF "v${VERSION}"
-    SHA512 7c3f142c1a8631e50f0dc92cbc3a24aa87c8dedc4c667f0d60d5f6fb73072cb22e186e654547f1a76a2fffeb9d9c2450b1ce7ce91d30a2d47dbd081c0b4dfe17
+    SHA512 10bff6e2e7d84bcc67e62a83ce91e9ecd5e9cae31a41e749707219d4cc9d5bb694718388de1e4d010f7b14cad580f5cdc4becbdfa502ee9f509d350592e4fffb
     HEAD_REF master
 )
 

--- a/ports/aws-c-mqtt/vcpkg.json
+++ b/ports/aws-c-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-mqtt",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "C99 implementation of the MQTT 3.1.1 specification.",
   "homepage": "https://github.com/awslabs/aws-c-mqtt",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-mqtt.json
+++ b/versions/a-/aws-c-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7eb14a7d331580abc1b3a7cd4354d658f4dbafa",
+      "version": "0.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "966b4bc29bf365b18e351e976b70484bfb7b94c0",
       "version": "0.15.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -481,7 +481,7 @@
       "port-version": 0
     },
     "aws-c-mqtt": {
-      "baseline": "0.15.2",
+      "baseline": "0.16.0",
       "port-version": 0
     },
     "aws-c-s3": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.16.0
