### PR TITLE
[gameinput] Update for version 3.4 release

### DIFF
--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -1,3 +1,5 @@
+set(_installNuGet ON)
+
 if(VCPKG_TARGET_IS_XBOX)
 
     cmake_path(SET GameDKXboxLatest "$ENV{GameDKXboxLatest}")
@@ -26,6 +28,7 @@ if(VCPKG_TARGET_IS_XBOX)
 
     # Output user-friendly status message for installed edition.
     if(${GAMEINPUT_H} MATCHES ".*/([0-9][0-9])([0-9][0-9])([0-9][0-9])/.*")
+        set(GDKEditionNumber ${CMAKE_MATCH_0})
         set(_months "null" "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December")
         list(GET _months ${CMAKE_MATCH_2} month)
         set(update "")
@@ -33,20 +36,31 @@ if(VCPKG_TARGET_IS_XBOX)
             set(update " Update ${CMAKE_MATCH_3}")
         endif()
         message(STATUS "Found the Microsoft GDK with Xbox Extensions (${month} 20${CMAKE_MATCH_1}${update})")
+    else()
+        set(GDKEditionNumber 000000)
     endif()
 
-    file(INSTALL ${GAMEINPUT_H} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-    file(INSTALL ${GAMEINPUT_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-    file(INSTALL ${GAMEINPUT_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    if(GDKEditionNumber LESS 251000)
+        # GameInput NuGet package works on Xbox, but only for October 2025 or later.
+        message(STATUS "Using GameInput files from the installed GDKX")
+        set(_installNuGet OFF)
+        set(LIB_NAME "gameinput.lib")
 
-    set(VCPKG_POLICY_SKIP_COPYRIGHT_CHECK enabled)
+        file(INSTALL ${GAMEINPUT_H} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+        file(INSTALL ${GAMEINPUT_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+        file(INSTALL ${GAMEINPUT_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 
-else()
+        set(VCPKG_POLICY_SKIP_COPYRIGHT_CHECK enabled)
+    endif()
+
+endif()
+
+if(_installNuGet)
 
     vcpkg_download_distfile(ARCHIVE
         URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
         FILENAME "gameinput.${VERSION}.zip"
-        SHA512 e91aef50dc929a9446772525a59e832050979b81c460314a9e42f45359cd533b196a0218adad70099a4b06863c4b640325c36bcd2445bad741eabf982cec5bf2
+        SHA512 53f93bdc3a897386abd8a48fc13bdf1e9d86644f9258b6ad24ede881d816b6c3792ea98b2b922ef0d9f92eabc47daacaf462dcae6ae31c94c2db77b206b53677
     )
 
     vcpkg_extract_source_archive(
@@ -56,7 +70,10 @@ else()
     )
 
     file(INSTALL "${PACKAGE_PATH}/native/include/gameinput.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-    file(INSTALL "${PACKAGE_PATH}/redist/GameInputRedist.msi" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+    if(NOT VCPKG_TARGET_IS_XBOX)
+        file(INSTALL "${PACKAGE_PATH}/redist/GameInputRedist.msi" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+    endif()
 
     vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
 

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -28,7 +28,7 @@ if(VCPKG_TARGET_IS_XBOX)
 
     # Output user-friendly status message for installed edition.
     if(${GAMEINPUT_H} MATCHES ".*/([0-9][0-9])([0-9][0-9])([0-9][0-9])/.*")
-        set(GDKEditionNumber ${CMAKE_MATCH_0})
+        set(GDKEditionNumber ${CMAKE_MATCH_1}${CMAKE_MATCH_2}${CMAKE_MATCH_3})
         set(_months "null" "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December")
         list(GET _months ${CMAKE_MATCH_2} month)
         set(update "")

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gameinput",
-  "version": "3.3.195",
+  "version": "3.4.218",
   "description": "GameInput",
   "homepage": "https://aka.ms/gameinput",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3293,7 +3293,7 @@
       "port-version": 0
     },
     "gameinput": {
-      "baseline": "3.3.195",
+      "baseline": "3.4.218",
       "port-version": 0
     },
     "gamenetworkingsockets": {

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a6b61029659928124b17f1f8a8e9e0c95a7b953",
+      "version": "3.4.218",
+      "port-version": 0
+    },
+    {
       "git-tree": "df6cb72a5e5df44329dc686316ef7d9ef4a7f6cf",
       "version": "3.3.195",
       "port-version": 0

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8a6b61029659928124b17f1f8a8e9e0c95a7b953",
+      "git-tree": "5dacf94e7619b30e4187f00b37c15ce4b04f4706",
       "version": "3.4.218",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The GameInput NuGet is now usable on Xbox platforms as a replacement for the version in the GDKX itself, but only on October 2025 or later versions of the GDKX. This port update now checks this to determine if a 'local' copy of gameinput should be used or the nuget package for Xbox.

Also fixed a problem with the generated CMake target for GDKX scenarios.