### PR TITLE
[grpc] fix `obj too big` error on mingw

### DIFF
--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -46,6 +46,11 @@ vcpkg_check_features(
         systemd     gRPC_USE_SYSTEMD
 )
 
+# Add big object support for MinGW
+if(VCPKG_TARGET_IS_MINGW)
+    list(APPEND FEATURE_OPTIONS "-DCMAKE_CXX_FLAGS=-Wa,-mbig-obj")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -48,7 +48,8 @@ vcpkg_check_features(
 
 # Add big object support for MinGW
 if(VCPKG_TARGET_IS_MINGW)
-    list(APPEND FEATURE_OPTIONS "-DCMAKE_CXX_FLAGS=-Wa,-mbig-obj")
+    string(APPEND VCPKG_C_FLAGS " -Wa,-mbig-obj")
+    string(APPEND VCPKG_CXX_FLAGS " -Wa,-mbig-obj")
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/grpc/vcpkg.json
+++ b/ports/grpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "grpc",
   "version-semver": "1.76.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "gRPC is a modern, open source, high-performance remote procedure call (RPC) framework that can run anywhere. gRPC enables client and server applications to communicate transparently, and simplifies the building of connected systems.",
   "homepage": "https://github.com/grpc/grpc",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3578,7 +3578,7 @@
     },
     "grpc": {
       "baseline": "1.76.0",
-      "port-version": 1
+      "port-version": 2
     },
     "grppi": {
       "baseline": "0.4.0",

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f41b57508f699e0ace610a4a85cd2dd5a8cef390",
+      "git-tree": "c9cdcf1533332b08638f3d8ea6215c76d2be31d7",
       "version-semver": "1.76.0",
       "port-version": 2
     },

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f41b57508f699e0ace610a4a85cd2dd5a8cef390",
+      "version-semver": "1.76.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "e749bf197089f61aa87fd888a607296200aa2a89",
       "version-semver": "1.76.0",
       "port-version": 1


### PR DESCRIPTION
Fix `obj too big` error on MinGW.

Fixes #52155

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
