### PR TITLE
[fltk] GPT Attempts fixing Linux FLTK metadata paths

### DIFF
--- a/ports/fltk/fix-linux-export-linkage.patch
+++ b/ports/fltk/fix-linux-export-linkage.patch
@@ -1,0 +1,135 @@
+diff --git a/CMake/FLTKConfig.cmake.in b/CMake/FLTKConfig.cmake.in
+index 22e165a..df9e5c7 100644
+--- a/CMake/FLTKConfig.cmake.in
++++ b/CMake/FLTKConfig.cmake.in
+@@ -28,6 +28,14 @@
+ 
+ set(FLTK_VERSION @FLTK_VERSION@)
+ 
++include(CMakeFindDependencyMacro)
++
++if(@USE_X11@)
++  find_dependency(X11)
++endif()
++if(@OPENGL_FOUND@)
++  find_dependency(OpenGL)
++endif()
+ include(${CMAKE_CURRENT_LIST_DIR}/FLTK-Targets.cmake)
+ 
+ set(FLTK_INCLUDE_DIRS "@INCLUDE_DIRS@")
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d153b1c..e347d9b 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -269,7 +269,22 @@ if (USE_THREADS)
+ endif (USE_THREADS)
+ 
+ if (USE_X11)
+-  list (APPEND OPTIONAL_LIBS ${X11_LIBRARIES})
++  if (TARGET X11::SM)
++    list (APPEND OPTIONAL_LIBS X11::SM)
++  endif ()
++  if (TARGET X11::ICE)
++    list (APPEND OPTIONAL_LIBS X11::ICE)
++  endif ()
++  if (TARGET X11::X11)
++    list (APPEND OPTIONAL_LIBS X11::X11)
++  else()
++    list (APPEND OPTIONAL_LIBS ${X11_X11_LIB})
++  endif ()
++  if (TARGET X11::Xext)
++    list (APPEND OPTIONAL_LIBS X11::Xext)
++  elseif (X11_Xext_FOUND)
++    list (APPEND OPTIONAL_LIBS ${X11_Xext_LIB})
++  endif ()
+ endif (USE_X11)
+ 
+ if (WIN32)
+@@ -281,23 +296,43 @@ if (FLTK_HAVE_CAIRO)
+ endif (FLTK_HAVE_CAIRO)
+ 
+ if (HAVE_XINERAMA)
+-  list (APPEND OPTIONAL_LIBS ${X11_Xinerama_LIB})
++  if (TARGET X11::Xinerama)
++    list (APPEND OPTIONAL_LIBS X11::Xinerama)
++  else()
++    list (APPEND OPTIONAL_LIBS ${X11_Xinerama_LIB})
++  endif ()
+ endif (HAVE_XINERAMA)
+ 
+ if (HAVE_XFIXES)
+-  list (APPEND OPTIONAL_LIBS ${X11_Xfixes_LIB})
++  if (TARGET X11::Xfixes)
++    list (APPEND OPTIONAL_LIBS X11::Xfixes)
++  else()
++    list (APPEND OPTIONAL_LIBS ${X11_Xfixes_LIB})
++  endif ()
+ endif (HAVE_XFIXES)
+ 
+ if (HAVE_XCURSOR)
+-  list (APPEND OPTIONAL_LIBS ${X11_Xcursor_LIB})
++  if (TARGET X11::Xcursor)
++    list (APPEND OPTIONAL_LIBS X11::Xcursor)
++  else()
++    list (APPEND OPTIONAL_LIBS ${X11_Xcursor_LIB})
++  endif ()
+ endif (HAVE_XCURSOR)
+ 
+ if (HAVE_XRENDER)
+-  list (APPEND OPTIONAL_LIBS ${X11_Xrender_LIB})
++  if (TARGET X11::Xrender)
++    list (APPEND OPTIONAL_LIBS X11::Xrender)
++  else()
++    list (APPEND OPTIONAL_LIBS ${X11_Xrender_LIB})
++  endif ()
+ endif (HAVE_XRENDER)
+ 
+ if (USE_XFT)
+-  list (APPEND OPTIONAL_LIBS ${X11_Xft_LIB})
++  if (TARGET X11::Xft)
++    list (APPEND OPTIONAL_LIBS X11::Xft)
++  else()
++    list (APPEND OPTIONAL_LIBS ${X11_Xft_LIB})
++  endif ()
+   if (LIB_fontconfig)
+     list (APPEND OPTIONAL_LIBS ${LIB_fontconfig})
+   endif (LIB_fontconfig)
+@@ -340,7 +375,11 @@ endif (OPTION_USE_SYSTEM_LIBPNG)
+ 
+ if (OPENGL_FOUND)
+   FL_ADD_LIBRARY (fltk_gl STATIC "${GLCPPFILES}")
+-  target_link_libraries (fltk_gl fltk ${OPENGL_LIBRARIES})
++  if (TARGET OpenGL::GLU AND TARGET OpenGL::GL)
++    target_link_libraries (fltk_gl fltk OpenGL::GLU OpenGL::GL)
++  else()
++    target_link_libraries (fltk_gl fltk ${OPENGL_LIBRARIES})
++  endif ()
+ endif (OPENGL_FOUND)
+ 
+ #######################################################################
+@@ -386,7 +425,11 @@ if (OPTION_BUILD_SHARED_LIBS AND NOT MSVC)
+ 
+   if (OPENGL_FOUND)
+     FL_ADD_LIBRARY (fltk_gl SHARED "${GLCPPFILES};${GL_HEADER_FILES};${GL_DRIVER_HEADER_FILES}")
+-    target_link_libraries (fltk_gl_SHARED fltk_SHARED ${OPENGL_LIBRARIES})
++    if (TARGET OpenGL::GLU AND TARGET OpenGL::GL)
++      target_link_libraries (fltk_gl_SHARED fltk_SHARED OpenGL::GLU OpenGL::GL)
++    else()
++      target_link_libraries (fltk_gl_SHARED fltk_SHARED ${OPENGL_LIBRARIES})
++    endif ()
+   endif (OPENGL_FOUND)
+ 
+ endif (OPTION_BUILD_SHARED_LIBS AND NOT MSVC)
+@@ -429,7 +472,11 @@ if (OPTION_BUILD_SHARED_LIBS AND MSVC)
+   endif (OPTION_USE_SYSTEM_ZLIB)
+ 
+   if (OPENGL_FOUND)
+-    target_link_libraries (fltk_SHARED ${OPENGL_LIBRARIES})
++    if (TARGET OpenGL::GLU AND TARGET OpenGL::GL)
++      target_link_libraries (fltk_SHARED OpenGL::GLU OpenGL::GL)
++    else()
++      target_link_libraries (fltk_SHARED ${OPENGL_LIBRARIES})
++    endif ()
+   endif (OPENGL_FOUND)
+ 
+ endif (OPTION_BUILD_SHARED_LIBS AND MSVC)

