### PR TITLE
[ffmpeg] add twolame feature option

### DIFF
--- a/ports/ffmpeg/0049-fix-twolame-pkgconfig.patch
+++ b/ports/ffmpeg/0049-fix-twolame-pkgconfig.patch
@@ -1,0 +1,15 @@
+diff --git a/configure b/configure
+index 6d66d1e..3a54b6c 100644
+--- a/configure
++++ b/configure
+@@ -7384,8 +7384,8 @@ enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -
+ enabled libtls            && require_pkg_config libtls libtls tls.h tls_configure &&
+                              { enabled gpl && ! enabled nonfree && die "ERROR: LibreSSL is incompatible with the gpl"; }
+ enabled libtorch          && check_cxxflags -std=c++17 && require_cxx libtorch torch/torch.h "torch::Tensor" -ltorch -lc10 -ltorch_cpu -lstdc++ -lpthread
+-enabled libtwolame        && require libtwolame twolame.h twolame_init -ltwolame &&
+-                             { check_lib libtwolame twolame.h twolame_encode_buffer_float32_interleaved -ltwolame ||
++enabled libtwolame        && require_pkg_config libtwolame twolame twolame.h twolame_init &&
++                             { check_lib libtwolame twolame.h twolame_encode_buffer_float32_interleaved $libtwolame_extralibs ||
+                                die "ERROR: libtwolame must be installed and version must be >= 0.3.10"; }
+ enabled libuavs3d         && require_pkg_config libuavs3d "uavs3d >= 1.1.41" uavs3d.h uavs3d_decode
+ enabled libv4l2           && require_pkg_config libv4l2 libv4l2 libv4l2.h v4l2_ioctl

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         0046-fix-msvc-detection.patch
         0047-fix-msvc-utf8.patch
         0048-backport-23039.patch
+        0049-fix-twolame-pkgconfig.patch
 )
 
 if(SOURCE_PATH MATCHES " ")
@@ -497,6 +498,14 @@ if("theora" IN_LIST FEATURES)
 else()
     set(OPTIONS "${OPTIONS} --disable-libtheora")
     set(WITH_THEORA OFF)
+endif()
+
+if("twolame" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-libtwolame")
+    set(WITH_TWOLAME ON)
+else()
+    set(OPTIONS "${OPTIONS} --disable-libtwolame")
+    set(WITH_TWOLAME OFF)
 endif()
 
 if("vorbis" IN_LIST FEATURES)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "8.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -64,6 +64,7 @@
             "swresample",
             "swscale",
             "theora",
+            "twolame",
             "vorbis",
             "vpx",
             "vulkan",
@@ -650,6 +651,12 @@
       "description": "Theora encoding via libtheora",
       "dependencies": [
         "libtheora"
+      ]
+    },
+    "twolame": {
+      "description": "MP2 encoding via libtwolame",
+      "dependencies": [
+        "libtwolame"
       ]
     },
     "vaapi": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3026,7 +3026,7 @@
     },
     "ffmpeg": {
       "baseline": "8.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ffmpeg-bin2c": {
       "baseline": "8.1.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3eec7480c1d2f5b777715b974c2935e5a57b06df",
+      "version": "8.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "87b34997b862634271df57cd4657ed0c6dcf4985",
       "version": "8.1.1",
       "port-version": 1


### PR DESCRIPTION
Follow-up to PR #51728
This PR adds a feature option to enable the libtwolame MP2 encoder in ffmpeg.

ffmpeg was tested encoding mpeg 2 files using twolame.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
