### PR TITLE
[slickquant-hyperliquid-cpp] Update to 0.1.2

### DIFF
--- a/ports/slickquant-hyperliquid-cpp/portfile.cmake
+++ b/ports/slickquant-hyperliquid-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/hyperliquid-cpp
     REF "v${VERSION}"
-    SHA512 9fa2bb555b8701483c56238adeebb984c7efc1b7bcdee821b55a6d41820401d2f8297b583810639519fc5c24eb01ddc3bcdfff67e0c785d218d08c29e1bc830b
+    SHA512 afa9b2b1a9879658c96632f1ae1f5c3e0b963d39cda88b4e86447f534ed809d11c1be69caf1d22ff12344e0f40a15cbcc2cd4c84bd1f0a3480a610bb6be892f1
     HEAD_REF main
     PATCHES
         slick-net.patch

--- a/ports/slickquant-hyperliquid-cpp/slick-net.patch
+++ b/ports/slickquant-hyperliquid-cpp/slick-net.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6654a1d..748f702 100644
+index 55c3e5f..5005920 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -14,8 +14,8 @@ endif()
@@ -21,4 +21,4 @@ index 6654a1d..748f702 100644
 -    message(STATUS "Found slick-net: ${slick-net_DIR}")
  endif()
  
- add_library(hyperliquid
+ add_library(hyperliquid STATIC

--- a/ports/slickquant-hyperliquid-cpp/vcpkg.json
+++ b/ports/slickquant-hyperliquid-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slickquant-hyperliquid-cpp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "SDK for Hyperliquid API trading with C++",
   "homepage": "https://github.com/SlickQuant/hyperliquid-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9393,7 +9393,7 @@
       "port-version": 0
     },
     "slickquant-hyperliquid-cpp": {
-      "baseline": "0.1.1",
+      "baseline": "0.1.2",
       "port-version": 0
     },
     "slikenet": {

--- a/versions/s-/slickquant-hyperliquid-cpp.json
+++ b/versions/s-/slickquant-hyperliquid-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "53e86fd7c39a38e09e5592ab00e21a7d6b24056e",
+      "git-tree": "6d56eb07a1ad27afd91c557dcb78032d79c49ed3",
       "version": "0.1.2",
       "port-version": 0
     },

--- a/versions/s-/slickquant-hyperliquid-cpp.json
+++ b/versions/s-/slickquant-hyperliquid-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53e86fd7c39a38e09e5592ab00e21a7d6b24056e",
+      "version": "0.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "29b5f250c6c1ab31a1196743026a92606ad980e0",
       "version": "0.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.1.2
