### PR TITLE
[nanoflann] Update to 1.10.0

### DIFF
--- a/ports/nanoflann/portfile.cmake
+++ b/ports/nanoflann/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jlblancoc/nanoflann
     REF "v${VERSION}"
-    SHA512 414da00a553f473fe8c541178a60cecb2b27039e31d434ebb7059f8337f3e4fb9fdacf312444692a9a48a9cd1efd129a0aa2e7b80409e053d529aae7e736a840
+    SHA512 adaed29f7acb21de288c20ff3b4830868ac0d1aa4d8a5a1945d2d13ae99e5cebd94fbd175a4eb35972a6234e8279e164d8189eea67c75162735a9656bbba8a6b
     HEAD_REF master
 )
 
@@ -19,12 +19,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(READ "${CURRENT_PACKAGES_DIR}/share/nanoflann/nanoflannConfig.cmake" _contents)
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/nanoflann/nanoflannConfig.cmake" "
-include(CMakeFindDependencyMacro)
-find_dependency(Threads)
-${_contents}")
-
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
-

--- a/ports/nanoflann/vcpkg.json
+++ b/ports/nanoflann/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoflann",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "nanoflann is a C++11 header-only library for building KD-Trees of datasets with different topologies: R2, R3 (point clouds), SO(2) and SO(3) (2D and 3D rotation groups).",
   "homepage": "https://github.com/jlblancoc/nanoflann",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6877,7 +6877,7 @@
       "port-version": 8
     },
     "nanoflann": {
-      "baseline": "1.9.0",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "nanogui": {

--- a/versions/n-/nanoflann.json
+++ b/versions/n-/nanoflann.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3011baf61429b899910c72f300d005affb2aee3a",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b9470b2ac7581bba9587ea5d1341101bb6db658",
       "version": "1.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x]  Exactly one version is added in each modified versions file.

Patching the config file is not necessary anymore [since v1.8.0](https://github.com/jlblancoc/nanoflann/commit/78af30af3db99e3648adf6d13be993ff81df30b7)