### PR TITLE
[cpr] Expose cpr SSL backend options

### DIFF
--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -10,14 +10,24 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        ssl CPR_ENABLE_SSL
+        openssl CPR_FORCE_OPENSSL_BACKEND
+        mbedtls CPR_FORCE_MBEDTLS_BACKEND
+        winssl  CPR_FORCE_WINSSL_BACKEND
 )
+
+# The generic "ssl" feature enables SSL with auto-detection; any forced backend
+# implies SSL too. With none selected cpr builds without SSL.
+set(CPR_ENABLE_SSL OFF)
+if("ssl" IN_LIST FEATURES OR "openssl" IN_LIST FEATURES OR "mbedtls" IN_LIST FEATURES OR "winssl" IN_LIST FEATURES)
+    set(CPR_ENABLE_SSL ON)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCPR_BUILD_TESTS=OFF
         -DCPR_USE_SYSTEM_CURL=ON
+        -DCPR_ENABLE_SSL=${CPR_ENABLE_SSL}
         ${FEATURE_OPTIONS}
         # skip test for unused sanitizer flags
         -DTHREAD_SANITIZER_AVAILABLE=OFF

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpr",
   "version-semver": "1.14.2",
+  "port-version": 1,
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "license": "MIT",
@@ -22,8 +23,34 @@
     "ssl"
   ],
   "features": {
+    "mbedtls": {
+      "description": "Use the Mbed TLS SSL backend.",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "mbedtls"
+          ]
+        },
+        "mbedtls"
+      ]
+    },
+    "openssl": {
+      "description": "Use the OpenSSL SSL backend.",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ]
+        },
+        "openssl"
+      ]
+    },
     "ssl": {
-      "description": "Enable SSL support",
+      "description": "Enable SSL support, letting cpr auto-detect the backend.",
       "dependencies": [
         {
           "name": "curl",
@@ -35,6 +62,19 @@
         {
           "name": "openssl",
           "platform": "linux"
+        }
+      ]
+    },
+    "winssl": {
+      "description": "Use the Windows native Schannel (WinSSL) backend.",
+      "supports": "windows",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "ssl"
+          ]
         }
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2150,7 +2150,7 @@
     },
     "cpr": {
       "baseline": "1.14.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cpu-features": {
       "baseline": "0.11.0",

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6426f78a3166512a107b0932c1b4a8e72e684763",
+      "version-semver": "1.14.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "9831fce6b2847eab6889364642da31eb7a13f02f",
       "version-semver": "1.14.2",
       "port-version": 0


### PR DESCRIPTION
This PR exposes various cpr build options as feature flags that allow for greater control over which SSL backends are being pulled in.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

