### PR TITLE
[nlopt] update to 2.11.0

### DIFF
--- a/ports/nlopt/portfile.cmake
+++ b/ports/nlopt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stevengj/nlopt
     REF "v${VERSION}"
-    SHA512 c7bc34c3fc00cb714473f5612329291dd3b7f2748a08c83ac0ab1fc719e9ce88c730eeeac88367273dd6e5f78e7afa0bed818374ae50b326fcd25f370abc1909
+    SHA512 72dfb5374f89f6a507f0a22317fd76b4fc26795d7868842e02dc67a76fbbaf04fb769cec7b366774f5d2a1ed0c2305878c9d82e0ef85e449f9350cdcaa58c262
     HEAD_REF master
 )
 vcpkg_check_features(

--- a/ports/nlopt/vcpkg.json
+++ b/ports/nlopt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nlopt",
-  "version": "2.10.1",
-  "port-version": 1,
+  "version": "2.11.0",
   "description": "Library for nonlinear local and global optimization, for functions with and without gradient information.",
   "homepage": "https://github.com/stevengj/nlopt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7049,8 +7049,8 @@
       "port-version": 2
     },
     "nlopt": {
-      "baseline": "2.10.1",
-      "port-version": 1
+      "baseline": "2.11.0",
+      "port-version": 0
     },
     "nmslib": {
       "baseline": "2.1.1",

--- a/versions/n-/nlopt.json
+++ b/versions/n-/nlopt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48f608867cdb33cb4a790c41d350181ef6d84a96",
+      "version": "2.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b84afa1056ae4cd9099bd98aa2a3eeabc453c4e5",
       "version": "2.10.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stevengj/nlopt/releases/tag/v2.11.0
