### PR TITLE
[gamenetworkingsockets] Update to 1.6.0

### DIFF
--- a/ports/gamenetworkingsockets/portfile.cmake
+++ b/ports/gamenetworkingsockets/portfile.cmake
@@ -1,27 +1,50 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/GameNetworkingSockets
-    REF fa489fd2cb0fc86ef2503e330935d3eb03a6a064 # v1.5.1
-    SHA512 7a69444b1951c46c0f74fce1566279257260ee3d382bbec4f43d68818ed467639af32235bb06b3779b4f8b3ce1ef451e449e136d1a9e9493688149eac88e07c9
+    REF "2cb93a06350bb065db53abdb0d87cf297e0bfd34" # v1.6.0
+    SHA512 c2deaa3aab42cd840dd13560ca4da40faa375ab846ea15af38d55eb7acc48cfe8cbdbe0c76b9c3484d26f9e1163e36ac1eb73a317e5c19cefe60d0b861d19e06
     HEAD_REF master
 )
 
-set(CRYPTO_BACKEND OpenSSL)
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        ice             ENABLE_ICE
+)
+
+# Select static vs dynamic based on the triplet.
+if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic")
+    set(BUILD_SHARED_LIB ON)
+    set(BUILD_STATIC_LIB OFF)
+else()
+    set(BUILD_SHARED_LIB OFF)
+    set(BUILD_STATIC_LIB ON)
+endif()
+
+# Link the MSVC CRT statically when the CRT linkage is static.
+# Not used on non-MSVC platforms; listed in MAYBE_UNUSED_VARIABLES accordingly.
+if("${VCPKG_CRT_LINKAGE}" STREQUAL "static")
+    set(MSVC_CRT_STATIC ON)
+else()
+    set(MSVC_CRT_STATIC OFF)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DUSE_CRYPTO=OpenSSL
+        -DBUILD_STATIC_LIB=${BUILD_STATIC_LIB}
+        -DBUILD_SHARED_LIB=${BUILD_SHARED_LIB}
+        -DMSVC_CRT_STATIC=${MSVC_CRT_STATIC}
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TOOLS=OFF
-        -DUSE_CRYPTO=${CRYPTO_BACKEND}
-        -DUSE_CRYPTO25519=${CRYPTO_BACKEND}
+        ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        MSVC_CRT_STATIC
 )
 
 vcpkg_cmake_install()
-
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/GameNetworkingSockets")
 vcpkg_fixup_pkgconfig()
 

--- a/ports/gamenetworkingsockets/vcpkg.json
+++ b/ports/gamenetworkingsockets/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "gamenetworkingsockets",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "GameNetworkingSockets is a basic transport layer for games.",
   "homepage": "https://github.com/ValveSoftware/GameNetworkingSockets",
   "license": "BSD-3-Clause",
-  "supports": "!(static & windows) & !uwp & !(arm64 & windows)",
+  "supports": "!uwp & !(arm64 & windows)",
   "dependencies": [
     "openssl",
     "protobuf",
@@ -16,5 +16,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "ice"
+  ],
+  "features": {
+    "ice": {
+      "description": "Build support for P2P connections using the native ICE client (STUN and TURN)."
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3293,7 +3293,7 @@
       "port-version": 0
     },
     "gamenetworkingsockets": {
-      "baseline": "1.5.1",
+      "baseline": "1.6.0",
       "port-version": 0
     },
     "gamma": {

--- a/versions/g-/gamenetworkingsockets.json
+++ b/versions/g-/gamenetworkingsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "191b0554b5826ec511edea3624228c9731b1c09e",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8be3126471e2fa085c5fa6a7cf98f2c648a583a6",
       "version": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
- Bump to v1.6.0
- Add `ice` feature (STUN/TURN P2P support), enabled by default
- Remove `ONLY_DYNAMIC_LIBRARY` restriction; static linking now works