### PR TITLE
[readline-unix] Unsupport emscripten

### DIFF
--- a/ports/readline-unix/vcpkg.json
+++ b/ports/readline-unix/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "readline-unix",
   "version": "8.3",
+  "port-version": 1,
   "description": "The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in.",
   "homepage": "https://tiswww.case.edu/php/chet/readline/rltop.html",
   "license": "GPL-3.0-or-later",
-  "supports": "!windows",
+  "supports": "!windows & !emscripten",
   "dependencies": [
     "ncurses",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8694,7 +8694,7 @@
     },
     "readline-unix": {
       "baseline": "8.3",
-      "port-version": 0
+      "port-version": 1
     },
     "readline-win32": {
       "baseline": "5.0",

--- a/versions/r-/readline-unix.json
+++ b/versions/r-/readline-unix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3514858d43058e46065a36ae05cc60a5b37fb9ea",
+      "version": "8.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "89a451cc17912d991349b6fb5efdaa3be65e8c08",
       "version": "8.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

readline fails to compile

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
