### PR TITLE
[dacap-clip] Update to 1.15

### DIFF
--- a/ports/dacap-clip/portfile.cmake
+++ b/ports/dacap-clip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO dacap/clip
   REF v${VERSION}
-  SHA512 d245781ae4e290f75195782522190fc4d7645b8718d640fb5e3f6f7a47d1bcbf29fb34407b4368698dfe0039abfc42eac805201a192ab4569a68eca6f6234c76
+  SHA512 decc603c14a91b3ba5fac1b61196c64e4a3325f53d9ee27568ef5501ccf3da950399bba3f9bdae6969342c8a9a255a36e3484db5cab8d351f19e7dfa14c69749
   PATCHES
     "fix-install-header-and-force-static-compilation.patch")
 

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dacap-clip",
-  "version": "1.14",
-  "port-version": 1,
+  "version": "1.15",
   "description": "Cross-platform C++ library to copy/paste clipboard content.",
   "homepage": "https://github.com/dacap/clip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2369,8 +2369,8 @@
       "port-version": 1
     },
     "dacap-clip": {
-      "baseline": "1.14",
-      "port-version": 1
+      "baseline": "1.15",
+      "port-version": 0
     },
     "dagir": {
       "baseline": "0.1.0",

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7703e8d0743a014979a227ab8b0e08fb92481da",
+      "version": "1.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "5f80542dcfe286dcff48a65d545afa634cb0bea0",
       "version": "1.14",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.15
