### PR TITLE
[presentmon] Update to 2.4.1

### DIFF
--- a/ports/presentmon/portfile.cmake
+++ b/ports/presentmon/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GameTechDev/PresentMon
     REF "v${VERSION}"
-    SHA512 1c606dd53a05b88a500a2deeb7099ce3cf0e9edfdf6ce8f9a1a91efecf9049bf700368066cbafc1e196f4bf8a6e43da86a2f10ad0843b582ab851e366a33eda4
+    SHA512 16838ce604df8d59f6aebd898bf30378b96262cbc92e873fd5e7c1d15b84302f68c36dfe72a3ed5d17064b1e1044c31426cc3b60b4ebf35d403736f16b88aaeb
     HEAD_REF main
 )
 

--- a/ports/presentmon/vcpkg.json
+++ b/ports/presentmon/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "presentmon",
-  "version-semver": "2.3.0",
+  "version-semver": "2.4.1",
   "description": "PresentMon is a tool to capture and analyze ETW events related to swap chain presentation on Windows.",
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7965,7 +7965,7 @@
       "port-version": 0
     },
     "presentmon": {
-      "baseline": "2.3.0",
+      "baseline": "2.4.1",
       "port-version": 0
     },
     "proj": {

--- a/versions/p-/presentmon.json
+++ b/versions/p-/presentmon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df60548457c5257230c28d8b2bcd163e205afb78",
+      "version-semver": "2.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d397dd1c9203af9da5d7833dc04117cdacaff59",
       "version-semver": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.4.1
