### PR TITLE
[whisper-cpp] update to 1.8.5

### DIFF
--- a/ports/whisper-cpp/portfile.cmake
+++ b/ports/whisper-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/whisper.cpp
     REF "v${VERSION}"
-    SHA512 3b41035f9aaad31f0360b2d54d01c9c238628dec7b24a2a012afa6c5f82be998e002c8d3a98d6d4187198ac1fba6dea894b2e9307e2aa07cd5f28d8da17b27be
+    SHA512 b59f715cde44d54ab65a70df5605ee412a4c2189bfcaef8698efd53910fb45bda10b2c0f5a30b94ca8fe15ff5ce7a3cd4fc75aebaf3257ff5eaf3a95336f6c9e
     HEAD_REF master
     PATCHES
         cmake-config.diff

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "whisper-cpp",
-  "version": "1.8.4",
-  "port-version": 1,
+  "version": "1.8.5",
   "description": "Port of OpenAI's Whisper model in C/C++",
   "homepage": "https://github.com/ggml-org/whisper.cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10853,8 +10853,8 @@
       "port-version": 0
     },
     "whisper-cpp": {
-      "baseline": "1.8.4",
-      "port-version": 1
+      "baseline": "1.8.5",
+      "port-version": 0
     },
     "wiiuse": {
       "baseline": "0.15.7",

--- a/versions/w-/whisper-cpp.json
+++ b/versions/w-/whisper-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cc3662db13cb9a7c20cae896bcb088ffe65b0a3",
+      "version": "1.8.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "45e8b8f0f1292abbed112697fabab56529974233",
       "version": "1.8.4",
       "port-version": 1


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ggml-org/whisper.cpp/releases/tag/v1.8.5