### PR TITLE
[clap-cleveraudio] Update to 1.2.8

### DIFF
--- a/ports/clap-cleveraudio/portfile.cmake
+++ b/ports/clap-cleveraudio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO free-audio/clap
     REF "${VERSION}"
-    SHA512 e99b20a8f8aeba9493d6d6110012a9147bb5facfdf78fce3d7ef4bfd2a16abba1b9e8b1ae55667eba9f11576d2b54d5391b972a09e52a3334ede81fe84ce22e8
+    SHA512 627ad083e7403a3ba69ca151757997e6ec7e94f9ee6b165c45e57b5ff0033f66b6fbfe99a8daa55574b86239912bf9f4d3f4377d08db986edbdc53c6ab870ccb
     HEAD_REF main
 )
 

--- a/ports/clap-cleveraudio/vcpkg.json
+++ b/ports/clap-cleveraudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clap-cleveraudio",
-  "version-semver": "1.2.7",
+  "version-semver": "1.2.8",
   "description": "CLAP is an audio plugin ABI which defines a standard for Digital Audio Workstations and audio plugins to work together",
   "homepage": "https://cleveraudio.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1773,7 +1773,7 @@
       "port-version": 0
     },
     "clap-cleveraudio": {
-      "baseline": "1.2.7",
+      "baseline": "1.2.8",
       "port-version": 0
     },
     "clapack": {

--- a/versions/c-/clap-cleveraudio.json
+++ b/versions/c-/clap-cleveraudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bdf4b348793aea98bdc9ab02f563325ac5079c1",
+      "version-semver": "1.2.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "045acb6522440e83d524db6e79f841ed285f4830",
       "version-semver": "1.2.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.2.8
