### PR TITLE
Fix IncrementalClean deleting applocal-deployed DLLs on full builds

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -269,6 +269,14 @@
     <Message Text="@(VcpkgAppLocalDLLs,'%0A')" Importance="Normal" Condition="$(_ZVcpkgAppLocalExitCode) == 0" />
     <ItemGroup Condition="$(_ZVcpkgAppLocalExitCode) == 0">
       <ReferenceCopyLocalPaths Include="@(VcpkgAppLocalDLLs)" />
+      <!-- Register the deployed DLLs as file writes so MSBuild's IncrementalClean
+           doesn't treat them as orphan outputs and delete them. Without this, any
+           clean-file entries recorded by AppLocalFromInstalledPreserve on a previous
+           link-skipped build cause IncrementalClean to delete the DLLs on the next
+           build where the link runs, immediately after they were deployed. The paths
+           are re-based to $(OutDir) because z-applocal logs source paths while
+           applocal.ps1 logs destination paths. -->
+      <FileWrites Include="@(VcpkgAppLocalDLLs -> '$(OutDir)%(Filename)%(Extension)')" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #51298.

### Problem

`AppLocalFromInstalled` deploys dependency DLLs to `$(OutDir)` but only registers them in `ReferenceCopyLocalPaths`, never in `FileWrites`. `AppLocalFromInstalledPreserve` (added in #50521) registers them in `FileWrites`, but **only on link-skipped builds**. The asymmetry makes the full-build path actively destructive:

1. **Build N (link skipped):** `AppLocalFromInstalledPreserve` adds the DLLs to `FileWrites`, and `_CleanRecordFileWrites` persists them into the project's clean file (`FileListAbsolute.txt`).
2. **Build N+1 (link runs, e.g. after editing a source file):** `AppLocalFromInstalled` re-deploys the DLLs but registers nothing, and `Preserve` is skipped (`LinkSkippedExecution != 'true'`). MSBuild's `IncrementalClean` compares the prior clean-file entries against the current `FileWrites`, concludes the DLLs are orphan outputs, and **deletes every applocal-deployed DLL from `$(OutDir)` — immediately after they were copied.** The binary then fails to start with `0xC0000135` / "module not found".

So any plain "no-op build, then relink" sequence wipes the DLLs. Before #50521 nothing ever put these DLLs into the clean file, so the full-build gap was harmless; with #50521 the skip path seeds the clean file that the full-build path then trips over.

Two factors make this hard to diagnose:

- The `ReferenceCopyLocalPaths` registration does *not* protect the DLLs when the project's output directory is outside its project directory (the common "central output dir" solution layout): the `FileWritesShareable` promotion in `_CleanGetCurrentAndPriorFileWrites` drops files outside `$(MSBuildProjectDirectory)` because `TrackFileWritesShareableOutsideOfProjectDirectory` defaults to `false`. With OutDir inside the project tree the bug is masked, which is presumably why it survived testing.
- `$(IntDir)vcpkg.applocal.log` is written before `IncrementalClean` runs, so the build log claims the DLLs were deployed while the output directory ends up without them.

Multi-project solutions sharing one `OutDir` (app + test DLLs) are hit hardest: whichever project hits the skip-then-link sequence deletes the shared DLLs for all of them, and since applocal only runs when the linker runs, ordinary incremental builds never restore them.

### Reproduction

Minimal `.vcxproj` (Application, `Release|x64`) linking any dynamic vcpkg dependency (e.g. `sdl3` or `zlib`, triplet `x64-windows`), with `OutDir`/`IntDir` placed **outside the project directory**, e.g. `$(ProjectDir)..\out\` (also note that incremental linking is disabled under `%TEMP%`, so a repro placed there will never skip the link and won't reproduce):

```
msbuild proj\repro.vcxproj /p:OutDir=%cd%\out\ /p:IntDir=%cd%\int\ ...   # full build
msbuild proj\repro.vcxproj ...                                          # no-op build (link skipped)
<edit a .cpp>
msbuild proj\repro.vcxproj ...                                          # relink
```

| Step | without fix | with fix |
|---|---|---|
| 1. full build | DLL deployed | DLL deployed |
| 2. no-op build | DLL present, clean file now lists it | DLL present |
| 3. relink | **DLL deleted by IncrementalClean** | DLL present |
| 4. no-op build | | DLL present |
| 5. relink | | DLL present |

Verified with the `applocal.ps1` path on VS 2026 (18.x). The deletion is visible in a `-v:diag` log as a `Delete` task inside `IncrementalClean` listing each deployed DLL.

### Fix

Register the deployed DLLs as `FileWrites` in `AppLocalFromInstalled`, mirroring what `AppLocalFromInstalledPreserve` does for the link-skipped path, with the same re-basing transform to `$(OutDir)` (the builtin z-applocal writes source paths while `applocal.ps1` writes destination paths). Both build paths now agree that the deployed DLLs are owned outputs, so `IncrementalClean` leaves them alone in every build sequence.

Related: #31901, #46037, #50521.
