### PR TITLE
[libsystemd] Update to 260.2

### DIFF
--- a/ports/libsystemd/portfile.cmake
+++ b/ports/libsystemd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO systemd/systemd
   REF "v${VERSION}"
-  SHA512 9f975dce6861853a817a7ceab18a24449a85d1bda6939b3a5173430c02a4d8a9a2b34ebb8cce1c51db9b0ff9078fcc65da7b0f44e3bdcbbe013b9e04bb6f0ff9
+  SHA512 63d15da49e7580952a48a0b50df20c1b398e4b77edf259510b0cdb9022e919387baadf2190194a50f1f582b83e0768c13997a4189cf0fb6a61b65015496d9c80
   PATCHES
     disable-warning-nonnull.patch
     only-libsystemd.patch

--- a/ports/libsystemd/vcpkg.json
+++ b/ports/libsystemd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsystemd",
-  "version": "260.1",
-  "description": "Libsystemd",
+  "version": "260.2",
+  "description": "System and Service Manager",
   "homepage": "https://github.com/systemd/systemd",
   "license": null,
   "supports": "linux",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5709,7 +5709,7 @@
       "port-version": 0
     },
     "libsystemd": {
-      "baseline": "260.1",
+      "baseline": "260.2",
       "port-version": 0
     },
     "libtar": {

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48f7900671bc8214fd530c415f8660b7ed4f0e2b",
+      "version": "260.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ce357911e80fc2ceba864f1a3ac7eeb73854336",
       "version": "260.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.