### PR TITLE
[libmt32emu] Update to 2.8.3

### DIFF
--- a/ports/libmt32emu/portfile.cmake
+++ b/ports/libmt32emu/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO munt/munt
     REF libmt32emu_${VERSION}
-    SHA512 29974bc97c15ae6c7824ee2525cebe0dc213b35f2cb45ffc1290cfe1b759ac3df556973a467716f8b395092ed1e7b94c2fa58f8a46b5660e6cf807fead9b5fad
+    SHA512 380f564dfe1e9754c40d1ba8f9ebe409bedd813accc166dce3783944d3c172e1afd68bdf536e3cc476d1362710eddea44b3457d26ba9aeb7f0cb5ed70efd3c3d
     HEAD_REF master
 )
 

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmt32emu",
-  "version": "2.8.2",
-  "port-version": 1,
+  "version": "2.8.3",
   "description": "A MT-32 emulator",
   "homepage": "https://github.com/munt/munt",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5337,8 +5337,8 @@
       "port-version": 0
     },
     "libmt32emu": {
-      "baseline": "2.8.2",
-      "port-version": 1
+      "baseline": "2.8.3",
+      "port-version": 0
     },
     "libmtp": {
       "baseline": "1.1.22",

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5aef6eb1c262bfceaf27837d9c4ede0ce7aeea6c",
+      "version": "2.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbe6d8140ea73705c80caee9a3bbe46c629f9994",
       "version": "2.8.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.8.3
