### PR TITLE
[intel-ipsec] Update to 2.0.2

### DIFF
--- a/ports/intel-ipsec/portfile.cmake
+++ b/ports/intel-ipsec/portfile.cmake
@@ -1,11 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/intel-ipsec-mb
-    REF bde82c8737edc04d80549f0a68225ede7e5cefd #v1.1
-    SHA512 f41dcde88b062e8ec2327987c6d36cd4f74a5e4fea386cc1ef8364f1dc432a2db02ca7d3312c0471b443cf93e815af6d74a4819c249afd6777aa91693b2546e5
-    HEAD_REF master
-    PATCHES
-        always-generate-pdb.patch # https://github.com/intel/intel-ipsec-mb/pull/93
+    REF "v${VERSION}"
+    SHA512 3a0f39f4fd65e6abb2c6d88477491b390a302cd2e470692b8c1c498f02fcfabf57b3fd1e70c767e0b4d9c591ccdc6344ba28971a7e65ba6e7c492bcfddab2cc4
+    HEAD_REF main
 )
 
 vcpkg_find_acquire_program(NASM)

--- a/ports/intel-ipsec/vcpkg.json
+++ b/ports/intel-ipsec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "intel-ipsec",
-  "version": "1.1",
+  "version": "2.0.2",
   "description": "Intel(R) Multi-Buffer Crypto for IPsec Library",
   "supports": "x64 & (windows | linux) & !uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4041,7 +4041,7 @@
       "port-version": 1
     },
     "intel-ipsec": {
-      "baseline": "1.1",
+      "baseline": "2.0.2",
       "port-version": 0
     },
     "intel-mkl": {

--- a/versions/i-/intel-ipsec.json
+++ b/versions/i-/intel-ipsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "246c3f00000dfcafa6dcff80691096187f1d62ce",
+      "version": "2.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "fd3b71153cb4510e0de7475975f85bbbe41e9747",
       "version": "1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.