### PR TITLE
[directx12-agility] Update for 1.619.3 servicing

### DIFF
--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # DX12 SDK Debug Layer i
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 fd6ed5a200c1589d91c85b35bb0018117695ac2c3858e8dd4fb3247e4cba94bc3c09325ccbf246aac9a37754f0bf9fb69f94199dc9a2ad42d534ad6e2d367770
+    SHA512 8d8525e95369e364120762b91d1f6d3770bab78135cff3dd958309c8bb9a19bdf141570d9d9e50a36f6de6cc6e7be30a7e39cf0af78ac41ea3134b41ddb0683e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.619.1",
+  "version": "1.619.3",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2509,7 +2509,7 @@
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.619.1",
+      "baseline": "1.619.3",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "580f82ca685a63f9a7275d13e8b1e01d92945bb5",
+      "version": "1.619.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "b5494c21c61fe470f19f84a0e98f284dd73198a1",
       "version": "1.619.1",
       "port-version": 0


### PR DESCRIPTION
NuGet package for runtime has been updated for servicing fixes.

> Note that the **directx-headers** are still 1.619.1 so have not been updated.