### PR TITLE
[liquid-dsp] update to 1.8.0

### DIFF
--- a/ports/liquid-dsp/fix-fftw3.patch
+++ b/ports/liquid-dsp/fix-fftw3.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07c1238..13d5f40 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -71,7 +71,7 @@ endif()
+ # check external libraries
+ #variable_watch(fftw3f_INCLUDE_DIR)
+ if (FIND_FFTW)
+-    find_package(fftw3f)
++    find_package(FFTW3f CONFIG REQUIRED)
+ endif()
+ 
+ # cross-platform threads (e.g. thread.h for C11
+@@ -466,8 +466,8 @@ foreach(target ${LIQUID_TARGETS})
+         PROPERTIES
+             PUBLIC_HEADER include/liquid.h)
+     target_link_libraries(${target} c m)
+-    if (fftw3f_FOUND)
+-        target_link_libraries(${target} fftw3f)
++    if (FFTW3f_FOUND)
++        target_link_libraries(${target} FFTW3::fftw3f)
+     endif()
+ endforeach()
+ 
+@@ -560,7 +560,7 @@ install(FILES
+ # ---------------------------------------- pkg-config ----------------------------------------
+ 
+ set(LIQUID_PC_LIBS_PRIVATE "")
+-if (fftw3f_FOUND)
++if (FFTW3f_FOUND)
+     string(APPEND LIQUID_PC_LIBS_PRIVATE " -lfftw3f")
+ endif()
+ 

--- a/ports/liquid-dsp/portfile.cmake
+++ b/ports/liquid-dsp/portfile.cmake
@@ -2,9 +2,19 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jgaeddert/liquid-dsp
     REF "v${VERSION}"
-    SHA512 04988cfc68ea562a47f16f5232e5eafada29d37e517ccfadd8dac9d83270c2cc2c1b5e9725e92b7cf6fed6d954aaa89b254038a2d7481e87202048a9521e4e22
+    SHA512 83c55bf80bd61c1bca7c198e7ff8ce3dd06b2ff0ce27d7211e5437f17fe191bc742bd03c40f4a2c98f364dc6c28d39a89371cccb80624815cce0b23199aaddf0
     HEAD_REF master
+    PATCHES
+        fix-fftw3.patch
 )
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_STATIC_LIBS ON)
+else()
+    set(BUILD_SHARED_LIBS ON)
+    set(BUILD_STATIC_LIBS OFF)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -15,10 +25,16 @@ vcpkg_cmake_configure(
         -DBUILD_SANDBOX=OFF
         -DBUILD_DOC=OFF
         -DCOVERAGE=OFF
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
 )
 
 vcpkg_cmake_install()
-
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/liquid-static)
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/liquid)
+endif()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/liquid-dsp/vcpkg.json
+++ b/ports/liquid-dsp/vcpkg.json
@@ -1,13 +1,18 @@
 {
   "name": "liquid-dsp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Digital signal processing library for software-defined radios.",
   "homepage": "https://liquidsdr.org/",
   "license": "MIT",
   "supports": "linux | osx",
   "dependencies": [
+    "fftw3",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6105,7 +6105,7 @@
       "port-version": 0
     },
     "liquid-dsp": {
-      "baseline": "1.7.0",
+      "baseline": "1.8.0",
       "port-version": 0
     },
     "litehtml": {

--- a/versions/l-/liquid-dsp.json
+++ b/versions/l-/liquid-dsp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7726ce29030fffbe389c1c7af543755c196701f1",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "823f83e0e888525d9d3449d7407bb3eaba1670f3",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/jgaeddert/liquid-dsp/releases/tag/v1.8.0
