### PR TITLE
[cute-headers] Update to 2026-06-11

### DIFF
--- a/ports/cute-headers/portfile.cmake
+++ b/ports/cute-headers/portfile.cmake
@@ -3,28 +3,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RandyGaul/cute_headers
-    REF 4f765abf4a59660e72f9f49c444371ba373e834b
-    SHA512 e898520dc668ce9d1f51c748da1c674f9fa0540bac7a0d10a45fde5ebb0ca6573dc5178ce41199a138e3153343b1ff0c589bc7908a8edcd4a7753d5a1440030b
+    REF f3983ab42e4551881340e2fb7033a5d120cd6edd
+    SHA512 08ef2ad162acd39408463da3c4c69325df742cf3e1afdb7508f6efaaab8ff8857a962489e6857e3f652eb8ab82ac0fdf9374cf1c11d6ee453a3000c3176c94c9
     HEAD_REF master
 )
 
 file(GLOB CUTE_HEADERS_FILES ${SOURCE_PATH}/*.h)
 file(COPY ${CUTE_HEADERS_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
-# Handle copyright
-file(STRINGS "${SOURCE_PATH}/cute_math2d.h" SOURCE_LINES)
-list(REVERSE SOURCE_LINES)
-
-set(line_no 0)
-foreach(line ${SOURCE_LINES})
-    math(EXPR line_no "${line_no} + 1")
-    if(line STREQUAL "/*")
-        break()
-    endif()
-endforeach()
-
-list(SUBLIST SOURCE_LINES 0 ${line_no} SOURCE_LINES)
-list(REVERSE SOURCE_LINES)
-list(JOIN SOURCE_LINES "\n" _contents)
-
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright "${_contents}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cute-headers/portfile.cmake
+++ b/ports/cute-headers/portfile.cmake
@@ -1,4 +1,4 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only library
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -9,6 +9,6 @@ vcpkg_from_github(
 )
 
 file(GLOB CUTE_HEADERS_FILES ${SOURCE_PATH}/*.h)
-file(COPY ${CUTE_HEADERS_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${CUTE_HEADERS_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cute-headers/vcpkg.json
+++ b/ports/cute-headers/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cute-headers",
-  "version-date": "2019-09-20",
-  "port-version": 2,
+  "version-date": "2026-06-11",
   "description": "Collection of cross-platform one-file C/C++ libraries with no dependencies",
   "homepage": "https://github.com/RandyGaul/cute_headers"
 }

--- a/ports/cute-headers/vcpkg.json
+++ b/ports/cute-headers/vcpkg.json
@@ -2,5 +2,6 @@
   "name": "cute-headers",
   "version-date": "2026-06-11",
   "description": "Collection of cross-platform one-file C/C++ libraries with no dependencies",
-  "homepage": "https://github.com/RandyGaul/cute_headers"
+  "homepage": "https://github.com/RandyGaul/cute_headers",
+  "license": "Zlib OR Unlicense"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2325,8 +2325,8 @@
       "port-version": 0
     },
     "cute-headers": {
-      "baseline": "2019-09-20",
-      "port-version": 2
+      "baseline": "2026-06-11",
+      "port-version": 0
     },
     "cutelyst2": {
       "baseline": "2.12.0",

--- a/versions/c-/cute-headers.json
+++ b/versions/c-/cute-headers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e229c6908958dbf9c97dfd57c914cf064814cfbd",
+      "git-tree": "52552c3fb844ab4f61df385ac0391fd68a30944d",
       "version-date": "2026-06-11",
       "port-version": 0
     },

--- a/versions/c-/cute-headers.json
+++ b/versions/c-/cute-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e229c6908958dbf9c97dfd57c914cf064814cfbd",
+      "version-date": "2026-06-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "73671c8a457d848d2fdb535fc56b72c48c344dcc",
       "version-date": "2019-09-20",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2026-06-11
