### PR TITLE
Add tesults-gtest v1.0.2

### DIFF
--- a/ports/tesults-gtest/portfile.cmake
+++ b/ports/tesults-gtest/portfile.cmake
@@ -1,0 +1,20 @@
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tesults/tesults-gtest
+    REF "v${VERSION}"
+    SHA512 674f8c10e02b77e7c00ac9188651eb1c3be5d649cda029b3b577a5d2c4ede58521b04620354b9032d3892a8a704a59047b6de0c293d9705a575b4ba437cb8682
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tesults-gtest)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tesults-gtest/vcpkg.json
+++ b/ports/tesults-gtest/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "tesults-gtest",
+  "version": "1.0.2",
+  "description": "Google Test event listener for reporting test results to Tesults",
+  "homepage": "https://github.com/tesults/tesults-gtest",
+  "license": "MIT",
+  "dependencies": [
+    "gtest",
+    "tesults-cpp",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9992,6 +9992,10 @@
       "baseline": "1.0.2",
       "port-version": 0
     },
+    "tesults-gtest": {
+      "baseline": "1.0.2",
+      "port-version": 0
+    },
     "tevclient": {
       "baseline": "2023-12-04",
       "port-version": 0

--- a/versions/t-/tesults-gtest.json
+++ b/versions/t-/tesults-gtest.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ae471f7747d4d2a9532c9d9af689cff72799fe82",
+      "version": "1.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the `gtest-tesults` port — a header-only Google Test event listener that reports test results to [Tesults](https://www.tesults.com).

- **Homepage**: https://github.com/tesults/gtest-tesults
- **License**: MIT
- **Version**: 1.0.1

### Port details

| Field | Value |
|---|---|
| Name | `gtest-tesults` |
| Version | `1.0.1` |
| Type | Header-only (INTERFACE library) |
| Dependencies | `gtest`, `tesults-cpp` |

### Usage

Set `TESULTS_TARGET` and register the listener before running tests:

```cpp
#include <gtest_tesults/gtest_tesults.h>
// auto-registers from TESULTS_TARGET env var — no code changes needed
```

Or register manually:

```cpp
auto cfg = gtest_tesults::config_from_args(argc, argv);
testing::UnitTest::GetInstance()->listeners().Append(new gtest_tesults::TesultsListener(cfg));
```

### Testing

Port was tested locally on macOS (Apple Silicon) with:
- CMake 3.14+
- AppleClang 21
- `vcpkg install gtest-tesults`

### Checklist

- [x] Port files follow vcpkg conventions
- [x] `vcpkg x-add-version` run and versioning files committed
- [x] SHA512 verified against GitHub archive
- [x] `vcpkg_install_copyright` included
- [x] Header-only: `set(VCPKG_BUILD_TYPE release)` and debug/lib dirs removed
- [x] `find_dependency` declarations in installed CMake config
- [x] Single version in versions file