### PR TITLE
[fastcdr] Update to 2.3.6

### DIFF
--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-CDR
     REF "v${VERSION}"
-    SHA512 cdf13b4801ec9a5dcc7f5b30963db75645f6e0287d4dbac46dbc2eb8e3881a5cdd4318f71178e3903b40fcddcc2b6d70a4a66ac2b5cf8a2e29161e1e0b1a5a94
+    SHA512 5c53d2b5abb433b8065e6eb3d819c60cc0e0fd7f25e92eb5d6e501c0590f47c90717f32c90c2b4b3a953454cad2e34094caa80845d763a8f0f97df56dba2963e
     HEAD_REF master
     PATCHES
         pdb-file.patch

--- a/ports/fastcdr/vcpkg.json
+++ b/ports/fastcdr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcdr",
-  "version-semver": "2.3.5",
+  "version-semver": "2.3.6",
   "description": "eProsima FastCDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.",
   "homepage": "https://github.com/eProsima/Fast-CDR",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2953,7 +2953,7 @@
       "port-version": 0
     },
     "fastcdr": {
-      "baseline": "2.3.5",
+      "baseline": "2.3.6",
       "port-version": 0
     },
     "fastcgi": {

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abf3734f6609154243da486fcb01d94e211423c0",
+      "version-semver": "2.3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "b099bffa7914cb2510f23cbfc2f6958d8f272137",
       "version-semver": "2.3.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.3.6
