### PR TITLE
[glaze] update to 7.8.1

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 d9dad5015165ca7a7d68921eb5253ea63357860775caca82fcb098adac26aa1ad381de1488bf67ededb6b5d38dc63057d50e8785a0b3b6373623e0aedf4dbdb9
+    SHA512 47a73255848505d96fb8aaf8c933ee081e51069dbc9fecd65b0c7adc366dca3e64074ae28208a0ca4dc4f387187362e8d096366ef1c94fe1d7f247b7ef4843ef
     HEAD_REF main
 )
 

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3441,7 +3441,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "7.8.0",
+      "baseline": "7.8.1",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c2d4aa7223fbed9b2385f60ca7e0fe36ae4e9af",
+      "version": "7.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "be5beabb5e9aceb860895f189f7a9254a086642c",
       "version": "7.8.0",
       "port-version": 0


### PR DESCRIPTION
Updates glaze to v7.8.1.

Release: https://github.com/stephenberry/glaze/releases/tag/v7.8.1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature-baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version glaze` and committing the result.
- [x] Exactly one version is added in each modified versions file.