### PR TITLE
[drogon] Early fix for empty async stream responses

### DIFF
--- a/ports/drogon/0005-fix-1.9.13-chunked-encoding-close-connection.patch
+++ b/ports/drogon/0005-fix-1.9.13-chunked-encoding-close-connection.patch
@@ -1,0 +1,53 @@
+diff --git a/lib/src/HttpResponseImpl.cc b/lib/src/HttpResponseImpl.cc
+index 7a36cee..90a18d6 100644
+--- a/lib/src/HttpResponseImpl.cc
++++ b/lib/src/HttpResponseImpl.cc
+@@ -750,7 +750,7 @@ void HttpResponseImpl::makeHeaderString(trantor::MsgBuffer &buffer)
+         {
+             // When the headers are created, it is time to set the transfer
+             // encoding to chunked if the contents size is not specified
+-            if (!ifCloseConnection() &&
++            if (version_ != Version::kHttp10 &&
+                 headers_.find("content-length") == headers_.end())
+             {
+                 LOG_DEBUG << "send stream with transfer-encoding chunked";
+diff --git a/lib/src/HttpServer.cc b/lib/src/HttpServer.cc
+index f6e4bff..e666e26 100644
+--- a/lib/src/HttpServer.cc
++++ b/lib/src/HttpServer.cc
+@@ -985,7 +985,7 @@ void HttpServer::sendResponse(const TcpConnectionPtr &conn,
+         auto &asyncStreamCallback = respImplPtr->asyncStreamCallback();
+         if (asyncStreamCallback)
+         {
+-            if (!respImplPtr->ifCloseConnection())
++            if (respImplPtr->version() != Version::kHttp10)
+             {
+                 asyncStreamCallback(
+                     std::make_unique<ResponseStream>(conn->sendAsyncStream(
+@@ -993,7 +993,7 @@ void HttpServer::sendResponse(const TcpConnectionPtr &conn,
+             }
+             else
+             {
+-                LOG_INFO << "Chunking Set CloseConnection !!!";
++                LOG_INFO << "Async stream not supported for HTTP/1.0";
+             }
+         }
+         auto &streamCallback = respImplPtr->streamCallback();
+@@ -1069,7 +1069,7 @@ void HttpServer::sendResponses(
+             {
+                 conn->send(buffer);
+                 buffer.retrieveAll();
+-                if (!respImplPtr->ifCloseConnection())
++                if (respImplPtr->version() != Version::kHttp10)
+                 {
+                     asyncStreamCallback(
+                         std::make_unique<ResponseStream>(conn->sendAsyncStream(
+@@ -1077,7 +1077,7 @@ void HttpServer::sendResponses(
+                 }
+                 else
+                 {
+-                    LOG_INFO << "Chunking Set CloseConnection !!!";
++                    LOG_INFO << "Async stream not supported for HTTP/1.0";
+                 }
+             }
+             auto &streamCallback = respImplPtr->streamCallback();

--- a/ports/drogon/portfile.cmake
+++ b/ports/drogon/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
          0002-drogon-config.patch
          0003-deps-redis.patch
          0004-drogon-ctl.patch
+         0005-fix-1.9.13-chunked-encoding-close-connection.patch
 )
 
 vcpkg_check_features(

--- a/ports/drogon/vcpkg.json
+++ b/ports/drogon/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "drogon",
   "version-semver": "1.9.13",
+  "port-version": 1,
   "description": "A C++14/17 based HTTP web application framework running on Linux/macOS/Unix/Windows",
   "homepage": "https://github.com/an-tao/drogon",
   "documentation": "https://drogon.docsforge.com/master/overview/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2626,7 +2626,7 @@
     },
     "drogon": {
       "baseline": "1.9.13",
-      "port-version": 0
+      "port-version": 1
     },
     "dstorage": {
       "baseline": "1.3.0",

--- a/versions/d-/drogon.json
+++ b/versions/d-/drogon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cff42d1531a49987579bde4c6aea966788f710da",
+      "version-semver": "1.9.13",
+      "port-version": 1
+    },
+    {
       "git-tree": "e3c4bfff746bbd58ac6fdaf2ac1b501d0871bdac",
       "version-semver": "1.9.13",
       "port-version": 0


### PR DESCRIPTION
This is an early patch for the accepted [PR #2527](https://github.com/drogonframework/drogon/pull/2527) of drogon.
(empty streamed responses body to client requests with `Connection: close`)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
