### PR TITLE
Don't compare against upstream for PR-against-PR in untrustedPR check

### DIFF
--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -67,16 +67,33 @@ jobs:
           git add -u
           git commit -m "tmp" --allow-empty
           # reset the version database to the state of the merge base, so that we can check that the PR only adds one version and doesn't modify any existing versions
-          git restore --source=$merge_base --staged --worktree -- versions
-          git clean -fd -- versions
-          echo '{"default": {}}' > versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
+          #
+          # This "compare against upstream" behavior only makes sense when the PR targets the
+          # canonical microsoft/vcpkg repository. When a PR is opened against another PR (for
+          # example, a PR targeting a branch in a fork rather than microsoft/vcpkg), the merge
+          # base already contains the parent PR's in-progress version-database changes, so
+          # comparing against it would incorrectly flag the expected mutation of those
+          # not-yet-published versions. There is no reliable way to discover the ultimate
+          # upstream merge base in that situation, so instead we validate the version database
+          # against the incoming changes as-is: we still confirm the database is internally
+          # consistent (and updated) but we don't attempt the upstream comparison.
+          if [ "${{ github.event.pull_request.base.repo.full_name }}" = "microsoft/vcpkg" ]; then
+            version_db_reset_ref="$merge_base"
+          else
+            version_db_reset_ref="$incoming_branch_commit"
+          fi
+          reset_version_db() {
+            git restore --source="$version_db_reset_ref" --staged --worktree -- versions
+            git clean -fd -- versions
+            echo '{"default": {}}' > versions/baseline.json # to allow deindexing, let x-add-version completely regenerate the baseline json
+          }
+          reset_version_db
           # check for version format errors separately by running x-add-version --all, recording problems it generates
           ./vcpkg x-add-version --all | grep -E '^warning:|instead of "version-string"' | tee .github-pr.version-string.out || true
           # reset the version database again
-          git restore --source=$merge_base --staged --worktree -- versions
-          git clean -fd -- versions
-          echo '{"default": {}}' > versions/baseline.json
-          # check that the PR only adds one version and doesn't modify any existing versions, ignoring any of the warnings recorded into .github-pr.version-string.out
+          reset_version_db
+          # check that the version database is valid, ignoring any of the warnings recorded into .github-pr.version-string.out
+          # When targeting microsoft/vcpkg this additionally checks that the PR only adds one version and doesn't modify any existing versions.
           ./vcpkg x-add-version --all --skip-version-format-check | tee .github-pr.x-add-version.out || true
           git add -A -- versions
           git diff --cached "$incoming_branch_commit" -- versions > .github-pr.x-add-version.diff


### PR DESCRIPTION
The "Check For Common Mistakes" workflow resets the version database to the merge base of the target and incoming branches and reruns x-add-version to verify that a PR adds exactly one version per changed port and does not modify any already-published versions.

When a PR is opened against another PR (for example, a PR targeting a branch in a fork rather than microsoft/vcpkg), that merge base already contains the parent PR's in-progress version-database entries. Comparing against it makes x-add-version treat the child's edits to those not-yet-published versions as illegal mutations of existing versions, failing otherwise-correct changes.

There is no reliable way to discover the ultimate upstream merge base in that situation, so when the PR does not target microsoft/vcpkg we validate the version database against the incoming changes as-is: we still confirm the database is internally consistent and updated, but we skip the upstream comparison so expected mutations of the parent PR's versions are not flagged.

Authored-by: Claude Opus 4.8

Demonstration that this fixes the problem:

https://github.com/microsoft/vcpkg/pull/52278 is an example "the PR a contributor would write"
https://github.com/BillyONeal/vcpkg/pull/8 is an example "PR against that PR that failed the old check"

Fixes check failures in:

https://github.com/toge/vcpkg/pull/13
https://github.com/toge/vcpkg/pull/14

/cc @toge