### PR TITLE
[ruvia] add port

### DIFF
--- a/ports/ruvia/portfile.cmake
+++ b/ports/ruvia/portfile.cmake
@@ -1,0 +1,53 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hyird/Ruvia
+    REF "v${VERSION}"
+    SHA512 1a8dd710458019121f4f06e79832dc5163929c1a165d22792ef8e988daf141d0cc75924b82304ce75115ee494a0a49fbddf0488041f98eedd275d5ceea600d36
+    HEAD_REF main
+    PATCHES
+        respect-msvc-runtime.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        jwt RUVIA_ENABLE_JWT
+        mariadb RUVIA_ENABLE_MARIADB
+        redis RUVIA_ENABLE_REDIS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DRUVIA_BUILD_EXAMPLES=OFF
+        -DRUVIA_BUILD_TECHEMPOWER=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME ruvia CONFIG_PATH lib/cmake/ruvia)
+vcpkg_copy_pdbs()
+
+set(RUVIA_CONFIG "${CURRENT_PACKAGES_DIR}/share/ruvia/ruviaConfig.cmake")
+file(READ "${RUVIA_CONFIG}" RUVIA_CONFIG_CONTENTS)
+string(REPLACE
+    [=[get_filename_component(_ruvia_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)]=]
+    [=[get_filename_component(_ruvia_prefix "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)]=]
+    RUVIA_CONFIG_CONTENTS
+    "${RUVIA_CONFIG_CONTENTS}"
+)
+string(REGEX REPLACE
+    [=[IMPORTED_LOCATION "\$\{_ruvia_prefix\}/lib/([^"]+)"]=]
+    [=[IMPORTED_CONFIGURATIONS "Debug;Release"
+        IMPORTED_LOCATION_RELEASE "${_ruvia_prefix}/lib/\1"
+        IMPORTED_LOCATION_DEBUG "${_ruvia_prefix}/debug/lib/\1"]=]
+    RUVIA_CONFIG_CONTENTS
+    "${RUVIA_CONFIG_CONTENTS}"
+)
+file(WRITE "${RUVIA_CONFIG}" "${RUVIA_CONFIG_CONTENTS}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ruvia/respect-msvc-runtime.patch
+++ b/ports/ruvia/respect-msvc-runtime.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8f50f2f..1893229 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD 23)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ 
+-if(MSVC)
++if(MSVC AND NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+ endif()
+ 
+@@ -87,7 +87,7 @@ if(RUVIA_ENABLE_JWT)
+     list(APPEND RUVIA_SOURCES src/auth/Jwt.cpp)
+ endif()
+ 
+-add_library(ruvia ${RUVIA_SOURCES})
++add_library(ruvia STATIC ${RUVIA_SOURCES})
+ 
+ add_library(ruvia::ruvia ALIAS ruvia)
+ 

--- a/ports/ruvia/vcpkg.json
+++ b/ports/ruvia/vcpkg.json
@@ -1,0 +1,38 @@
+{
+  "name": "ruvia",
+  "version": "0.0.2",
+  "description": "Small C++23 HTTP/1.1 web framework with built-in TLS, routing, middleware, streaming, WebSocket, and PMR-oriented runtime.",
+  "homepage": "https://github.com/hyird/Ruvia",
+  "license": "MIT",
+  "dependencies": [
+    "asio",
+    "mimalloc",
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "jwt": {
+      "description": "Build HMAC JWT helper APIs."
+    },
+    "mariadb": {
+      "description": "Build MariaDB-compatible database APIs.",
+      "dependencies": [
+        "libmariadb"
+      ]
+    },
+    "redis": {
+      "description": "Build Redis client APIs.",
+      "dependencies": [
+        "hiredis"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8968,6 +8968,10 @@
       "baseline": "0.17.3",
       "port-version": 0
     },
+    "ruvia": {
+      "baseline": "0.0.2",
+      "port-version": 0
+    },
     "rxcpp": {
       "baseline": "4.1.1",
       "port-version": 1

--- a/versions/r-/ruvia.json
+++ b/versions/r-/ruvia.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b4f9338c12d0e1e90b15d1051c9baf890531bfcc",
+      "version": "0.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new `ruvia` port for Ruvia 0.0.2.

Ruvia is a C++23 HTTP/1.1 web framework with built-in TLS, routing, middleware, streaming, WebSocket, and PMR-oriented runtime support. The port is static-library only and exposes optional `jwt`, `mariadb`, and `redis` features.

The patch keeps the 0.0.2 release compatible with vcpkg triplet semantics by respecting an externally provided `CMAKE_MSVC_RUNTIME_LIBRARY` and by making the upstream library target explicitly static.

Validation performed locally:

- `vcpkg format-manifest ports/ruvia/vcpkg.json`
- `vcpkg x-add-version ruvia`
- `vcpkg x-ci-verify-versions --verbose`
- `vcpkg install ruvia --overlay-ports=F:\workspace\Ruvia\vcpkg-overlay --triplet x64-windows`
- `vcpkg install ruvia --overlay-ports=F:\workspace\Ruvia\vcpkg-overlay --triplet x64-windows-static`
- `vcpkg install ruvia[jwt,mariadb,redis] --overlay-ports=F:\workspace\Ruvia\vcpkg-overlay --triplet x64-windows`
- Minimal downstream `find_package(ruvia CONFIG REQUIRED)` consumer builds and runs for dynamic/static triplets and all-features headers.