### PR TITLE
[jsonrpcpp] Add new port (v1.4.0)

### DIFF
--- a/ports/cxxmcp/portfile.cmake
+++ b/ports/cxxmcp/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO caomengxuan666/cxxmcp
+    REF "v${VERSION}"
+    SHA512 e40c49977533fa0d4cef3b5d6eaef5f25bf71743f38942f993fcf19dac3dbf199d0b656d1b9fac2e2d13dfc5b887e6028845d4080cef8a837c133aa77dd62de6
+    HEAD_REF master
+)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCXXMCP_BUILD_SDK=ON
+        -DCXXMCP_BUILD_RUNTIME=OFF
+        -DCXXMCP_BUILD_APP=OFF
+        -DCXXMCP_BUILD_GATEWAY=OFF
+        -DCXXMCP_BUILD_CLI=OFF
+        -DCXXMCP_BUILD_EXAMPLES=OFF
+        -DCXXMCP_BUILD_TESTS=OFF
+        -DCXXMCP_BUILD_DOCS=OFF
+        -DCXXMCP_USE_SYSTEM_DEPS=ON
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME cxxmcp CONFIG_PATH lib/cmake/cxxmcp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cxxmcp/usage
+++ b/ports/cxxmcp/usage
@@ -1,0 +1,14 @@
+cxxmcp provides CMake targets:
+
+  find_package(cxxmcp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE cxxmcp::sdk)
+
+Narrow targets are also available:
+
+  cxxmcp::protocol
+  cxxmcp::transport
+  cxxmcp::handler
+  cxxmcp::peer
+  cxxmcp::service
+  cxxmcp::client
+  cxxmcp::server

--- a/ports/cxxmcp/vcpkg.json
+++ b/ports/cxxmcp/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "cxxmcp",
+  "version-semver": "2.0.2",
+  "description": "C++ MCP SDK for protocol, client, server, transport, peer, and handler APIs.",
+  "homepage": "https://github.com/caomengxuan666/cxxmcp",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "cpp-httplib",
+      "default-features": false
+    },
+    "nlohmann-json",
+    "tl-expected",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/jsonrpcpp/portfile.cmake
+++ b/ports/jsonrpcpp/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO badaix/jsonrpcpp
+    REF "v${VERSION}"
+    SHA512 d6c1ff8113f1b8581c258acdc7f59a3669e43636b06d73db1c4396da4a7797dc9b1d7e3a9f81039cc06c2970806b9b5a565cb2d9c8f0041866067dfcded93fff
+    HEAD_REF master
+)
+
+# Fix include path to use vcpkg's nlohmann-json
+vcpkg_replace_string(
+    "${SOURCE_PATH}/include/jsonrpcpp.hpp"
+    [[#include <json.hpp>]]
+    [[#include <nlohmann/json.hpp>]]
+)
+
+# Remove bundled json.hpp from install command and delete the file
+vcpkg_replace_string(
+    "${SOURCE_PATH}/CMakeLists.txt"
+    "install(FILES include/jsonrpcpp.hpp include/json.hpp"
+    "install(FILES include/jsonrpcpp.hpp"
+)
+file(REMOVE "${SOURCE_PATH}/include/json.hpp")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLE=OFF
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/jsonrpcpp/usage
+++ b/ports/jsonrpcpp/usage
@@ -1,0 +1,11 @@
+jsonrpcpp is a header-only library. You can use it by including the headers:
+
+    #include <jsonrpcpp/jsonrpcpp.hpp>
+
+Since jsonrpcpp depends on nlohmann-json, you need to link against it:
+
+    find_package(nlohmann_json CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE nlohmann_json::nlohmann_json)
+
+For more information, see the documentation at:
+    https://github.com/badaix/jsonrpcpp

--- a/ports/jsonrpcpp/vcpkg.json
+++ b/ports/jsonrpcpp/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "jsonrpcpp",
+  "version-semver": "1.4.0",
+  "description": "C++ JSON-RPC 2.0 library",
+  "homepage": "https://github.com/badaix/jsonrpcpp",
+  "license": "MIT",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4224,6 +4224,10 @@
       "baseline": "0.21.0",
       "port-version": 1
     },
+    "jsonrpcpp": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "juce": {
       "baseline": "8.0.7",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2340,6 +2340,10 @@
       "baseline": "4.1.0",
       "port-version": 0
     },
+    "cxxmcp": {
+      "baseline": "2.0.2",
+      "port-version": 0
+    },
     "cxxopts": {
       "baseline": "3.3.1",
       "port-version": 1

--- a/versions/c-/cxxmcp.json
+++ b/versions/c-/cxxmcp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "355237577782d56f047098d0674d4ca6fdaf030c",
+      "version-semver": "2.0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/j-/jsonrpcpp.json
+++ b/versions/j-/jsonrpcpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "055a01446414dd503587cb729d6b4628a43ab0d1",
+      "version-semver": "1.4.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## New Port Request

- [x] I have read the [documentation](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide)
- [x] I have read [the guide for creating a new port](https://learn.microsoft.com/vcpkg/get_started/get-started-packaging)

### jsonrpcpp

**Description:** C++ JSON-RPC 2.0 library

**Homepage:** https://github.com/badaix/jsonrpcpp

**License:** MIT

### Checklist

- [x] `vcpkg.json` is valid
- [x] `portfile.cmake` follows best practices
- [x] `usage` file is provided
- [x] Version database updated
- [x] Builds successfully without warnings

### Notes

- This is a header-only library
- Depends on `nlohmann-json` (uses vcpkg's version instead of bundled)
- No CMake config files exported (header-only)