### PR TITLE
[aws-c-common] Update to 0.14.0

### DIFF
--- a/ports/aws-c-common/portfile.cmake
+++ b/ports/aws-c-common/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-common
     REF "v${VERSION}"
-    SHA512 8cd803dfb07f54d41d9e29f30c5f110bb0700817bd7c9946dd382be3cbee7aaae532bd6482a55622f6f80705023ef5deb17931c0b137df6f7d18ca2532cc49d9
+    SHA512 f0615baf90b428002b7e446f8167edd80f620e94cd56aaca139b0a6a4353cb898f63adab66bdfe115a36481103e6eee17b60427120b6f0cc007b3bfe57db67eb
     HEAD_REF master
     PATCHES
         disable-internal-crt-option.patch # Disable internal crt option because vcpkg contains crt processing flow

--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-common",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "549cc78365245796596c1630b9b4b81e0a753f8d",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b05a65e8033a83d650c37ecd89ee72cdd662c21c",
       "version": "0.13.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -461,7 +461,7 @@
       "port-version": 0
     },
     "aws-c-common": {
-      "baseline": "0.13.1",
+      "baseline": "0.14.0",
       "port-version": 0
     },
     "aws-c-compression": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.14.0
