### PR TITLE
[mongo-cxx-driver] Update to 4.3.1

### DIFF
--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-cxx-driver
     REF "r${VERSION}"
-    SHA512 21592fd610bb1e75b6a2c0bcf476044aa84a651d301d035f4e36e99ca0ada5b4609411e90569a913a685d2cdb7d669e702e9bdabdbdfeb99a19b0cf168637a12
+    SHA512 dddf167eaa7b9e4d407b639d3c0365d4c71d1a1c642e04ef0149fcbf0d0720ed0e532352c63d7ce7328e0cdc126fbbf281f34bc94dc919e40bf1cc792260ecef
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-cxx-driver",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6653,7 +6653,7 @@
       "port-version": 0
     },
     "mongo-cxx-driver": {
-      "baseline": "4.3.0",
+      "baseline": "4.3.1",
       "port-version": 0
     },
     "mongoose": {

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b41588eca7197ec172d304972cabd85eb3e5cb0",
+      "version": "4.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "23ca101312ac919b87c2c5cd9259c8efb806ace0",
       "version": "4.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 4.3.1
