### PR TITLE
[dspark] new port

### DIFF
--- a/ports/dspark/portfile.cmake
+++ b/ports/dspark/portfile.cmake
@@ -1,0 +1,28 @@
+# DSPark vcpkg port — submit to microsoft/vcpkg once a release tag exists.
+# Update REF and SHA512 for the published release archive
+# (vcpkg hashes the GitHub source tarball of the tag).
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO CristianMoresi/DSPark
+    REF v1.4.1
+    SHA512 b9fd5b6d7428a2a82589661d65f73e91a72aeeb243572ad5c88aaa6974b8ad6a5282a01b6c3623872f2b2241e97070555864be243af8de2b1a29807a64684bfd
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDSPARK_BUILD_CONFORMANCE=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME dspark CONFIG_PATH lib/cmake/dspark)
+
+# Header-only: no compiled libraries, and config_fixup moved the cmake files
+# from lib/cmake to share/, so lib/ is left empty (vcpkg rejects empty
+# installed directories).
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dspark/vcpkg.json
+++ b/ports/dspark/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "dspark",
+  "version": "1.4.1",
+  "description": "Header-only audio DSP framework in pure C++20 with zero external dependencies: filters, dynamics, reverbs, physical analog models, pitch tools, EBU R128 metering and more.",
+  "homepage": "https://github.com/CristianMoresi/DSPark",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2632,6 +2632,10 @@
       "baseline": "1.9.13",
       "port-version": 1
     },
+    "dspark": {
+      "baseline": "1.4.1",
+      "port-version": 0
+    },
     "dstorage": {
       "baseline": "1.3.0",
       "port-version": 0

--- a/versions/d-/dspark.json
+++ b/versions/d-/dspark.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "44697241bd0b878c98590780303ab599792750d6",
+      "version": "1.4.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

Adds a new port: **dspark** 1.2.2 — a header-only audio DSP framework in pure C++20 with zero external dependencies (filters, dynamics processors, reverbs, physical analog models, pitch tools, EBU R128 metering).

- Upstream: https://github.com/CristianMoresi/DSPark (MIT)
- Header-only INTERFACE library installed via the upstream CMake package; the port disables the conformance-suite build and installs headers plus CMake config.
- I am the upstream author and will maintain the port.

**Checklist**

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version (header-only: all platforms).
- [x] Any fixed CI baseline entries are removed from that file (none).
- [x] Any patches that are no longer applied are deleted from the port's directory (none).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.