### PR TITLE
[sdl3-image] Add support for JPEG XL and AVIF image formats

### DIFF
--- a/ports/sdl3-image/portfile.cmake
+++ b/ports/sdl3-image/portfile.cmake
@@ -12,14 +12,12 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        avif    SDLIMAGE_AVIF
         jpeg    SDLIMAGE_JPG
+        jxl     SDLIMAGE_JXL
         png     SDLIMAGE_PNG
         tiff    SDLIMAGE_TIF
         webp    SDLIMAGE_WEBP
-    INVERTED_FEATURES
-        # Disabled capabilities: Needing dependencies.
-        core    SDLIMAGE_AVIF
-        core    SDLIMAGE_JXL
 )
 
 vcpkg_cmake_configure(

--- a/ports/sdl3-image/vcpkg.json
+++ b/ports/sdl3-image/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "sdl3-image",
   "version": "3.4.4",
-  "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
+  "port-version": 1,
+  "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: AVIF, BMP, GIF, JPEG, JPEG XL, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",
   "dependencies": [
@@ -19,10 +20,28 @@
     }
   ],
   "features": {
+    "avif": {
+      "description": "Support for AVIF image format",
+      "dependencies": [
+        {
+          "name": "libavif",
+          "features": [
+            "aom",
+            "dav1d"
+          ]
+        }
+      ]
+    },
     "jpeg": {
       "description": "Support for JPEG image format",
       "dependencies": [
         "libjpeg-turbo"
+      ]
+    },
+    "jxl": {
+      "description": "Support for JPEG XL image format",
+      "dependencies": [
+        "libjxl"
       ]
     },
     "png": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9134,7 +9134,7 @@
     },
     "sdl3-image": {
       "baseline": "3.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl3-mixer": {
       "baseline": "3.2.4",

--- a/versions/s-/sdl3-image.json
+++ b/versions/s-/sdl3-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b42d5467aa2899a40271972eb817d0da82eab05",
+      "version": "3.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "7d64d0dd26d1a025b99b83429838551fde4a65cf",
       "version": "3.4.4",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

