### PR TITLE
[vcpkg-ci-libusb] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-libusb/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-libusb/portfile.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-libusb/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-libusb/project/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-libusb C)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libusb IMPORTED_TARGET REQUIRED libusb-1.0)
+
+add_executable(main main.c)
+target_link_libraries(main PRIVATE PkgConfig::libusb)

--- a/scripts/test_ports/vcpkg-ci-libusb/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-libusb/project/main.c
@@ -1,0 +1,11 @@
+#include <libusb-1.0/libusb.h>
+
+int main()
+{
+    libusb_context *ctx = NULL;
+    int ret = libusb_init(&ctx);
+    if (ret != 0)
+        return 1;
+    libusb_exit(ctx);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-libusb/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-libusb/project/main.c
@@ -1,11 +1,9 @@
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
-int main()
-{
+int main() {
     libusb_context *ctx = NULL;
     int ret = libusb_init(&ctx);
-    if (ret != 0)
-        return 1;
+    if (ret != 0) return 1;
     libusb_exit(ctx);
     return 0;
 }

--- a/scripts/test_ports/vcpkg-ci-libusb/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-libusb/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "vcpkg-ci-libusb",
+  "version-string": "ci",
+  "description": "Validates libusb",
+  "dependencies": [
+    {
+      "name": "libusb"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Add a ci port for libusb