### PR TITLE
[ms-gdk] Add backport for October 2024 Update 3

### DIFF
--- a/backports/ms-gdk/2410.3.1923/pfusage
+++ b/backports/ms-gdk/2410.3.1923/pfusage
@@ -1,0 +1,12 @@
+
+  find_package(playfab.services.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+
+  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
+
+  find_package(playfab.party.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabParty)
+
+  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/backports/ms-gdk/2410.3.1923/portfile.cmake
+++ b/backports/ms-gdk/2410.3.1923/portfile.cmake
@@ -1,0 +1,78 @@
+set(GDK_EDITION_NUMBER 241003)
+
+# The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
+    FILENAME "ms-gdk.${VERSION}.zip"
+    SHA512 7c609990fabc02bbbbc003a6c18d35039e4212452754dd1c5df04f2ecb331b58cc35bc185721687267bbd69a1e50650af01bfe56595298d912265d6b7414b3a6
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        playfab BUILD_PLAYFAB_SERVICES
+)
+
+set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
+
+# We use the gameinput port instead
+file(REMOVE "${GRDK_PATH}/GameKit/Include/GameInput.h")
+file(REMOVE "${GRDK_PATH}/GameKit/Lib/amd64/GameInput.lib")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${GRDK_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.gameruntime)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.game.chat.2.cpp.api)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.libhttpclient)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.services.api.c)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.xcurl.api)
+
+set(LICENSE_FILES "${PACKAGE_PATH}/LICENSE.md")
+
+list(APPEND LICENSE_FILES
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.LibHttpClient/Include/httpClient/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.XCurl.API/Include/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/cpprest/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/pplx/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-c/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-cpp/ThirdPartyNotices.txt"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+if("playfab" IN_LIST FEATURES)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
+
+    list(APPEND LICENSE_FILES
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
+    )
+
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/pfusage" USAGE_CONTENT)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" ${USAGE_CONTENT})
+else()
+endif()
+
+file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/backports/ms-gdk/2410.3.1923/usage
+++ b/backports/ms-gdk/2410.3.1923/usage
@@ -1,0 +1,16 @@
+The Microsoft GDK package provides CMake targets:
+
+  find_package(xbox.gameruntime CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameRuntime)
+
+  find_package(xbox.libhttpclient CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::HTTPClient)
+
+  find_package(xbox.xcurl.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XCurl)
+
+  find_package(xbox.services.api.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XSAPI)
+
+  find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameChat2)

--- a/backports/ms-gdk/2410.3.1923/vcpkg.json
+++ b/backports/ms-gdk/2410.3.1923/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "ms-gdk",
+  "version": "2410.3.1923",
+  "description": "Microsoft Game Development Kit (GDK)",
+  "homepage": "https://aka.ms/gdkx",
+  "documentation": "https://aka.ms/gamedevdocs",
+  "license": null,
+  "supports": "windows & x64 & !uwp & !xbox & !staticcrt",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "playfab": {
+      "description": "Include PlayFab Extension Libraries"
+    }
+  }
+}

--- a/backports/ms-gdk/2410.4.1946/pfusage
+++ b/backports/ms-gdk/2410.4.1946/pfusage
@@ -1,0 +1,12 @@
+
+  find_package(playfab.services.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+
+  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
+
+  find_package(playfab.party.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabParty)
+
+  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/backports/ms-gdk/2410.4.1946/portfile.cmake
+++ b/backports/ms-gdk/2410.4.1946/portfile.cmake
@@ -1,0 +1,78 @@
+set(GDK_EDITION_NUMBER 241004)
+
+# The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
+    FILENAME "ms-gdk.${VERSION}.zip"
+    SHA512 7c67a8bc5764d8e10a13ec1eb762db0956aa811253604ece4f28a9768e290f919d48b8c7a6467cd3498e3049e24302a22a1e2b9f868980ed585888e46c6f4acf
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        playfab BUILD_PLAYFAB_SERVICES
+)
+
+set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
+
+# We use the gameinput port instead
+file(REMOVE "${GRDK_PATH}/GameKit/Include/GameInput.h")
+file(REMOVE "${GRDK_PATH}/GameKit/Lib/amd64/GameInput.lib")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${GRDK_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.gameruntime)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.game.chat.2.cpp.api)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.libhttpclient)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.services.api.c)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.xcurl.api)
+
+set(LICENSE_FILES "${PACKAGE_PATH}/LICENSE.md")
+
+list(APPEND LICENSE_FILES
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.LibHttpClient/Include/httpClient/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.XCurl.API/Include/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/cpprest/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/pplx/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-c/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-cpp/ThirdPartyNotices.txt"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+if("playfab" IN_LIST FEATURES)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
+
+    list(APPEND LICENSE_FILES
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
+    )
+
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/pfusage" USAGE_CONTENT)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" ${USAGE_CONTENT})
+else()
+endif()
+
+file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/backports/ms-gdk/2410.4.1946/usage
+++ b/backports/ms-gdk/2410.4.1946/usage
@@ -1,0 +1,16 @@
+The Microsoft GDK package provides CMake targets:
+
+  find_package(xbox.gameruntime CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameRuntime)
+
+  find_package(xbox.libhttpclient CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::HTTPClient)
+
+  find_package(xbox.xcurl.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XCurl)
+
+  find_package(xbox.services.api.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XSAPI)
+
+  find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameChat2)

