### PR TITLE
[cudnn-frontend] Update to 1.25.0

### DIFF
--- a/ports/cudnn-frontend/portfile.cmake
+++ b/ports/cudnn-frontend/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIA/cudnn-frontend
     REF "v${VERSION}"
-    SHA512 9951c2bc7d7f1db6d384106f3b0ed65b519176bc96a0fad735d1033d0c70fedc431bd135cdf6a4c6c8bfce6856132cd86308a8ddefe8e81dc111438172696ddc
+    SHA512 50af0affa160aa3df4eb5e292ca675afc518a390712d528890e66c7aaa99f8b72a5947ecace92f2bfb84a32cb687d597bc4d2f2e0ddac71143d1fd74cabc9a07
     HEAD_REF main
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/include/cudnn_frontend/thirdparty")

--- a/ports/cudnn-frontend/vcpkg.json
+++ b/ports/cudnn-frontend/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cudnn-frontend",
-  "version-semver": "1.24.1",
+  "version-semver": "1.25.0",
   "description": "cudnn_frontend provides a c++ wrapper for the cudnn backend API and samples on how to use it",
   "homepage": "https://github.com/NVIDIA/cudnn-frontend",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2277,7 +2277,7 @@
       "port-version": 17
     },
     "cudnn-frontend": {
-      "baseline": "1.24.1",
+      "baseline": "1.25.0",
       "port-version": 0
     },
     "cunit": {

--- a/versions/c-/cudnn-frontend.json
+++ b/versions/c-/cudnn-frontend.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05215868279db55e482375f24b845fda63d35eb5",
+      "version-semver": "1.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "281e55d608cfb7766e31125b57a447094a35a9b5",
       "version-semver": "1.24.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.25.0
