### PR TITLE
[cnats] Update to 3.13.0

### DIFF
--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nats-io/nats.c
     REF "v${VERSION}"
-    SHA512 d1243cd3ea2bc4cffb50b12acb745a3b573eacdc30457dc59ae33def0217ec090df6c706c67cba4ee75ade6db5adf3742affed771aeb77305048a18d8bbac695
+    SHA512 32b2c5bd5569a132604b1e1a88bd7d6b84376287c1d55e1d2daa34eafa13c0772127bda5cca3be74984c06cc0821f7ac6624c2d74c257eaa04bc61865b6945db
     HEAD_REF main
     PATCHES
         fix-sodium-dep.patch

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cnats",
-  "version": "3.12.0",
-  "port-version": 2,
+  "version": "3.13.0",
   "description": "A C client for the NATS messaging system",
   "homepage": "https://github.com/nats-io/nats.c",
   "license": "Apache-2.0",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -194,7 +194,6 @@ clipboardxx:arm64-linux=fail
 clockutils:arm-neon-android=fail # gnustl_shared is no longer supported. Please switch to either c++_shared or c++_static.
 clockutils:arm64-android=fail
 clockutils:x64-android=fail
-cnats[sodium]:arm64-linux=cascade
 coin:arm64-linux=fail
 coin[openal]:arm64-linux=feature-fails
 coin-or-cbc:arm64-linux=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1873,8 +1873,8 @@
       "port-version": 0
     },
     "cnats": {
-      "baseline": "3.12.0",
-      "port-version": 2
+      "baseline": "3.13.0",
+      "port-version": 0
     },
     "cnl": {
       "baseline": "1.1.7",

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19fb2027fc67cac4566a203a95c50f1febe8f37b",
+      "version": "3.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c4ea79353736c06af4962a47ccdfe91f2109b04b",
       "version": "3.12.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 3.13.0
