### PR TITLE
[jsoncons] Update to 1.8.1

### DIFF
--- a/ports/jsoncons/portfile.cmake
+++ b/ports/jsoncons/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO danielaparker/jsoncons
     REF v${VERSION}
-    SHA512 5c5ceac9462793c862fe8eab368e5a21ff10c36a5e1367bf011bcc32c99cb090766d75104736ee0009fa66609a55003eae6980e09edf1bacdee8573180a34c7e
+    SHA512 3840f1bec34b93b8e36aaa881ff38b1b52bd245c52848e61ae16ccc3b2892138f7e40a75cdba821b4ffbef7f86c9a5a40be9c8d40409dfc1bee777c4400b2039
     HEAD_REF master
 )
 

--- a/ports/jsoncons/vcpkg.json
+++ b/ports/jsoncons/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jsoncons",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "description": "A C++, header-only library for constructing JSON and JSON-like text and binary data formats, with JSON Pointer, JSON Patch, JSON Schema, JSONPath, JMESPath, CSV, MessagePack, CBOR, BSON, UBJSON",
   "homepage": "https://github.com/danielaparker/jsoncons",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4209,7 +4209,7 @@
       "port-version": 7
     },
     "jsoncons": {
-      "baseline": "1.7.0",
+      "baseline": "1.8.1",
       "port-version": 0
     },
     "jsoncpp": {

--- a/versions/j-/jsoncons.json
+++ b/versions/j-/jsoncons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d04ef1fdb4aa01edc203d7867494f3e818d75f31",
+      "version": "1.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2cc97c0d3cb1575abc6d3895d2ceccdb878f326",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.8.1
