### PR TITLE
[vcpkg-ci-yoga] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-yoga/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-yoga/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-yoga/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-yoga/project/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-yoga)
+
+find_package(yoga CONFIG REQUIRED)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE yoga::yogacore)

--- a/scripts/test_ports/vcpkg-ci-yoga/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-yoga/project/main.cpp
@@ -1,0 +1,8 @@
+#include <yoga/Yoga.h>
+
+int main() {
+    YGNodeRef node = YGNodeNew();
+    if (node == nullptr) return 1;
+    YGNodeFree(node);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-yoga/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-yoga/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "vcpkg-ci-yoga",
+  "version-string": "ci",
+  "description": "Validates yoga",
+  "dependencies": [
+    {
+      "name": "yoga"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Add a ci port for yoga