### PR TITLE
[mujoco] update to 3.9.0

### DIFF
--- a/ports/mujoco/fix_dependencies.patch
+++ b/ports/mujoco/fix_dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 08e0bd0..3cbd89d 100644
+index e01c662..e3afbf8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -173,7 +173,7 @@ if(EMSCRIPTEN)
+@@ -175,7 +175,7 @@ if(EMSCRIPTEN)
  endif()
  
  
@@ -11,7 +11,7 @@ index 08e0bd0..3cbd89d 100644
  if(MUJOCO_ENABLE_AVX_INTRINSICS)
    target_compile_definitions(mujoco PUBLIC mjUSEPLATFORMSIMD)
  endif()
-@@ -196,9 +196,9 @@ target_link_libraries(
+@@ -198,9 +198,9 @@ target_link_libraries(
    mujoco
    PRIVATE ccd
            lodepng
@@ -25,10 +25,10 @@ index 08e0bd0..3cbd89d 100644
  
  set_target_properties(
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index 4381a75..502c73e 100644
+index 664fc31..07ad2eb 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
-@@ -84,7 +84,7 @@ set(BUILD_SHARED_LIBS
+@@ -88,7 +88,7 @@ set(BUILD_SHARED_LIBS
      CACHE INTERNAL "Build SHARED libraries"
  )
  
@@ -37,7 +37,7 @@ index 4381a75..502c73e 100644
    FetchContent_Declare(
      lodepng
      GIT_REPOSITORY https://github.com/lvandeve/lodepng.git
-@@ -108,7 +108,7 @@ if(NOT TARGET lodepng)
+@@ -112,7 +112,7 @@ if(NOT TARGET lodepng)
    endif()
  endif()
  
@@ -46,7 +46,7 @@ index 4381a75..502c73e 100644
    FetchContent_Declare(
      marchingcubecpp
      GIT_REPOSITORY https://github.com/aparis69/MarchingCubeCpp.git
-@@ -122,6 +122,22 @@ if(NOT TARGET marchingcubecpp)
+@@ -126,6 +126,22 @@ if(NOT TARGET marchingcubecpp)
    endif()
  endif()
  
@@ -69,7 +69,7 @@ index 4381a75..502c73e 100644
  set(QHULL_ENABLE_TESTING OFF)
  # Patch changes in https://github.com/qhull/qhull/pull/173.patch
  set(QHULL_PATCH_COMMAND
-@@ -130,32 +146,39 @@ set(QHULL_PATCH_COMMAND
+@@ -134,32 +150,39 @@ set(QHULL_PATCH_COMMAND
  
  findorfetch(
    USE_SYSTEM_PACKAGE
@@ -114,7 +114,7 @@ index 4381a75..502c73e 100644
    PACKAGE_NAME
    tinyxml2
    LIBRARY_NAME
-@@ -168,9 +191,10 @@ findorfetch(
+@@ -172,9 +195,10 @@ findorfetch(
    tinyxml2
    EXCLUDE_FROM_ALL
  )
@@ -126,7 +126,7 @@ index 4381a75..502c73e 100644
  # update cmake_minimum_required version for compatibility with newer version of cmake
  if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
    set(CMAKE_POLICY_VERSION_MINIMUM ${MUJOCO_CMAKE_MIN_REQ})
-@@ -178,7 +202,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+@@ -182,7 +206,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
  endif()
  findorfetch(
    USE_SYSTEM_PACKAGE
@@ -135,7 +135,7 @@ index 4381a75..502c73e 100644
    PACKAGE_NAME
    tinyobjloader
    LIBRARY_NAME
-@@ -211,7 +235,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+@@ -215,7 +239,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
  endif()
  findorfetch(
    USE_SYSTEM_PACKAGE
@@ -144,7 +144,7 @@ index 4381a75..502c73e 100644
    PACKAGE_NAME
    ccd
    LIBRARY_NAME
-@@ -229,12 +253,13 @@ if(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
+@@ -233,12 +257,13 @@ if(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
    unset(CMAKE_POLICY_VERSION_MINIMUM)
    unset(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
  endif()
@@ -160,6 +160,29 @@ index 4381a75..502c73e 100644
    if(MSVC)
      # C4005 is the MSVC equivalent of -Wmacro-redefined.
      target_compile_options(ccd PRIVATE /wd4005)
+@@ -254,12 +279,7 @@ else()
+   set(_BUILD_TESTS_WAS_DEFINED FALSE)
+ endif()
+ set(BUILD_TESTS OFF)
+-fetchpackage(
+-  PACKAGE_NAME  miniz
+-  GIT_REPO      https://github.com/richgel999/miniz.git
+-  GIT_TAG       ${MUJOCO_DEP_VERSION_miniz}
+-  TARGETS       miniz
+-)
++find_package(miniz CONFIG REQUIRED)
+ if(_BUILD_TESTS_WAS_DEFINED)
+   set(BUILD_TESTS "${_OLD_BUILD_TESTS}")
+ else()
+@@ -281,7 +301,7 @@ if(MUJOCO_BUILD_TESTS OR MUJOCO_BUILD_STUDIO OR MUJOCO_USE_FILAMENT)
+   set(ABSL_BUILD_TESTING OFF)
+   findorfetch(
+     USE_SYSTEM_PACKAGE
+-    OFF
++    ON
+     PACKAGE_NAME
+     absl
+     LIBRARY_NAME
 diff --git a/plugin/obj_decoder/CMakeLists.txt b/plugin/obj_decoder/CMakeLists.txt
 index 689dfc5..9f86232 100644
 --- a/plugin/obj_decoder/CMakeLists.txt
@@ -183,3 +206,13 @@ index 7885f5f..1da1be2 100644
    target_compile_options(glfw PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
    target_link_options(glfw PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
  endif()
+diff --git a/src/xml/mjz/CMakeLists.txt b/src/xml/mjz/CMakeLists.txt
+index ab92623..4ec37e9 100644
+--- a/src/xml/mjz/CMakeLists.txt
++++ b/src/xml/mjz/CMakeLists.txt
+@@ -18,4 +18,4 @@ set(MUJOCO_MJZ_SRCS
+ )
+ 
+ target_sources(mujoco PRIVATE ${MUJOCO_MJZ_SRCS})
+-target_link_libraries(mujoco PRIVATE miniz)
++target_link_libraries(mujoco PRIVATE miniz::miniz)

--- a/ports/mujoco/portfile.cmake
+++ b/ports/mujoco/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO deepmind/mujoco
     REF ${VERSION}
-    SHA512 42931b3ab2c0058f7429dd70c1dd6f82d5a256b28ddd19beb9a74617231d9f735f496bff5e51c2bf2290de11435201e966ea834ff1cb22fa603835aac11f88e0
+    SHA512 4479142e29919d326760983a55bd16fcfa351457af70190b560552d2aad19d79bfcf68f7f542278ba41ff08b1ec48da2b845cbf9e1565ca7381780167fa6cfdd
     PATCHES
         fix_dependencies.patch
         disable-werror.patch

--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -15,6 +15,7 @@
     "glfw3",
     "lodepng",
     "marchingcubecpp",
+    "miniz",
     "qhull",
     "tinyobjloader",
     "tinyxml2",

--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mujoco",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "Multi-Joint dynamics with Contact.",
   "homepage": "https://mujoco.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6793,7 +6793,7 @@
       "port-version": 0
     },
     "mujoco": {
-      "baseline": "3.8.1",
+      "baseline": "3.9.0",
       "port-version": 0
     },
     "mujs": {

--- a/versions/m-/mujoco.json
+++ b/versions/m-/mujoco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c9f6e3f8a862642b6ee00bb711a77877eb53f26",
+      "git-tree": "a631ce7edfc1c929dd145de4ada3937154d12e76",
       "version": "3.9.0",
       "port-version": 0
     },

--- a/versions/m-/mujoco.json
+++ b/versions/m-/mujoco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c9f6e3f8a862642b6ee00bb711a77877eb53f26",
+      "version": "3.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "33da2f693255eedda882ac8fbbb10904745a8ecf",
       "version": "3.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/google-deepmind/mujoco/releases/tag/3.9.0
