### PR TITLE
[libdicom] update to 1.3.0

### DIFF
--- a/ports/libdicom/portfile.cmake
+++ b/ports/libdicom/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ImagingDataCommons/libdicom
     REF "v${VERSION}"
-    SHA512 7323616a0beee9954f725daeef255215b337ce56d921ea836262fe3a84ee2eb0cce8d6caf6610c88daea2a9b2d0a1deefb70a750268131f82ad48e66a5a29bdd
+    SHA512 060c640b8ea4730ec24ed0d576f86ced354af63b752ff893e7327eb715f34a3fbafe223be6e8a76b81ed79014005644aff78aeed100ea5d39b4338d330740cda
     HEAD_REF main
     PATCHES
         cross-build.diff

--- a/ports/libdicom/vcpkg.json
+++ b/ports/libdicom/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdicom",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "libdicom is a C library and a set of command-line tools for reading DICOM WSI files",
   "homepage": "https://github.com/ImagingDataCommons/libdicom",
   "documentation": "https://libdicom.readthedocs.io/en/latest/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4885,7 +4885,7 @@
       "port-version": 0
     },
     "libdicom": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libdisasm": {

--- a/versions/l-/libdicom.json
+++ b/versions/l-/libdicom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9d1aeae23ee5262a4a225a5deceffda630958e6",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fe0d522e302efed181f0e490848585fdb5894e3a",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ImagingDataCommons/libdicom/releases/tag/v1.3.0
