### PR TITLE
[libosmium] Update to 2.23.1

### DIFF
--- a/ports/libosmium/portfile.cmake
+++ b/ports/libosmium/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osmcode/libosmium
     REF "v${VERSION}"
-    SHA512 c06396ce5417883ca84e7bef8a8443c179d1bb6d094f484ee2640a34d048d77106642229a6afa50bdb543d9f4ecdee259575f0c279f013b3a2108bf47afb8cc6
+    SHA512 cb53b631a1e58b8ae13cedf58d4b1552b679e67862c1c3d2df1adec31bec60e8ebc941f22f5c318f1224bfb274bdd534926148506a0c3f0f10041e4adfa84bb9
 )
 
 vcpkg_cmake_configure(

--- a/ports/libosmium/vcpkg.json
+++ b/ports/libosmium/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libosmium",
-  "version-semver": "2.23.0",
+  "version-semver": "2.23.1",
   "description": "A fast and flexible C++ library for working with OpenStreetMap data",
   "homepage": "https://osmcode.org/libosmium/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5437,7 +5437,7 @@
       "port-version": 3
     },
     "libosmium": {
-      "baseline": "2.23.0",
+      "baseline": "2.23.1",
       "port-version": 0
     },
     "libosmscout": {

--- a/versions/l-/libosmium.json
+++ b/versions/l-/libosmium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e5f564188ae5167c155b8355bda5d98110173e1",
+      "version-semver": "2.23.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1232fd653f564918f9a3736f2ffc9d809801bbf9",
       "version-semver": "2.23.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.23.1
