### PR TITLE
[msgpack] update to 7.0.0

### DIFF
--- a/ports/msgpack-c/portfile.cmake
+++ b/ports/msgpack-c/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO msgpack/msgpack-c
     REF "c-${VERSION}"
-    SHA512 b211af122e894bc0c32fa02ebcc0130ac797d99b7c60688df26247bc020d51b7322b4858fd12a749d28812c5efb66b5dc687cdfe20f4bc68a21eb484d531230a
+    SHA512 839588b03af7d8319197bbda8e23aef82fee29cb861559d4a737638504441e9aa1cf5405f672ccaf60fdeb52329ecc7baed5208dfd8ea64fe8cf3f749eaa640c
     HEAD_REF c_master
 )
 

--- a/ports/msgpack-c/vcpkg.json
+++ b/ports/msgpack-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "msgpack-c",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.",
   "homepage": "https://github.com/msgpack/msgpack-c",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6757,7 +6757,7 @@
       "port-version": 0
     },
     "msgpack-c": {
-      "baseline": "6.1.0",
+      "baseline": "7.0.0",
       "port-version": 0
     },
     "msgpack11": {

--- a/versions/m-/msgpack-c.json
+++ b/versions/m-/msgpack-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4af81c77a1fe849a7882ab345989d1a6f45e62db",
+      "version": "7.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5c8acb24165351f4d83c4d56af97277d0be4f77a",
       "version": "6.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/msgpack/msgpack-c/releases/tag/c-7.0.0
