### PR TITLE
[usd] update to 26.05

### DIFF
--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PixarAnimationStudios/OpenUSD
     REF "v${USD_VERSION}"
-    SHA512 3d5dae46c7ae096501dc51b373ba05c8603a1cf16e5054728d41d0c2970b59ce3ee5ec83e1c575b92482bc8cf2c59643df093a9e7aa82bcdd53dada05292720d
+    SHA512 d10222a457d71470a26ad6dc812685f257bf5c90a64a11d90e543ef7eaba803aa4e2593c358ebd430ba55856e987f7a6f50597b1ad6d2da737c239ad4f18ad6a
     HEAD_REF release
     PATCHES
         003-fix-dep.patch

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usd",
-  "version": "26.3",
+  "version": "26.5",
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenUSD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10449,7 +10449,7 @@
       "port-version": 1
     },
     "usd": {
-      "baseline": "26.3",
+      "baseline": "26.5",
       "port-version": 0
     },
     "usearch": {

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74916c26d54242a3b610bfe7059bfad0d454f717",
+      "version": "26.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "346d7fa5dffe48fcf9ba07c11d191294720bd419",
       "version": "26.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
