### PR TITLE
[alsa] update to 1.2.16

### DIFF
--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alsa-project/alsa-lib
     REF "v${VERSION}"
-    SHA512 0b8a7d83a0bbce2153475923dff0fe47ed946a8adf2022f5f99c027465bd1c04a4eb06861c72bd88943b1af9b46b7967f8417f14c0261623e130ebde4e833e5d
+    SHA512 8cdc28e1c978e76d32ab4b3f4054e30e0313cd53794c30e2b1edb47495d71f5a3ada7eac406e9493ef8230595e765e7488aa579f9613edb4531e77a47a1b5c36
     HEAD_REF master
     PATCHES
         fix-plugin-dir.patch

--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alsa-project/alsa-lib
     REF "v${VERSION}"
-    SHA512 8cdc28e1c978e76d32ab4b3f4054e30e0313cd53794c30e2b1edb47495d71f5a3ada7eac406e9493ef8230595e765e7488aa579f9613edb4531e77a47a1b5c36
+    SHA512 9de428db87d8706e89c3985f338d9cf306b91427402ca2e4154b2da334033dc8a3aa365d41b2d831a0d9cedda0d5f833b31699c23be685f0d5ca457328f1b2b1
     HEAD_REF master
     PATCHES
         fix-plugin-dir.patch

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alsa",
-  "version": "1.2.16",
+  "version": "1.2.16.1",
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "alsa",
-  "version": "1.2.15.3",
-  "port-version": 1,
+  "version": "1.2.16",
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cc9e7fe273ca061e363a4bfc1c927fdeaae9472",
+      "version": "1.2.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "f816bc653d9b4942df8c704837de9d88c1ae330f",
       "version": "1.2.15.3",
       "port-version": 1

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d14578d365187686dfcaea991f88ed179d6898d",
+      "version": "1.2.16.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7cc9e7fe273ca061e363a4bfc1c927fdeaae9472",
       "version": "1.2.16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -109,8 +109,8 @@
       "port-version": 0
     },
     "alsa": {
-      "baseline": "1.2.15.3",
-      "port-version": 1
+      "baseline": "1.2.16",
+      "port-version": 0
     },
     "amd-adl-sdk": {
       "baseline": "18.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -109,7 +109,7 @@
       "port-version": 0
     },
     "alsa": {
-      "baseline": "1.2.16",
+      "baseline": "1.2.16.1",
       "port-version": 0
     },
     "amd-adl-sdk": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/alsa-project/alsa-lib/releases/tag/v1.2.16
