### PR TITLE
[lightningscanner] Update to 1.0.2

### DIFF
--- a/ports/lightningscanner/portfile.cmake
+++ b/ports/lightningscanner/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO localcc/LightningScanner
     REF v${VERSION}
-    SHA512 fa2aefb6a6097544f578a96592b7b2ff58d5bccac7b10a0ab45fbe87e1204b3cbde5c16c64974e7434ea385727fb150b39080bf809f9698d944f75a6c110fe3c
+    SHA512 17e40a0aa42bfafb581f5812d15f9c0b4548d759548f336e686472b56ffb69afda323471c7525b2dcdebe9b128103534a5dbce0b1e61ed1f829664b3418b5147
 )
 
 vcpkg_cmake_configure(

--- a/ports/lightningscanner/vcpkg.json
+++ b/ports/lightningscanner/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lightningscanner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A lightning-fast memory signature/pattern scanner, capable of scanning gigabytes of data per second.",
   "homepage": "https://localcc.github.io/LightningScanner/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6073,7 +6073,7 @@
       "port-version": 0
     },
     "lightningscanner": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "lilv": {

--- a/versions/l-/lightningscanner.json
+++ b/versions/l-/lightningscanner.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f47c74fc2b7e0124e10b20d7ffca196684de6044",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a9096d7c2c2c14b7e438e48f6aecd194c2356172",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.0.2
