### PR TITLE
[earcut-hpp] include cstdint

### DIFF
--- a/ports/earcut-hpp/include-cstdint.patch
+++ b/ports/earcut-hpp/include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/include/mapbox/earcut.hpp b/include/mapbox/earcut.hpp
+index a73ae87..6d30bc7 100644
+--- a/include/mapbox/earcut.hpp
++++ b/include/mapbox/earcut.hpp
+@@ -4,6 +4,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <cstddef>
++#include <cstdint>
+ #include <limits>
+ #include <memory>
+ #include <utility>

--- a/ports/earcut-hpp/portfile.cmake
+++ b/ports/earcut-hpp/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 87f52bf99273dc47f78ebacd4ee0ccbab4edd3f9b85d97aed1c0d1165b3e2523e1a71f3a37a118e82170e79d57a2e09644d4115facb63dc6f704affb9c428e6b
     HEAD_REF master
+    PATCHES
+        include-cstdint.patch # this patch is alread merged. remove it once the next version is released.
 )
 
 # This is a header only library

--- a/ports/earcut-hpp/vcpkg.json
+++ b/ports/earcut-hpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "earcut-hpp",
   "version": "2.2.4",
+  "port-version": 1,
   "description": "earcut.hpp is a C++ port of earcut.js, a fast, header-only polygon triangulation library.",
   "homepage": "https://github.com/mapbox/earcut.hpp",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2702,7 +2702,7 @@
     },
     "earcut-hpp": {
       "baseline": "2.2.4",
-      "port-version": 0
+      "port-version": 1
     },
     "eastl": {
       "baseline": "3.27.1",

--- a/versions/e-/earcut-hpp.json
+++ b/versions/e-/earcut-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0cddb3e60853e9d725903c4fbf10336b35698166",
+      "version": "2.2.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "f4f99272400624124150cb485899cdc3efb24313",
       "version": "2.2.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Upstream already fixed this issue, but new version isn't released yet.
https://github.com/mapbox/earcut.hpp/commit/7fa7aa30183849e988ae79ab2eef19f9ae97acf4
