### PR TITLE
[vcpkg-ci-qtquickcontrols2] New ci port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-qtquickcontrols2/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-qtquickcontrols2/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(vcpkg-ci-qtquickcontrols2)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 COMPONENTS Core Qml Quick QuickControls2 REQUIRED)
+
+add_executable(vcpkg-ci-qtquickcontrols2 main.cpp resources.qrc)
+
+target_compile_definitions(vcpkg-ci-qtquickcontrols2 PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
+target_link_libraries(vcpkg-ci-qtquickcontrols2 PRIVATE Qt6::Core Qt6::Qml Qt6::Quick Qt6::QuickControls2)
+
+qt_import_qml_plugins(vcpkg-ci-qtquickcontrols2)

--- a/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/main.cpp
@@ -1,0 +1,21 @@
+#include <QDebug>
+#include <QGuiApplication>
+#include <QOpenGLContext>
+#include <QQmlApplicationEngine>
+
+int main(int argc, char *argv[]) {
+    QGuiApplication app(argc, argv);
+
+    QQmlApplicationEngine engine;
+    const QUrl url(QStringLiteral("qrc:/main.qml"));
+    QObject::connect(
+        &engine, &QQmlApplicationEngine::objectCreated, &app,
+        [](QObject *obj, const QUrl &objUrl) {
+            if (!obj) {
+                QCoreApplication::exit(-1);
+            }
+        },
+        Qt::QueuedConnection);
+    engine.load(url);
+    return app.exec();
+}

--- a/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/main.qml
+++ b/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/main.qml
@@ -1,0 +1,8 @@
+import QtQuick.Controls
+
+ApplicationWindow {
+    width: 960
+    height: 540
+    visible: true
+    title: qsTr("Main")
+}

--- a/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/resources.qrc
+++ b/scripts/test_ports/vcpkg-ci-qtquickcontrols2/project/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/scripts/test_ports/vcpkg-ci-qtquickcontrols2/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-qtquickcontrols2/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "vcpkg-ci-qtquickcontrols2",
+  "version-string": "ci",
+  "description": "Validates qtquickcontrols2",
+  "dependencies": [
+    "qtbase",
+    "qtdeclarative",
+    "qtquickcontrols2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
