### PR TITLE
[whisper-cpp] update to 1.8.6

### DIFF
--- a/ports/whisper-cpp/portfile.cmake
+++ b/ports/whisper-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/whisper.cpp
     REF "v${VERSION}"
-    SHA512 b59f715cde44d54ab65a70df5605ee412a4c2189bfcaef8698efd53910fb45bda10b2c0f5a30b94ca8fe15ff5ce7a3cd4fc75aebaf3257ff5eaf3a95336f6c9e
+    SHA512 f686f7e4cb7a0c8d5734c21bbe7ba5225c559007a8ab91a14a140e22f9fbe2353ae19df6a4306fb85737ff2dc698804e4c626085bf951cde60123cfd2d0ae8a1
     HEAD_REF master
     PATCHES
         cmake-config.diff

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "whisper-cpp",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Port of OpenAI's Whisper model in C/C++",
   "homepage": "https://github.com/ggml-org/whisper.cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10853,7 +10853,7 @@
       "port-version": 0
     },
     "whisper-cpp": {
-      "baseline": "1.8.5",
+      "baseline": "1.8.6",
       "port-version": 0
     },
     "wiiuse": {

--- a/versions/w-/whisper-cpp.json
+++ b/versions/w-/whisper-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc0fb0138cef78a65ce8c3c48ad680dfb53e1b8e",
+      "version": "1.8.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "7cc3662db13cb9a7c20cae896bcb088ffe65b0a3",
       "version": "1.8.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ggml-org/whisper.cpp/releases/tag/v1.8.6
