### PR TITLE
[cpu-features] update to 0.11.0

### DIFF
--- a/ports/cpu-features/portfile.cmake
+++ b/ports/cpu-features/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/cpu_features
     REF "v${VERSION}"
-    SHA512 40c314c584fcf109d9a641c055cb75f335fd5425dd336fe831828b956226eaf0ac2fd8ffceeaf10e02afa9cec01cb0ddc6af8ff78f20dd925783e6958d0b9304
+    SHA512 6e3f484a6cd676d1c0b5571642397289dae3979085140d1324c10c5a971b34e9e46293217cbdf62f02a4b0632fb631fefeee876d579bafeeec1a0b75ba466809
     HEAD_REF master
     PATCHES
         0001-ndk-compat-export-include-dirs.patch

--- a/ports/cpu-features/vcpkg.json
+++ b/ports/cpu-features/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cpu-features",
-  "version": "0.10.1",
-  "port-version": 1,
+  "version": "0.11.0",
   "description": "A cross-platform C library to retrieve CPU features (such as available instructions) at runtime",
   "homepage": "https://github.com/google/cpu_features",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2153,8 +2153,8 @@
       "port-version": 0
     },
     "cpu-features": {
-      "baseline": "0.10.1",
-      "port-version": 1
+      "baseline": "0.11.0",
+      "port-version": 0
     },
     "cpuid": {
       "baseline": "0.8.1",

--- a/versions/c-/cpu-features.json
+++ b/versions/c-/cpu-features.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29d983585753586944922dc241710fad6c7dabc4",
+      "version": "0.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "40c5147fa5fa1c44dbcb3b3e9f9722ad005dab18",
       "version": "0.10.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/google/cpu_features/releases/tag/v0.11.0
