### PR TITLE
[libspatialite] Re-wire features/CFLAGS for MSVC

### DIFF
--- a/ports/libspatialite/gaiaconfig-msvc.patch
+++ b/ports/libspatialite/gaiaconfig-msvc.patch
@@ -1,31 +1,64 @@
-diff --git a/src/headers/spatialite/gaiaconfig-msvc.h b/src/headers/spatialite/gaiaconfig-msvc.h
-index 37f0bd1..0053258 100644
---- a/src/headers/spatialite/gaiaconfig-msvc.h
-+++ b/src/headers/spatialite/gaiaconfig-msvc.h
-@@ -2,7 +2,7 @@
+diff --git a/src/headers/spatialite/gaiaconfig-msvc.h.in b/src/headers/spatialite/gaiaconfig-msvc.h.in
+index 8b49f74..75565d2 100644
+--- a/src/headers/spatialite/gaiaconfig-msvc.h.in
++++ b/src/headers/spatialite/gaiaconfig-msvc.h.in
+@@ -1,7 +1,8 @@
++/* ./src/headers/spatialite/gaiaconfig-msvc.h - vcpkg @PORT@[@FEATURES@] */
  /* ./src/headers/spatialite/gaiaconfig-msvc.h.in - manually maintained */
  
  /* Should be defined in order to enable GCP support. */
--#define ENABLE_GCP 1
-+// #define ENABLE_GCP 1
+-#undef ENABLE_GCP
++#cmakedefine ENABLE_GCP 1
  
  /* Should be defined in order to enable GeoPackage support. */
  #define ENABLE_GEOPACKAGE 1
-@@ -11,7 +11,7 @@
+@@ -10,7 +11,7 @@
  #define ENABLE_LIBXML2 1
  
  /* Should be defined in order to enable RTTOPO support. */
 -#define ENABLE_RTTOPO 1
-+// #define ENABLE_RTTOPO 1
++#cmakedefine ENABLE_RTTOPO 1
  
  /* Should be defined in order to enable GEOS_370 support. */
  #define GEOS_370 1
-@@ -32,7 +32,7 @@
- /* #undef OMIT_FREEXL */
+@@ -25,31 +26,31 @@
+ #define GEOS_REENTRANT 1
+ 
+ /* Should be defined in order to disable EPSG full support. */
+-#undef OMIT_EPSG
++/* #undef OMIT_EPSG */
+ 
+ /* Should be defined in order to disable FREEXL support. */
+-#undef OMIT_FREEXL
++#cmakedefine OMIT_FREEXL 1
  
  /* Should be defined in order to disable GEOCALLBACKS support. */
 -#define OMIT_GEOCALLBACKS 1
-+// #define OMIT_GEOCALLBACKS 1
++/* #define OMIT_GEOCALLBACKS */
  
  /* Should be defined in order to disable GEOS support. */
- /* #undef OMIT_GEOS */
+-#undef OMIT_GEOS
++/* #undef OMIT_GEOS */
+ 
+ /* Should be defined in order to disable ICONV support. */
+-#undef OMIT_ICONV
++/* #undef OMIT_ICONV */
+ 
+ /* Should be defined in order to disable KNN support. */
+-#undef OMIT_KNN
++/* #undef OMIT_KNN */
+ 
+ /* Should be defined in order to disable MATHSQL support. */
+-#undef OMIT_MATHSQL
++/* #undef OMIT_MATHSQL */
+ 
+ /* Should be defined in order to disable PROJ.4 support. */
+-#undef OMIT_PROJ
++/* #undef OMIT_PROJ */
+ 
+ /* Should be defined in order to enable PROJ.6 support. */
+ #define PROJ_NEW 1
+ 
+ /* the Version of this package */
+-#undef SPATIALITE_VERSION
++#define SPATIALITE_VERSION "@VERSION@"

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -20,13 +20,19 @@ vcpkg_extract_source_archive(SOURCE_PATH
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS unused
     FEATURES
-        freexl          ENABLE_FREEXL
         gcp             ENABLE_GCP
         rttopo          ENABLE_RTTOPO
+    INVERTED_FEATURES
+        freexl          OMIT_FREEXL
+)
+configure_file(
+    "${SOURCE_PATH}/src/headers/spatialite/gaiaconfig-msvc.h.in"
+    "${SOURCE_PATH}/src/headers/spatialite/gaiaconfig-msvc.h"
+    @ONLY
 )
 
 set(pkg_config_modules geos libxml-2.0 proj sqlite3 zlib)
-if(ENABLE_FREEXL)
+if(NOT OMIT_FREEXL)
     list(APPEND pkg_config_modules freexl)
 endif()
 if(ENABLE_RTTOPO)
@@ -36,9 +42,10 @@ endif()
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     x_vcpkg_pkgconfig_get_modules(
         PREFIX PKGCONFIG
-        MODULES --msvc-syntax ${pkg_config_modules}
+        MODULES ${pkg_config_modules}
         CFLAGS
         LIBS
+        USE_MSVC_SYNTAX_ON_WINDOWS
     )
 
     # cherry-picked from Makefile.vc (CFLAGS) and nmake.opt (OPTFLAGS)
@@ -47,15 +54,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         string(APPEND CFLAGS " /DDLL_EXPORT")
         set(WANT_LIB spatialite_i.lib)
-    endif()
-    if(NOT ENABLE_FREEXL)
-        string(APPEND CFLAGS " /DOMIT_FREEXL")
-    endif()
-    if(ENABLE_GCP)
-        string(APPEND CFLAGS " /DENABLE_GCP")
-    endif()
-    if(ENABLE_RTTOPO)
-        string(APPEND CFLAGS " /DENABLE_RTTOPO")
     endif()
 
     set(SYSTEM_LIBS "iconv.lib charset.lib")
@@ -111,10 +109,10 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         vcpkg_replace_string("${outfile}" "  -lm" " ")
     endif()
 else()
-    if(ENABLE_FREEXL)
-        set(FREEXL_OPTION "--enable-freexl")
-    else()
+    if(OMIT_FREEXL)
         set(FREEXL_OPTION "--disable-freexl")
+    else()
+        set(FREEXL_OPTION "--enable-freexl")
     endif()
     if(ENABLE_GCP)
         set(GCP_OPTION "--enable-gcp")

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.1.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/fossil/libspatialite/index",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5666,7 +5666,7 @@
     },
     "libspatialite": {
       "baseline": "5.1.0",
-      "port-version": 6
+      "port-version": 7
     },
     "libspeechd": {
       "baseline": "0.12.1",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebd8ba5e099ad0309f13c0de1b0216a5170dfb77",
+      "version": "5.1.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "8b274963d26395ee2e6ad430255147714cdcc159",
       "version": "5.1.0",
       "port-version": 6


### PR DESCRIPTION
Cherry-picked from https://github.com/microsoft/vcpkg/pull/51761 where the temporary disabling of 32-bit minizip showed shortcomings in dependency controls for the MSVC platform. Instead of poorly injecting and forwarding CFLAGS, generates and install the configuration header file as needed.