### PR TITLE
[hical61-hical] update to 2.6.4

### DIFF
--- a/ports/hical61-hical/portfile.cmake
+++ b/ports/hical61-hical/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Hical61/Hical
     REF "v${VERSION}"
-    SHA512 b6713a4b8eefdbc15c2dc2400ddbd76dc3f0dd484e70d074ebdc79dc77e4ab028b5a4690c47bfe9b03e68dacc70a6cde87397dbd28714a97c0acd7a27f87402f
+    SHA512 d550d2d5b78b323e6f8016eb2a10d96d1ee28cc32824ba9dedefd4b1b3bc2252b3b2c8a9ae06e0ca6c9980c6782372edeca2c24f36692480d413ec8358308c6f
     HEAD_REF main
 )
 

--- a/ports/hical61-hical/vcpkg.json
+++ b/ports/hical61-hical/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hical61-hical",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Modern C++20/C++26 high-performance web framework based on Boost.Asio with native HTTP/WebSocket stack",
   "homepage": "https://github.com/Hical61/Hical",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3817,7 +3817,7 @@
       "port-version": 0
     },
     "hical61-hical": {
-      "baseline": "2.6.3",
+      "baseline": "2.6.4",
       "port-version": 0
     },
     "hidapi": {

--- a/versions/h-/hical61-hical.json
+++ b/versions/h-/hical61-hical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "201ae5b9b0677a96d7beaab0e104565c55d1813e",
+      "version": "2.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "9b9d8c2075eff02c7516fbc15b0e837d9854cba9",
       "version": "2.6.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Hical61/Hical/releases/tag/v2.6.4
