### PR TITLE
[icu] Utilize the icu library in the Windows SDK

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -1,3 +1,23 @@
+if("windowssystem" IN_LIST FEATURES)
+    if(NOT VCPKG_TARGET_IS_WINDOWS)
+        message(FATAL_ERROR "The 'windowssystem' feature for ICU is only supported on Windows platforms.")
+    endif()
+    
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        message(FATAL_ERROR "The Windows OS native ICU library is a dynamic system DLL. Static linkage cannot be forced.")
+    endif()
+
+    # Install the CMake wrapper configuration
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+    
+    # Write a dummy copyright file required by vcpkg linting guidelines
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "Distributed under the terms of the Windows SDK License Agreement.")
+
+    # Mark port installation as successfully completed empty placeholder 
+    set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+    return()
+endif()
+
 vcpkg_download_distfile(
     ARCHIVE
     URLS "https://github.com/unicode-org/icu/releases/download/release-${VERSION}/icu4c-${VERSION}-sources.tgz"

--- a/ports/icu/vcpkg-cmake-wrapper.cmake
+++ b/ports/icu/vcpkg-cmake-wrapper.cmake
@@ -132,3 +132,45 @@ endif()
 if(TARGET ICU::uc)
     target_compile_features(ICU::uc INTERFACE cxx_std_17)
 endif()
+
+if("windowssystem" IN_LIST FEATURES)
+    # 1. Clear out any cached variables to prevent accidental lookups
+    unset(ICU_FOUND CACHE)
+    
+    # 2. Leverage Windows SDK environment paths
+    if(DEFINED ENV{WindowsSDKDir} AND DEFINED ENV{WindowsSDKVersion})
+        set(WindowsSDK_UM_Include "$ENV{WindowsSDKDir}Include/$ENV{WindowsSDKVersion}um")
+    else()
+        # Fallback if environment variables are missing from the current shell context
+        set(WindowsSDK_UM_Include "C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um")
+    endif()
+
+    # 3. Explicitly map targets to system library binaries
+    set(ICU_INCLUDE_DIRS "${WindowsSDK_UM_Include}" CACHE PATH "Windows SDK ICU Include Dir" FORCE)
+    set(ICU_INCLUDE_DIR "${WindowsSDK_UM_Include}" CACHE PATH "Windows SDK ICU Include Dir" FORCE)
+    
+    # Windows native ICU exports a unified icu.lib import library for icu.dll
+    find_library(ICU_SYSTEM_LIB NAMES icu PATHS "$ENV{WindowsSDKDir}Lib/$ENV{WindowsSDKVersion}um/$ENV{VCPKG_TARGET_ARCHITECTURE}" REQUIRED)
+    
+    set(ICU_LIBRARIES "${ICU_SYSTEM_LIB}" CACHE STRING "Windows Native ICU Lib" FORCE)
+    set(ICU_FOUND TRUE CACHE BOOL "Windows Native ICU Found" FORCE)
+    
+    # 4. Generate the standard modern CMake imported targets expected by downstream ports
+    if(NOT TARGET ICU::icu)
+        add_library(ICU::icu INTERFACE IMPORTED)
+        set_target_properties(ICU::icu PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${ICU_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES "${ICU_LIBRARIES}"
+        )
+        # Map common aliases that downstream CMake scripts look for
+        add_library(ICU::uc ALIAS ICU::icu)
+        add_library(ICU::i18n ALIAS ICU::icu)
+        add_library(ICU::data ALIAS ICU::icu)
+    endif()
+
+    # Skip running standard find_package logic
+    set(ICU_FIND_QUIETLY TRUE)
+else()
+    # Call the original underlying find path for a compiled ICU port
+    _find_package(${ARGS})
+endif()

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "icu",
   "version": "78.3",
+  "port-version": 1,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",
@@ -25,6 +26,9 @@
     "tools": {
       "description": "Build tools",
       "supports": "!uwp"
+    },
+    "windowssystem": {
+      "description": "Use the native ICU binaries bundled with the Windows 10+ OS and SDK instead of compiling from source."
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3922,7 +3922,7 @@
     },
     "icu": {
       "baseline": "78.3",
-      "port-version": 0
+      "port-version": 1
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4104d7cc2896d92a6f6f4d77538aa2b8e1744478",
+      "version": "78.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "f52873e40a919aa2d4c9f2832eeacb81b406dc28",
       "version": "78.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->
Fixes #947 

I used Google Gemini to help with this issue.

Marking as draft as I don't have access to a windows machine to test it.

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
