### PR TITLE
[kubazip] update to 0.3.14

### DIFF
--- a/ports/kubazip/fix-name-conflict.diff
+++ b/ports/kubazip/fix-name-conflict.diff
@@ -7,7 +7,7 @@ index 7409000..d89ef41 100644
  target_include_directories(${PROJECT_NAME} PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 -  $<INSTALL_INTERFACE:include>
-+  $<INSTALL_INTERFACE:include>/kubazip
++  $<INSTALL_INTERFACE:include/kubazip>
  )
 -
 +set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME kubazip)

--- a/ports/kubazip/fix-name-conflict.diff
+++ b/ports/kubazip/fix-name-conflict.diff
@@ -1,19 +1,20 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 804df5e..d45ef96 100644
+index 7409000..d89ef41 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -47,8 +47,9 @@ endif()
+@@ -52,9 +52,9 @@ endif()
  
  target_include_directories(${PROJECT_NAME} PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 -  $<INSTALL_INTERFACE:include>
-+  $<INSTALL_INTERFACE:include/kubazip>
++  $<INSTALL_INTERFACE:include>/kubazip
  )
+-
 +set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME kubazip)
- 
- # test
- if (NOT CMAKE_DISABLE_TESTING)
-@@ -85,7 +86,7 @@ endif()
+ if(NOT ZIP_ENABLE_INFLATE)
+     target_compile_definitions(${PROJECT_NAME} PUBLIC ZIP_ENABLE_INFLATE=0)
+ endif()
+@@ -116,7 +116,7 @@ endif()
  ###
  
  set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")

--- a/ports/kubazip/portfile.cmake
+++ b/ports/kubazip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kuba--/zip
     REF "v${VERSION}"
-    SHA512 f91d0ec0f6b034c185d65989fc3cae8db598434bc97d99053194a96d17f3ab1d2a13094c3a6ae207315c329d66f3e1b643ba725575bde9139e2bc2d9cf98cb04
+    SHA512 e35df05d1db4542223f251b052094a8926f1e84a9051db3ff3f60cd0c3af912e0e3053852df8f24eb37b25c0be90afe058c613e9139ccfad0c3ad4d3950c2e70
     HEAD_REF master
     PATCHES
         fix-name-conflict.diff

--- a/ports/kubazip/portfile.cmake
+++ b/ports/kubazip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kuba--/zip
     REF "v${VERSION}"
-    SHA512 fb5841f11fa5a7f6f1457952d57b61349ad2bcdda0b2b7b0045655a03bd6c743ad3b68cc510147b3b9bbd1962f753d46f66d251df82bf6dc65c117dd23b8e743
+    SHA512 f91d0ec0f6b034c185d65989fc3cae8db598434bc97d99053194a96d17f3ab1d2a13094c3a6ae207315c329d66f3e1b643ba725575bde9139e2bc2d9cf98cb04
     HEAD_REF master
     PATCHES
         fix-name-conflict.diff

--- a/ports/kubazip/vcpkg.json
+++ b/ports/kubazip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubazip",
-  "version": "0.3.7",
+  "version": "0.3.11",
   "description": "A portable, simple zip library written in C",
   "homepage": "https://github.com/kuba--/zip",
   "license": "MIT",

--- a/ports/kubazip/vcpkg.json
+++ b/ports/kubazip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubazip",
-  "version": "0.3.11",
+  "version": "0.3.14",
   "description": "A portable, simple zip library written in C",
   "homepage": "https://github.com/kuba--/zip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4581,7 +4581,7 @@
       "port-version": 0
     },
     "kubazip": {
-      "baseline": "0.3.7",
+      "baseline": "0.3.11",
       "port-version": 0
     },
     "kubernetes": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4581,7 +4581,7 @@
       "port-version": 0
     },
     "kubazip": {
-      "baseline": "0.3.11",
+      "baseline": "0.3.14",
       "port-version": 0
     },
     "kubernetes": {

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11c650b591e7cfc03ac5da7ef87ad9f51004a834",
+      "version": "0.3.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "acf1373fcf82a6c48591fe1d8706d87b97c01310",
       "version": "0.3.7",
       "port-version": 0

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11c650b591e7cfc03ac5da7ef87ad9f51004a834",
+      "git-tree": "c32262098411677ec058d24b3e868448c57a325e",
       "version": "0.3.11",
       "port-version": 0
     },

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "c32262098411677ec058d24b3e868448c57a325e",
-      "version": "0.3.11",
+      "git-tree": "09cda8d314d5c4e8e6a49b51f34aa7a65272c2e6",
+      "version": "0.3.14",
       "port-version": 0
     },
     {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/kuba--/zip/releases/tag/v0.3.14
