### PR TITLE
[salome-med-fichier] fix cross-compilation failure on arm64-linux

### DIFF
--- a/ports/salome-med-fichier/portfile.cmake
+++ b/ports/salome-med-fichier/portfile.cmake
@@ -35,6 +35,11 @@ endforeach()
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static"  MEDFILE_BUILD_STATIC_LIBS)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic"  MEDFILE_BUILD_SHARED_LIBS)
 
+# Ensure a host-compatible pkg-config is used. During cross-compilation, the target
+# triplet's pkgconf (e.g. arm64) cannot execute on the host. Without this, CMake may
+# cache the wrong PKG_CONFIG_EXECUTABLE, breaking find_dependency(MPI) from hdf5-config.
+vcpkg_find_acquire_program(PKGCONFIG)
+
 # If there are problems with the cmake build try switching to autotools for !windows
 vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE # Writes into the source dir
@@ -45,6 +50,7 @@ vcpkg_cmake_configure(
       -DMEDFILE_INSTALL_DOC=OFF
       -DMEDFILE_BUILD_TESTS=OFF
       -DCMAKE_Fortran_COMPILER=NOTFOUND # Disable Fortran
+      "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
     )
 
 vcpkg_cmake_install()

--- a/ports/salome-med-fichier/vcpkg.json
+++ b/ports/salome-med-fichier/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "salome-med-fichier",
   "version": "4.1.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "med-fichier provides a low level C API for fine-grained access to the structure of MED files (.med)",
   "homepage": "https://www.salome-platform.org",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9010,7 +9010,7 @@
     },
     "salome-med-fichier": {
       "baseline": "4.1.1",
-      "port-version": 4
+      "port-version": 5
     },
     "salome-medcoupling": {
       "baseline": "9.10.0",

--- a/versions/s-/salome-med-fichier.json
+++ b/versions/s-/salome-med-fichier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5931d9d100aa4c7103471af4e461790883266cd0",
+      "version": "4.1.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "17749288e0218249b7dca4398828532a16853ed3",
       "version": "4.1.1",
       "port-version": 4


### PR DESCRIPTION
Pass a host-compatible PKG_CONFIG_EXECUTABLE to cmake configure to prevent CMake from caching the target triplet's pkgconf binary (which cannot execute on the x86_64 host). This fixes the BUILD_FAILED regression where hdf5-config.cmake's find_dependency(MPI) fails because FindMPI cannot use the arm64 pkgconf to discover MPI libraries.

Follows the same pattern as freerdp, openvino, and other cross-compilation aware ports.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.
