### PR TITLE
[ryml] Update to 0.15.2

### DIFF
--- a/ports/ryml/cmake-fix.patch
+++ b/ports/ryml/cmake-fix.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d80b395..8f1699e 100644
+index cd11625..4fb8872 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -27,10 +27,7 @@ option(RYML_INSTALL "Enable install target" ON)
+@@ -30,10 +30,7 @@ option(RYML_INSTALL "Enable install target" ON)
  
  #-------------------------------------------------------
  
@@ -14,7 +14,7 @@ index d80b395..8f1699e 100644
  
  c4_add_library(ryml
      SOURCES
-@@ -77,10 +74,10 @@ c4_add_library(ryml
+@@ -84,10 +81,10 @@ c4_add_library(ryml
          ryml.natvis
      SOURCE_ROOT ${RYML_SRC_DIR}
      INC_DIRS
@@ -27,3 +27,11 @@ index d80b395..8f1699e 100644
      )
  
  if(RYML_WITH_TAB_TOKENS)
+@@ -177,7 +174,6 @@ endif()
+ if(RYML_INSTALL)
+     c4_install_target(ryml)
+     c4_install_exports(DEPENDENCIES c4core)
+-    c4_pack_project()
+ endif()
+ 
+ 

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 0e818ec5c2c792b0111e753c207e8f84a67964d510f2caf8b2c9a41a2859306778a09a6f22a1134f5b162a5577948c048aa8f474a58e2501cba6cea08555b29b
+    SHA512 dc667fe59f393c84b6c39ddae5a76b62c7f68bddab5b046ffc62ca4d75f8e9e22b53ba81036ced35d38948baad4a0df2592eea94a2e1f169c7c11b272dd60937
     HEAD_REF master
     PATCHES
         cmake-fix.patch
@@ -18,7 +18,7 @@ vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 7292f9856d9c41581f2731e73fdf08880e0f4353b757da38a13ec89b62c5c8cb52b9efc1a9ff77336efa0b6809727c17649e607d8ecacc965a9b2a7a49925237
+    SHA512 dc667fe59f393c84b6c39ddae5a76b62c7f68bddab5b046ffc62ca4d75f8e9e22b53ba81036ced35d38948baad4a0df2592eea94a2e1f169c7c11b272dd60937
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -11,14 +11,14 @@ vcpkg_from_github(
         cmake-fix.patch
 )
 
-set(CM_COMMIT_HASH fe41e86552046c3df9ba73a40bf3d755df028c1e)
+set(CM_COMMIT_HASH 9b4161420e7af50796bb2c984bbfc7b451cbb668)
 
 # Get cmake scripts for rapidyaml
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 dc667fe59f393c84b6c39ddae5a76b62c7f68bddab5b046ffc62ca4d75f8e9e22b53ba81036ced35d38948baad4a0df2592eea94a2e1f169c7c11b272dd60937
+    SHA512 d840c28b9144d657b78ddaa69c8061347bf8c9c44ff49bff4eb806369d1d6058dcb091b1cb981e8842c9cd3cebf5c4e5bc5498230ec47dd59d8fb0e38d845f58
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",

--- a/scripts/test_ports/vcpkg-ci-ryml/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-ryml/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-ryml/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-ryml/project/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-ryml)
+
+find_package(ryml CONFIG REQUIRED)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE ryml::ryml)

--- a/scripts/test_ports/vcpkg-ci-ryml/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-ryml/project/main.cpp
@@ -1,0 +1,14 @@
+#include <ryml/ryml.hpp>
+#include <ryml/ryml_std.hpp>
+
+int main() {
+    char yml_buf[] = "{foo: 1, bar: [2, 3], john: doe}";
+    ryml::Tree tree = ryml::parse_in_place(ryml::to_substr(yml_buf));
+    ryml::ConstNodeRef root = tree.rootref();
+    if (!root.is_map()) return 1;
+    if (!root.has_child("foo")) return 2;
+    int foo = 0;
+    root["foo"] >> foo;
+    if (foo != 1) return 3;
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-ryml/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ryml/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-ryml",
+  "version-string": "ci",
+  "description": "Validates ryml",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "ryml"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8977,7 +8977,7 @@
       "port-version": 2
     },
     "ryml": {
-      "baseline": "0.15.1",
+      "baseline": "0.15.2",
       "port-version": 0
     },
     "ryu": {

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c726ced97af2bdbb9ce06bfbb3b4fe5359b447b1",
+      "git-tree": "7f9987cb43d12f6efc5fece7aca1540f0ced60b4",
       "version": "0.15.2",
       "port-version": 0
     },

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7a87fdd946f2f03299c3fcc4706ec21879d67ee4",
+      "git-tree": "c726ced97af2bdbb9ce06bfbb3b4fe5359b447b1",
       "version": "0.15.2",
       "port-version": 0
     },

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a87fdd946f2f03299c3fcc4706ec21879d67ee4",
+      "version": "0.15.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8410af3bcd402713b344ebec66fc19c10915242a",
       "version": "0.15.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.15.2
