### PR TITLE
[msgpack-c] Update to 7.0.1

### DIFF
--- a/ports/msgpack-c/portfile.cmake
+++ b/ports/msgpack-c/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO msgpack/msgpack-c
     REF "c-${VERSION}"
-    SHA512 839588b03af7d8319197bbda8e23aef82fee29cb861559d4a737638504441e9aa1cf5405f672ccaf60fdeb52329ecc7baed5208dfd8ea64fe8cf3f749eaa640c
+    SHA512 98f62c38d9b658f0da4e2bc4cdcbfebc14e99eb27b16609e418e065dcdbe7321eb4a97c090f716be2f37263636f491b76eb273a28bb69c790b0cdadf60729614
     HEAD_REF c_master
 )
 

--- a/ports/msgpack-c/vcpkg.json
+++ b/ports/msgpack-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "msgpack-c",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.",
   "homepage": "https://github.com/msgpack/msgpack-c",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6765,7 +6765,7 @@
       "port-version": 0
     },
     "msgpack-c": {
-      "baseline": "7.0.0",
+      "baseline": "7.0.1",
       "port-version": 0
     },
     "msgpack11": {

--- a/versions/m-/msgpack-c.json
+++ b/versions/m-/msgpack-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36ca7709b4dfb3d0946128f6b1b9afdb2672c537",
+      "version": "7.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4af81c77a1fe849a7882ab345989d1a6f45e62db",
       "version": "7.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 7.0.1
