### PR TITLE
[luau] update to 0.723

### DIFF
--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 58e3b87f4e7c12e0a9a96b9b6f540a4a8a113eaf063f2983fddabe1c84d3079fab91195f4af37ca0b028d235317070e4f908d092c075f74753967b8a309fd5bc
+    SHA512 4e654c8e26312f9bbc0cd34e07847760e3d1d0649b158e1ea87b6ada849cd577b60fb0eba01721c925369d885eacb72551f38b35cb58d64b73ec25c302ecf5d5
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.722",
+  "version": "0.723",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6249,7 +6249,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.722",
+      "baseline": "0.723",
       "port-version": 0
     },
     "lunarg-vulkantools": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "643b61ed04d1416cbf8c05e186dbebc4105345a8",
+      "version": "0.723",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7b59906bca9eb6b749f6d4a87942d96671406cf",
       "version": "0.722",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/luau-lang/luau/releases/tag/0.723
