### PR TITLE
[openssl] Update to 3.6.3

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
     REF "openssl-${VERSION}"
-    SHA512 29002ce50cb95a4f4f1d0e9d3f684401fbd4eac34203dc2eef3b6334af5d44aa46bf788b63a6f5c139c383eafb7269ae87a58a9a3ad5912903b9773e545ccc0a
+    SHA512 a89c08101fa1d7e3c09b14f4a90d450bcf336a4f6a3e6e4ea990e4deddcd9ce250472f9114438fd134ff4b47fe93dd47232308567088b2b1c0b2eb50e3b56bdf
     PATCHES
         cmake-config.patch
         command-line-length.patch

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7461,7 +7461,7 @@
       "port-version": 0
     },
     "openssl": {
-      "baseline": "3.6.2",
+      "baseline": "3.6.3",
       "port-version": 0
     },
     "opensubdiv": {

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4a2360e8425d8d5e2a24436804b592bef26980b",
+      "version": "3.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "131700c32d3bdaa8b4862deb3113a8053793833f",
       "version": "3.6.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.~~
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.