--- a/ports/fltk/portfile.cmake
+++ b/ports/fltk/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     SHA512 b18ff6322349af4416a37d28c4f42ebe355260786ed42bdd54dcc20dc92db1a38a8db74e6d637fdff8f320bdd51e2515c0fa939d30679c5f22ea99fb32c97204
     PATCHES
         dependencies.patch
+        fix-linux-export-linkage.patch
         config-path.patch
         include.patch
         fix-system-link.patch
@@ -59,12 +60,20 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/fltk-config")
     file(RENAME "${CURRENT_PACKAGES_DIR}/bin/fltk-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/fltk-config")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fltk-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fltk-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../.." IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fltk-config" "srcdir=." [[srcdir=.
+
+PKG_CONFIG_PATH="$libdir/pkgconfig${PKG_CONFIG_PATH+:$PKG_CONFIG_PATH}"
+export PKG_CONFIG_PATH]])
     if(NOT VCPKG_BUILD_TYPE)
         file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug")
         file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/fltk-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/fltk-config")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/fltk-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../../..")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/fltk-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../.." IGNORE_UNCHANGED)
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/fltk-config" "{prefix}/include" "{prefix}/../include")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/fltk-config" "srcdir=." [[srcdir=.
+
+PKG_CONFIG_PATH="$libdir/pkgconfig${PKG_CONFIG_PATH+:$PKG_CONFIG_PATH}"
+export PKG_CONFIG_PATH]])
     endif()
 endif()
 if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/fluid${VCPKG_TARGET_EXECUTABLE_SUFFIX}" OR

