### PR TITLE
[vcpkg-ci-leveldb] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-leveldb/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-leveldb/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-leveldb/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-leveldb/project/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-leveldb)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(leveldb CONFIG REQUIRED)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE leveldb::leveldb)

--- a/scripts/test_ports/vcpkg-ci-leveldb/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-leveldb/project/main.cpp
@@ -1,0 +1,23 @@
+#include <leveldb/db.h>
+#include <cassert>
+#include <string>
+#include <filesystem>
+
+int main() {
+    std::filesystem::path tmp = std::filesystem::temp_directory_path() / "vcpkg-ci-leveldb-test";
+    std::filesystem::remove_all(tmp);
+    leveldb::DB* db = nullptr;
+    leveldb::Options options;
+    options.create_if_missing = true;
+    leveldb::Status status = leveldb::DB::Open(options, tmp.string(), &db);
+    assert(status.ok());
+    status = db->Put(leveldb::WriteOptions(), "hello", "leveldb");
+    assert(status.ok());
+    std::string value;
+    status = db->Get(leveldb::ReadOptions(), "hello", &value);
+    assert(status.ok());
+    assert(value == "leveldb");
+    delete db;
+    std::filesystem::remove_all(tmp);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-leveldb/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-leveldb/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "vcpkg-ci-leveldb",
+  "version-string": "ci",
+  "description": "Validates leveldb",
+  "dependencies": [
+    {
+      "name": "leveldb",
+      "features": [
+        "crc32c",
+        "snappy"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Add a ci port for leveldb