### PR TITLE
[intrusive-shared-ptr] Update to 1.12

### DIFF
--- a/ports/intrusive-shared-ptr/portfile.cmake
+++ b/ports/intrusive-shared-ptr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gershnik/intrusive_shared_ptr
     REF "v${VERSION}"
-    SHA512 f4e8ebf58d4a51e04c951cef7f8726094a3f3892df582871c3f44d1b39cb289ccb4d3919e454527fadd5efeb69a186df9de4d0c1746a230cdb44ae7f8380ed4d
+    SHA512 ba4a3e88368219893ff03e803ba8f03c4bf61e7bd5ff1e5b50fdfa67cc8756719f5ba4ac77a9dd7fe7a5db03c33a51bfb74b7c6bb8100376a0e7c8c22a8690f1
     HEAD_REF master
 )
 

--- a/ports/intrusive-shared-ptr/vcpkg.json
+++ b/ports/intrusive-shared-ptr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "intrusive-shared-ptr",
-  "version": "1.11",
+  "version": "1.12",
   "description": "Intrusive reference counting smart pointer, highly configurable reference counted base class and various adapters. Also known as libisptr.",
   "homepage": "https://github.com/gershnik/intrusive_shared_ptr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4057,7 +4057,7 @@
       "port-version": 7
     },
     "intrusive-shared-ptr": {
-      "baseline": "1.11",
+      "baseline": "1.12",
       "port-version": 0
     },
     "intx": {

--- a/versions/i-/intrusive-shared-ptr.json
+++ b/versions/i-/intrusive-shared-ptr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d7bbacfff53a6c842d76baae3790d77b61dc849",
+      "version": "1.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "74581785ee94b773e963852f67a995dce2a306cb",
       "version": "1.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.12
