### PR TITLE
[tinyexr] update to 3.0.0

### DIFF
--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyexr
     REF "v${VERSION}"
-    SHA512 af032e8d501359d480b57974c402637c4eecfd6af9912461eea6bef68d189219d658ae52c5c3a40693348aa9fdf968e355a01b7320a97148207d0bfa6b6cd2ab
+    SHA512 736388fada2dd83ca78e6fa1110ff7142be626dfb2225096cd207caf092e952c63f7537af4074b1926681d5df40ab23bafda77fca0a88b5ba8986a75e3d72dfe
     HEAD_REF master
     PATCHES
         fixtargets.patch

--- a/ports/tinyexr/vcpkg.json
+++ b/ports/tinyexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyexr",
-  "version": "1.0.13",
+  "version": "3.0.0",
   "description": "Library to load and save OpenEXR(.exr) images",
   "homepage": "https://github.com/syoyo/tinyexr",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10129,7 +10129,7 @@
       "port-version": 2
     },
     "tinyexr": {
-      "baseline": "1.0.13",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "tinyfiledialogs": {

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5edc094f2f230f582dea0bdcf3ecab4bcd98a1eb",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b57981eab50cf3f24ddf6037443a876e1ff728c1",
       "version": "1.0.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/syoyo/tinyexr/releases/tag/v3.0.0
