### PR TITLE
[gmp] [mpfr] [mpc] Unsupport emscripten

### DIFF
--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "gmp",
   "version": "6.3.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "license": "LGPL-3.0-only OR GPL-2.0-only",
-  "supports": "!xbox",
+  "supports": "!xbox & !emscripten",
   "dependencies": [
     {
       "name": "gmp",

--- a/ports/mpc/vcpkg.json
+++ b/ports/mpc/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "mpc",
   "version": "1.3.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.",
   "homepage": "https://www.multiprecision.org/mpc/",
   "license": "LGPL-3.0-or-later",
+  "supports": "!emscripten",
   "dependencies": [
     "gmp",
     "mpfr",

--- a/ports/mpfr/vcpkg.json
+++ b/ports/mpfr/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "mpfr",
   "version": "4.2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
   "homepage": "https://www.mpfr.org",
   "license": "LGPL-3.0-or-later",
-  "supports": "!xbox",
+  "supports": "!xbox & !emscripten",
   "dependencies": [
     "gmp",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3502,7 +3502,7 @@
     },
     "gmp": {
       "baseline": "6.3.0",
-      "port-version": 3
+      "port-version": 4
     },
     "gmsh": {
       "baseline": "4.15.2",
@@ -6698,11 +6698,11 @@
     },
     "mpc": {
       "baseline": "1.3.1",
-      "port-version": 3
+      "port-version": 4
     },
     "mpfr": {
       "baseline": "4.2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "mpg123": {
       "baseline": "1.33.4",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1c3a9ff42e95b48b8f390bf1eba0a7a0f7b8e17",
+      "version": "6.3.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "9b979ff042700c317cb1ae4f2471e00bcfcf7d82",
       "version": "6.3.0",
       "port-version": 3

--- a/versions/m-/mpc.json
+++ b/versions/m-/mpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0dbb952738714956a61d9f17e96d8e71c4f7004c",
+      "version": "1.3.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "e7d70a0d67f2f806baaa55bcce2be90d39454349",
       "version": "1.3.1",
       "port-version": 3

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66b6d24b1eea10a079fcf20382e6005354a44982",
+      "version": "4.2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "8ba45f432d750cfba4c8d7e1f29cf8d04bbc9cb1",
       "version": "4.2.2",
       "port-version": 1


### PR DESCRIPTION
gmp fails to configure.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
