### PR TITLE
[nanoflann] Update to 1.10.1

### DIFF
--- a/ports/nanoflann/portfile.cmake
+++ b/ports/nanoflann/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jlblancoc/nanoflann
-    REF "v${VERSION}"
-    SHA512 adaed29f7acb21de288c20ff3b4830868ac0d1aa4d8a5a1945d2d13ae99e5cebd94fbd175a4eb35972a6234e8279e164d8189eea67c75162735a9656bbba8a6b
+    REF "${VERSION}"
+    SHA512 95c4e929c9e5accc99ac5f2927119ed3f8240729ed7695ed1fbe89ee96ba3498c1aa25164c57819d44f0f829a7c2b46c468932bb0bfb665bb01f60bf1bb9e02a
     HEAD_REF master
 )
 

--- a/ports/nanoflann/vcpkg.json
+++ b/ports/nanoflann/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoflann",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "nanoflann is a C++11 header-only library for building KD-Trees of datasets with different topologies: R2, R3 (point clouds), SO(2) and SO(3) (2D and 3D rotation groups).",
   "homepage": "https://github.com/jlblancoc/nanoflann",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6877,7 +6877,7 @@
       "port-version": 8
     },
     "nanoflann": {
-      "baseline": "1.10.0",
+      "baseline": "1.10.1",
       "port-version": 0
     },
     "nanogui": {

--- a/versions/n-/nanoflann.json
+++ b/versions/n-/nanoflann.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3cc2b71481b2c0c0b7e2a89effbc1fd07dcbcd1",
+      "version": "1.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3011baf61429b899910c72f300d005affb2aee3a",
       "version": "1.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Tag schema has been changed, see: https://github.com/jlblancoc/nanoflann/issues/305