--- a/ports/fltk/vcpkg.json
+++ b/ports/fltk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fltk",
   "version": "1.3.11",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FLTK (pronounced fulltick) is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.",
   "homepage": "https://www.fltk.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3118,7 +3118,7 @@
     },
     "fltk": {
       "baseline": "1.3.11",
-      "port-version": 1
+      "port-version": 2
     },
     "fluidlite": {
       "baseline": "2023-04-18",

--- a/versions/f-/fltk.json
+++ b/versions/f-/fltk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c45aa9b6b12f0f533dd61fb325bd51e180ebdf9d",
+      "version": "1.3.11",
+      "port-version": 2
+    },
+    {
       "git-tree": "1fd82b793982e7541fd67ed94edcc7f8bd949601",
       "version": "1.3.11",
       "port-version": 1


### PR DESCRIPTION
Yesterday in https://github.com/microsoft/vcpkg/pull/52182 we saw this pattern again:

```console
REGRESSION: mathgl:x64-linux failed with BUILD_FAILED. If expected, add mathgl:x64-linux=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
ninja: error: '/usr/lib/x86_64-linux-gnu/libXft.so', needed by 'utils/mglview', missing and no known rule to make it

REGRESSION: octave:x64-linux failed with BUILD_FAILED. If expected, add octave:x64-linux=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
/usr/bin/ld: cannot find -lXft: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:13119: libinterp/dldfcn/__fltk_uigetfile__.la] Error 1
make[2]: *** Waiting for unfinished jobs....
/usr/bin/ld: cannot find -lXft: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:13131: libinterp/dldfcn/__init_fltk__.la] Error 1
make[1]: *** [Makefile:28742: all-recursive] Error 1
make: *** [Makefile:11735: all] Error 2
```

with failure logs to that we previously saw in https://github.com/microsoft/vcpkg/pull/51569 . I asked GPT5.4 if it had any better ideas as I think we are at a loss as to how sometimes Xft looks like it's present on the system, and sometimes it looks like it isn't. It wrote this change. However, I'm not convinced that GPT 5.4 is correct here. It seems reasonable to change things to use CMake targets rather than embed absolute paths, and that might make it easier to debug if/when this happens again, but I still don't *really* have a repro for what makes this happen in the first place.

To that end I am putting up this result as a draft so others can look at it but I would not merge this without further verification / understanding of why this happens when it happens.

GPT 5.4's response follows:

========================================

The FLTK Linux package metadata was exporting host absolute system library paths such as /usr/lib/.../libX11.so and /usr/lib/.../libOpenGL.so through share/fltk/FLTK-Targets.cmake. That let downstream consumers pick up host .so files directly instead of linking through declared dependencies.

Patch rationale:
- add ports/fltk/fix-linux-export-linkage.patch: replace the X11 and OpenGL entries that were resolving to host absolute paths in exported targets with imported CMake targets when they exist, while keeping the original discovered variables as fallback. This keeps the metadata tolerant of platform-specific library naming while preventing embedded host paths.
- update CMake/FLTKConfig.cmake.in in that patch: add find_dependency(X11) and find_dependency(OpenGL) because the exported imported targets must be created before FLTK-Targets.cmake is loaded by downstream projects.
- update ports/fltk/portfile.cmake to apply the new patch: this is what wires the export-metadata fix into the port build.
- keep the installed fltk-config PKG_CONFIG_PATH setup in ports/fltk/portfile.cmake: this is necessary because FLTK's script eagerly evaluates the pkg-config-based image library fragments even for octave's normal --use-gl --ldflags probe. Without pointing pkg-config at the package's own lib/pkgconfig directory, fltk-config emits libjpeg/libpng lookup errors for a normal downstream use.
- bump ports/fltk/vcpkg.json to port-version 2 and refresh versions/baseline.json plus versions/f-/fltk.json: the package contents and installed metadata changed, so the registry entries need a matching version update.

This change was authored by GPT-5.4 after rebuilding the port on Linux and checking the resulting installed metadata and downstream consumer behavior.
