### PR TITLE
New theiamcr-c package

### DIFF
--- a/ports/theiamcr-c/portfile.cmake
+++ b/ports/theiamcr-c/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cliquot22/TheiaMCR_C
+    REF "${VERSION}"
+    SHA512 0  # vcpkg will auto-update this
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Install headers
+vcpkg_copy_pdbs()

--- a/ports/theiamcr-c/portfile.cmake
+++ b/ports/theiamcr-c/portfile.cmake
@@ -1,18 +1,30 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cliquot22/TheiaMCR_C
-    REF "${VERSION}"
-    SHA512 0  # vcpkg will auto-update this
+    REF "v${VERSION}"
+    SHA512 97d8730d51a09ba9a22ab86f5e541624e022b319e2731c23c9370994ac95dd69901bbfd69a987b1c20d0a2d634536b61fb4eda047bb19384f5773f87baa280ae  # keep your existing hash
     HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        python ENABLE_PYTHON_BINDINGS
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+# Fix 1: Move CMake config files from lib/cmake to share/${PORT}
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/TheiaMCR_C)
 
-# Install headers
+# Fix 2: Remove duplicate headers from debug tree
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/license" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
 vcpkg_copy_pdbs()

--- a/ports/theiamcr-c/vcpkg.json
+++ b/ports/theiamcr-c/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "theiamcr-c",
+  "version": "3.5.0",
+  "description": "C++ Motor Control Board Interface - C-linkage shared library and native C++ library for Theia MCR IQ 400 motor control board",
+  "homepage": "https://github.com/cliquot22/TheiaMCR_C",
+  "documentation": "https://github.com/cliquot22/TheiaMCR_C/wiki",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "spdlog",
+      "version>=": "1.11.0"
+    }
+  ],
+  "features": {
+    "python": {
+      "description": "Build pybind11 Python module",
+      "dependencies": [
+        "pybind11"
+      ]
+    }
+  }
+}

--- a/ports/theiamcr-c/vcpkg.json
+++ b/ports/theiamcr-c/vcpkg.json
@@ -3,12 +3,16 @@
   "version": "3.5.0",
   "description": "C++ Motor Control Board Interface - C-linkage shared library and native C++ library for Theia MCR IQ 400 motor control board",
   "homepage": "https://github.com/cliquot22/TheiaMCR_C",
-  "documentation": "https://github.com/cliquot22/TheiaMCR_C/wiki",
   "license": "MIT",
   "dependencies": [
+    "spdlog",
     {
-      "name": "spdlog",
-      "version>=": "1.11.0"
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "features": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
