### PR TITLE
[curl] Expose Apple SecTrust build option

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -15,36 +15,37 @@ vcpkg_replace_string("${SOURCE_PATH}/include/curl/curlver.h" [[LIBCURL_TIMESTAMP
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        brotli      CURL_BROTLI
-        c-ares      ENABLE_ARES
-        gnutls      CURL_USE_GNUTLS
-        gsasl       CURL_USE_GSASL
-        gssapi      CURL_USE_GSSAPI
-        gssapi      VCPKG_LOCK_FIND_PACKAGE_GSS
-        http2       USE_NGHTTP2
-        http2       VCPKG_LOCK_FIND_PACKAGE_NGHTTP2
-        http3       USE_NGTCP2
-        httpsrr     USE_HTTPSRR
-        idn2        USE_LIBIDN2
-        idn2        VCPKG_LOCK_FIND_PACKAGE_Libidn2
-        ldap        VCPKG_LOCK_FIND_PACKAGE_LDAP
-        mbedtls     CURL_USE_MBEDTLS
-        openssl     CURL_CA_FALLBACK
-        openssl     CURL_USE_OPENSSL
-        psl         CURL_USE_LIBPSL
-        ssh         CURL_USE_LIBSSH2
-        ssh         VCPKG_LOCK_FIND_PACKAGE_Libssh2
-        ssls-export USE_SSLS_EXPORT
-        sspi        CURL_WINDOWS_SSPI
-        tool        BUILD_CURL_EXE
-        winidn      USE_WIN32_IDN
-        wolfssl     CURL_USE_WOLFSSL
-        zstd        CURL_ZSTD
+        apple-sectrust USE_APPLE_SECTRUST
+        brotli         CURL_BROTLI
+        c-ares         ENABLE_ARES
+        gnutls         CURL_USE_GNUTLS
+        gsasl          CURL_USE_GSASL
+        gssapi         CURL_USE_GSSAPI
+        gssapi         VCPKG_LOCK_FIND_PACKAGE_GSS
+        http2          USE_NGHTTP2
+        http2          VCPKG_LOCK_FIND_PACKAGE_NGHTTP2
+        http3          USE_NGTCP2
+        httpsrr        USE_HTTPSRR
+        idn2           USE_LIBIDN2
+        idn2           VCPKG_LOCK_FIND_PACKAGE_Libidn2
+        ldap           VCPKG_LOCK_FIND_PACKAGE_LDAP
+        mbedtls        CURL_USE_MBEDTLS
+        openssl        CURL_CA_FALLBACK
+        openssl        CURL_USE_OPENSSL
+        psl            CURL_USE_LIBPSL
+        ssh            CURL_USE_LIBSSH2
+        ssh            VCPKG_LOCK_FIND_PACKAGE_Libssh2
+        ssls-export    USE_SSLS_EXPORT
+        sspi           CURL_WINDOWS_SSPI
+        tool           BUILD_CURL_EXE
+        winidn         USE_WIN32_IDN
+        wolfssl        CURL_USE_WOLFSSL
+        zstd           CURL_ZSTD
     INVERTED_FEATURES
-        ldap        CURL_DISABLE_LDAP
-        ldap        CURL_DISABLE_LDAPS
-        non-http    HTTP_ONLY
-        websockets  CURL_DISABLE_WEBSOCKETS
+        ldap           CURL_DISABLE_LDAP
+        ldap           CURL_DISABLE_LDAPS
+        non-http       HTTP_ONLY
+        websockets     CURL_DISABLE_WEBSOCKETS
 )
 
 if("ssl" IN_LIST FEATURES AND

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "8.20.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -21,6 +21,19 @@
     "ssl"
   ],
   "features": {
+    "apple-sectrust": {
+      "description": "Apple SecTrust support",
+      "supports": "osx | ios",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ]
+        }
+      ]
+    },
     "brotli": {
       "description": "brotli support (brotli)",
       "dependencies": [

--- a/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
@@ -91,6 +91,14 @@
             "tool"
           ],
           "platform": "!android & !uwp & !arm"
+        },
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "apple-sectrust"
+          ],
+          "platform": "osx | ios"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2278,7 +2278,7 @@
     },
     "curl": {
       "baseline": "8.20.0",
-      "port-version": 1
+      "port-version": 2
     },
     "curlcpp": {
       "baseline": "3.1",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b002aad48cf2740ca6b3a74ed4bb94cb7f50c72",
+      "version": "8.20.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "94fb76b63c2f0251b57301ba9842ebe9ff2b6164",
       "version": "8.20.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #48355
Closes #51089
Closes #52158
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
