### PR TITLE
[libmultisense] update to 7.9.0

### DIFF
--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO carnegierobotics/LibMultiSense
     REF ${VERSION}
-    SHA512 71c779cc0f23818aaab4cbba0a5aa5b3ad979180247a3d76b0f8fd5a3b7ced106520fa5df69946cd84510211b6508f5df80b09aecbbabb6601fee5f38ec79bc7
+    SHA512 3f1278a2996517a6ca3c1baed765499365ab1bfd7a15e229e3d5babc7ee41c99b804a69d9e1f9ee9f3e075e01fd9624c04e98e3fad2f7b6b10c8986bd2bbe5a3
     HEAD_REF master
     PATCHES
         0000-disable-error-on-warning.patch

--- a/ports/libmultisense/vcpkg.json
+++ b/ports/libmultisense/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmultisense",
-  "version": "7.6.0",
+  "version": "7.9.0",
   "description": "A C++ library for interfacing with the MultiSense S family of sensors from Carnegie Robotics.",
   "homepage": "https://github.com/carnegierobotics/LibMultiSense",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5333,7 +5333,7 @@
       "port-version": 1
     },
     "libmultisense": {
-      "baseline": "7.6.0",
+      "baseline": "7.9.0",
       "port-version": 0
     },
     "libmupdf": {

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "874494b29bd6789da929ecd69d9ec19e584b1993",
+      "version": "7.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "88faa7763bbf94f2670b23f179e1a8a840965582",
       "version": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/carnegierobotics/LibMultiSense/releases/tag/7.9.0