--- a/backports/ms-gdk/2410.4.1946/vcpkg.json
+++ b/backports/ms-gdk/2410.4.1946/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "ms-gdk",
+  "version": "2410.4.1946",
+  "description": "Microsoft Game Development Kit (GDK)",
+  "homepage": "https://aka.ms/gdkx",
+  "documentation": "https://aka.ms/gamedevdocs",
+  "license": null,
+  "supports": "windows & x64 & !uwp & !xbox & !staticcrt",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "playfab": {
+      "description": "Include PlayFab Extension Libraries"
+    }
+  }
+}

--- a/backports/ms-gdk/2410.5.1966/pfusage
+++ b/backports/ms-gdk/2410.5.1966/pfusage
@@ -1,0 +1,12 @@
+
+  find_package(playfab.services.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+
+  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
+
+  find_package(playfab.party.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabParty)
+
+  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/backports/ms-gdk/2410.5.1966/portfile.cmake
+++ b/backports/ms-gdk/2410.5.1966/portfile.cmake
@@ -1,0 +1,78 @@
+set(GDK_EDITION_NUMBER 241005)
+
+# The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
+    FILENAME "ms-gdk.${VERSION}.zip"
+    SHA512 6a200a21485c3e539cee063ca2e0a9f52ee0a79311982528b260ff3d3f254fccd609f4e9bca4ee54b42b6b9046b130afe2e129544005a72a1c459e7a4333b2cd
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        playfab BUILD_PLAYFAB_SERVICES
+)
+
+set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
+
+# We use the gameinput port instead
+file(REMOVE "${GRDK_PATH}/GameKit/Include/GameInput.h")
+file(REMOVE "${GRDK_PATH}/GameKit/Lib/amd64/GameInput.lib")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${GRDK_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.gameruntime)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.game.chat.2.cpp.api)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.libhttpclient)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.services.api.c)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.xcurl.api)
+
+set(LICENSE_FILES "${PACKAGE_PATH}/LICENSE.md")
+
+list(APPEND LICENSE_FILES
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.LibHttpClient/Include/httpClient/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.XCurl.API/Include/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/cpprest/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/pplx/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-c/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-cpp/ThirdPartyNotices.txt"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+if("playfab" IN_LIST FEATURES)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
+
+    list(APPEND LICENSE_FILES
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
+    )
+
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/pfusage" USAGE_CONTENT)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" ${USAGE_CONTENT})
+else()
+endif()
+
+file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/backports/ms-gdk/2410.5.1966/usage
+++ b/backports/ms-gdk/2410.5.1966/usage
@@ -1,0 +1,16 @@
+The Microsoft GDK package provides CMake targets:
+
+  find_package(xbox.gameruntime CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameRuntime)
+
+  find_package(xbox.libhttpclient CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::HTTPClient)
+
+  find_package(xbox.xcurl.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XCurl)
+
+  find_package(xbox.services.api.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XSAPI)
+
+  find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameChat2)

--- a/backports/ms-gdk/2410.5.1966/vcpkg.json
+++ b/backports/ms-gdk/2410.5.1966/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "ms-gdk",
+  "version": "2410.5.1966",
+  "description": "Microsoft Game Development Kit (GDK)",
+  "homepage": "https://aka.ms/gdkx",
+  "documentation": "https://aka.ms/gamedevdocs",
+  "license": null,
+  "supports": "windows & x64 & !uwp & !xbox & !staticcrt",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "playfab": {
+      "description": "Include PlayFab Extension Libraries"
+    }
+  }
+}

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -61,6 +61,11 @@
       "port-version": 0
     },
     {
+      "git-tree": "f820da05b8e94a4ff7ce95ccca22e93668eec09e",
+      "version": "2410.3.1923",
+      "port-version": 0
+    },
+    {
       "git-tree": "0535ef02e82f2357f1f1fc45d680246374a2f9df",
       "version": "2410.2.1916",
       "port-version": 0

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -61,6 +61,11 @@
       "port-version": 0
     },
     {
+      "git-tree": "f56e1c6908998decbe94c47f6bfcc438e70ec35e",
+      "version": "2410.5.1966",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ded534836ec266c7a5c301b2727a837a5cecc00",
       "version": "2410.4.1946",
       "port-version": 0

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -61,6 +61,11 @@
       "port-version": 0
     },
     {
+      "git-tree": "9ded534836ec266c7a5c301b2727a837a5cecc00",
+      "version": "2410.4.1946",
+      "port-version": 0
+    },
+    {
       "git-tree": "f820da05b8e94a4ff7ce95ccca22e93668eec09e",
       "version": "2410.3.1923",
       "port-version": 0


### PR DESCRIPTION
This is being done to 'fill in' our release history for this port as customers may need to use specific QFEs to ship their title in future. This adds 2410.3, 2410.4, and 2410.5 to the history for version overrides.