### PR TITLE
[luabridge3] update to 3.0-rc12

### DIFF
--- a/ports/luabridge3/portfile.cmake
+++ b/ports/luabridge3/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kunitoki/LuaBridge3
-    REF b892ce066217601928fbc3f37a6a8706faf410da # 3.0-rc11
-    SHA512 2574c804b18581cc5ac0966690135b4ff8145bf821c6d682279af10ede5a4d2a58a0f20fa3f1485bd16b33ebfca38937e9aabad8198f0bf3c8070dcf31372af0
+    REF 53e031b7df6a14d43f92a54fd792b76dbadcc970 # 3.0-rc12
+    SHA512 0e07beddf2c48e4ad48733ca8d0d6dded6b23bc670ccf887cf21e468ccdc06e78fae1966c07cfee06fd4d8452c0abc91a9df6542cc4837fe0d11d1cd73e9b1a8
     HEAD_REF master
 )
 

--- a/ports/luabridge3/vcpkg.json
+++ b/ports/luabridge3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luabridge3",
-  "version": "3.0-rc11",
+  "version": "3.0-rc12",
   "description": "A lightweight, dependency-free, suitable for game development library for binding Lua to C++17",
   "homepage": "https://github.com/kunitoki/LuaBridge3",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6225,7 +6225,7 @@
       "port-version": 0
     },
     "luabridge3": {
-      "baseline": "3.0-rc11",
+      "baseline": "3.0-rc12",
       "port-version": 0
     },
     "luafilesystem": {

--- a/versions/l-/luabridge3.json
+++ b/versions/l-/luabridge3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76487dfd2911ea569c1cc6a1b901f432ed1b5a7b",
+      "version": "3.0-rc12",
+      "port-version": 0
+    },
+    {
       "git-tree": "1aea2c35deba7675a7c6d04050d8752dd2143184",
       "version": "3.0-rc11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/kunitoki/LuaBridge3/releases/tag/3.0-rc12
