### PR TITLE
[openal-soft] update to 1.25.2

### DIFF
--- a/ports/openal-soft/devendor-fmt.diff
+++ b/ports/openal-soft/devendor-fmt.diff
@@ -1,23 +1,24 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b65e924..814d59e 100644
+index 57a4c77..4a8089f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -256,7 +256,8 @@ if(ALSOFT_ENABLE_MODULES)
+@@ -258,8 +258,8 @@ if(ALSOFT_ENABLE_MODULES)
  endif()
  
  
 -add_subdirectory(fmt-11.2.0 EXCLUDE_FROM_ALL)
+-
 +find_package(fmt CONFIG REQUIRED)
 +add_library(alsoft::fmt ALIAS fmt::fmt)
  
- 
  set(CPP_DEFS ) # C pre-processor, not C++
-@@ -1614,7 +1615,7 @@ if(LIBTYPE STREQUAL "STATIC")
+ set(INC_PATHS )
+@@ -1729,7 +1729,7 @@ if(LIBTYPE STREQUAL "STATIC")
      target_compile_definitions(${IMPL_TARGET} PUBLIC AL_LIBTYPE_STATIC)
      target_include_directories(${IMPL_TARGET} PRIVATE ${OpenAL_SOURCE_DIR}/gsl/include)
-     target_link_libraries(${IMPL_TARGET} PRIVATE ${LINKER_FLAGS} ${EXTRA_LIBS} ${MATH_LIB}
--        $<BUILD_LOCAL_INTERFACE:alsoft::fmt>)
-+        alsoft::fmt)
+     target_link_libraries(${IMPL_TARGET} PRIVATE Threads::Threads ${LINKER_FLAGS} ${EXTRA_LIBS}
+-        ${MATH_LIB} $<BUILD_LOCAL_INTERFACE:alsoft::fmt>)
++        ${MATH_LIB} alsoft::fmt)
  
      if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET
          AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.13")

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcat/openal-soft
     REF ${VERSION}
-    SHA512 47eccb317ed6040c549f2b51d2d45afcdcd03d56d8cb0ea9ef8a98d2c61c9629ffad39596cffa2ad848dd3b65a227a6591406dc483ebd3a3e03bb0a4d0f112b1
+    SHA512 d3790aedce0bdb0b348b35f917dec0626de2486f5967c9160cf2d50d5c2a00ff264ff73133ac6a0aa9207e8e5042e5d4fcc663c1e733df8e733647e843c39b25
     HEAD_REF master
     PATCHES
         pkgconfig-cxx.diff

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openal-soft",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7317,7 +7317,7 @@
       "port-version": 0
     },
     "openal-soft": {
-      "baseline": "1.25.1",
+      "baseline": "1.25.2",
       "port-version": 0
     },
     "openblas": {

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cba35aaad1988e69d2d2f3da65fc211fc64b7409",
+      "version": "1.25.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6aef35d27ec2119c280b9a60324226cba2ddea27",
       "version": "1.25.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/kcat/openal-soft/releases/tag/1.25.2
