### PR TITLE
[vcpkg-ci-thorvg] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-thorvg/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-thorvg/portfile.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-thorvg/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-thorvg/project/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-thorvg)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(thorvg IMPORTED_TARGET REQUIRED thorvg-1)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE PkgConfig::thorvg)

--- a/scripts/test_ports/vcpkg-ci-thorvg/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-thorvg/project/main.cpp
@@ -1,0 +1,7 @@
+#include <thorvg.h>
+
+int main() {
+    tvg::Initializer::init(1);
+    tvg::Initializer::term();
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-thorvg/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-thorvg/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-thorvg",
+  "version-string": "ci",
+  "description": "Validates thorvg",
+  "dependencies": [
+    "thorvg",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Add a ci port for thorvg