### PR TITLE
[aws-c-s3] Update to 0.12.6

### DIFF
--- a/ports/aws-c-s3/portfile.cmake
+++ b/ports/aws-c-s3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-s3
     REF "v${VERSION}"
-    SHA512 d32c2cb52e4eebea1aa1a3c44447b020e5adccebeecfb9de517ef260eda8691db878b1d270d4b2a81d7f707d91d629848cda4a60153390cf073c4b844e3c1a64
+    SHA512 efa16c319bee8b09fd24c8812c46276221f0c94669a9dedcde010911dbe8c8c2f45e43db6892d4f8d3e9ad4eb1a53ebc8404b38e2c38b2ee3f8a19db294d579a
     HEAD_REF master
 )
 

--- a/ports/aws-c-s3/vcpkg.json
+++ b/ports/aws-c-s3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-s3",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "C99 library implementation for communicating with the S3 service, designed for maximizing throughput on high bandwidth EC2 instances.",
   "homepage": "https://github.com/awslabs/aws-c-s3",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-s3.json
+++ b/versions/a-/aws-c-s3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e23a6ea5e50ca64e62bc741565d35f9aed224cf",
+      "version": "0.12.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "2bfd9de5d055e60fe2c018a586453778f49350d5",
       "version": "0.12.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -489,7 +489,7 @@
       "port-version": 0
     },
     "aws-c-s3": {
-      "baseline": "0.12.5",
+      "baseline": "0.12.6",
       "port-version": 0
     },
     "aws-c-sdkutils": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.12.6
