### PR TITLE
[glaze] update to 7.8.0

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 acfddf6e93a21ed475b91f9bc47e6aa37273c1a3694ebcb24e86bd6b05a47c98cf6bcb64d3ebbde08ac26d06783af3759e9426660d8b59f2014a50eb5d057707
+    SHA512 d9dad5015165ca7a7d68921eb5253ea63357860775caca82fcb098adac26aa1ad381de1488bf67ededb6b5d38dc63057d50e8785a0b3b6373623e0aedf4dbdb9
     HEAD_REF main
 )
 

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "7.7.1",
+  "version": "7.8.0",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3437,7 +3437,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "7.7.1",
+      "baseline": "7.8.0",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be5beabb5e9aceb860895f189f7a9254a086642c",
+      "version": "7.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d4c79793fbf17c5a94ce7bd9233c85846990496",
       "version": "7.7.1",
       "port-version": 0


### PR DESCRIPTION
Updates glaze to v7.8.0.

Release: https://github.com/stephenberry/glaze/releases/tag/v7.8.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature-baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version glaze` and committing the result.
- [x] Exactly one version is added in each modified versions file.