### PR TITLE
[sdl3-mixer] update to 3.2.4

### DIFF
--- a/ports/sdl3-mixer/portfile.cmake
+++ b/ports/sdl3-mixer/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO libsdl-org/SDL_mixer
     REF "release-${VERSION}"
     HEAD_REF main
-    SHA512 9c66e0157c6a8e8d2269a7979da099618bcff760a641ed8949c42e806f4ffe07df908f3b62caf40a24cfba10f918a86ec21c4ecef2a1e9611a80935440035783
+    SHA512 f173ff0346c1645f665fc17c78021b0487fcb2742a6228663872afc0ff926c1f19e3e3c150f352020b7523bb5de924390980dd8978c4b223cde83a16048f0d2d
     PATCHES
         fluidsynth.diff
 )

--- a/ports/sdl3-mixer/vcpkg.json
+++ b/ports/sdl3-mixer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3-mixer",
-  "version": "3.2.2",
+  "version": "3.2.4",
   "description": "An audio mixer that supports various file formats for Simple Directmedia Layer.",
   "homepage": "https://github.com/libsdl-org/SDL_mixer",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9121,7 +9121,7 @@
       "port-version": 0
     },
     "sdl3-mixer": {
-      "baseline": "3.2.2",
+      "baseline": "3.2.4",
       "port-version": 0
     },
     "sdl3-net": {

--- a/versions/s-/sdl3-mixer.json
+++ b/versions/s-/sdl3-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecff2e2a49731c660bd451c0707c6935f4659de6",
+      "version": "3.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "7eea821bd013f9c2019acdecd0cbd43a7fbbdaa7",
       "version": "3.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libsdl-org/SDL_mixer/releases/tag/release-3.2.4
