### PR TITLE
[libmultisense] Update to `v7.9.0`

### DIFF
--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO carnegierobotics/LibMultiSense
     REF ${VERSION}
-    SHA512 71c779cc0f23818aaab4cbba0a5aa5b3ad979180247a3d76b0f8fd5a3b7ced106520fa5df69946cd84510211b6508f5df80b09aecbbabb6601fee5f38ec79bc7
+    SHA512 3f1278a2996517a6ca3c1baed765499365ab1bfd7a15e229e3d5babc7ee41c99b804a69d9e1f9ee9f3e075e01fd9624c04e98e3fad2f7b6b10c8986bd2bbe5a3
     HEAD_REF master
     PATCHES
         0000-disable-error-on-warning.patch
@@ -39,6 +39,11 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+# LibMultiSense installs additional CMake helper modules alongside `MultiSenseConfig.cmake`.
+# `vcpkg_cmake_config_fixup()` only removes debug-side `*Config`/`*Targets` files, which leaves
+# `${CURRENT_PACKAGES_DIR}/debug/share/MultiSense` populated and triggers a post-build policy error.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
 if ("utilities" IN_LIST FEATURES)
     set(_tool_names
         ChangeIpUtility
@@ -52,6 +57,9 @@ if ("utilities" IN_LIST FEATURES)
     )
     if ("json-serialization" IN_LIST FEATURES)
         list(APPEND _tool_names DeviceInfoUtility)
+    endif ()
+    if ("opencv" IN_LIST FEATURES)
+        list(APPEND _tool_names FeatureDetectorUtility)
     endif ()
     vcpkg_copy_tools(
         TOOL_NAMES ${_tool_names}

--- a/ports/libmultisense/vcpkg.json
+++ b/ports/libmultisense/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmultisense",
-  "version": "7.6.0",
+  "version": "7.9.0",
   "description": "A C++ library for interfacing with the MultiSense S family of sensors from Carnegie Robotics.",
   "homepage": "https://github.com/carnegierobotics/LibMultiSense",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5349,7 +5349,7 @@
       "port-version": 1
     },
     "libmultisense": {
-      "baseline": "7.6.0",
+      "baseline": "7.9.0",
       "port-version": 0
     },
     "libmupdf": {

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ffa516c573b9bce9dcf3baa32cb7bb29fc892104",
+      "version": "7.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "88faa7763bbf94f2670b23f179e1a8a840965582",
       "version": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
