### PR TITLE
[stillwater-universal] Update to 4.7.2

### DIFF
--- a/ports/stillwater-universal/portfile.cmake
+++ b/ports/stillwater-universal/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stillwater-sc/universal
     REF "v${VERSION}"
-    SHA512 7b6fd7855d2041da0f57bf9dc5887cd6cfa517ac75a7ae7076a0f2f23ce71894ef35cadf64a105e1e3b14fc2dcc9bc84b08ecedf440d79b00d2ea156b3f337e9
+    SHA512 90128895ae7d77060acfc83148908a5b51569c6e57c67ac231f510ddffa5119105e752ae789e0c51364eb783a4f876ca912dde405578d42d65a88f378a8e8d24
     HEAD_REF master
     PATCHES
         fix-install-path.patch

--- a/ports/stillwater-universal/vcpkg.json
+++ b/ports/stillwater-universal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stillwater-universal",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "A header-only C++ library for plug-in replacement number systems for native types",
   "homepage": "https://github.com/stillwater-sc/universal",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9713,7 +9713,7 @@
       "port-version": 0
     },
     "stillwater-universal": {
-      "baseline": "4.7.1",
+      "baseline": "4.7.2",
       "port-version": 0
     },
     "stlab": {

--- a/versions/s-/stillwater-universal.json
+++ b/versions/s-/stillwater-universal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a55ee555cbce98502d9d57d44e1158de33a8c80",
+      "version": "4.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "47025f8cc194ddeef22c11e9fa104b066d693c16",
       "version": "4.7.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 4.7.2
