### PR TITLE
[cudnn-frontend] Update to 1.24.1

### DIFF
--- a/ports/cudnn-frontend/portfile.cmake
+++ b/ports/cudnn-frontend/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIA/cudnn-frontend
     REF "v${VERSION}"
-    SHA512 6e074b9f3b50bf90480cd1c342dd6ec84e5c2470a43b1f9c91f23a5006222d394dc1cefd9665a1ae1c2fedfdedd4b6ae42f3ae012d965bb497ac853868a31f88
+    SHA512 9951c2bc7d7f1db6d384106f3b0ed65b519176bc96a0fad735d1033d0c70fedc431bd135cdf6a4c6c8bfce6856132cd86308a8ddefe8e81dc111438172696ddc
     HEAD_REF main
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/include/cudnn_frontend/thirdparty")

--- a/ports/cudnn-frontend/vcpkg.json
+++ b/ports/cudnn-frontend/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cudnn-frontend",
-  "version-semver": "1.24.0",
+  "version-semver": "1.24.1",
   "description": "cudnn_frontend provides a c++ wrapper for the cudnn backend API and samples on how to use it",
   "homepage": "https://github.com/NVIDIA/cudnn-frontend",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2269,7 +2269,7 @@
       "port-version": 17
     },
     "cudnn-frontend": {
-      "baseline": "1.24.0",
+      "baseline": "1.24.1",
       "port-version": 0
     },
     "cunit": {

--- a/versions/c-/cudnn-frontend.json
+++ b/versions/c-/cudnn-frontend.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "281e55d608cfb7766e31125b57a447094a35a9b5",
+      "version-semver": "1.24.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b1ff0b05ed7d934666a69c48d1adebc8be4952cb",
       "version-semver": "1.24.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.24.1
