### PR TITLE
[clickhouse-cpp] Update to 2.6.2

### DIFF
--- a/ports/clickhouse-cpp/portfile.cmake
+++ b/ports/clickhouse-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ClickHouse/clickhouse-cpp
     REF "v${VERSION}"
-    SHA512 626cce4d6037cbeb86c5720ece7ac95c9ff0e561825e7907934669709091886d209f3128798db41a89ef3585d0639e40a5c4f96a0e724b6bee25291710ad391e
+    SHA512 3b6d76a541d75e3565b3d196193ac04baa7e99c54fd175deeb5bb143f9192243966c7d82a5c3159760d8b77f9e3d6b88254bce9ee58af53505dc0c5dc6e429a6
     HEAD_REF master
     PATCHES
         fix-deps-and-build-type.patch

--- a/ports/clickhouse-cpp/vcpkg.json
+++ b/ports/clickhouse-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-cpp",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "C++ client for Yandex ClickHouse",
   "homepage": "https://github.com/ClickHouse/clickhouse-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1825,7 +1825,7 @@
       "port-version": 0
     },
     "clickhouse-cpp": {
-      "baseline": "2.6.1",
+      "baseline": "2.6.2",
       "port-version": 0
     },
     "clipboardxx": {

--- a/versions/c-/clickhouse-cpp.json
+++ b/versions/c-/clickhouse-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "031c91dfbde168813e4837a2855f7ef248974b70",
+      "version": "2.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "bedebf882dde9d7fa3926dd88b5e92e3c3c828f6",
       "version": "2.6.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.6.2
