### PR TITLE
Fix MSBuild duplicate import warning.

### DIFF
--- a/scripts/buildsystems/msbuild/support/Bootstrap.targets
+++ b/scripts/buildsystems/msbuild/support/Bootstrap.targets
@@ -1,5 +1,5 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildThisFileDirectory)\GetGlobalProperties.task" />
+  <Import Project="$(MSBuildThisFileDirectory)\GetGlobalProperties.task" Condition="'$(_ZVcpkgGetGlobalPropertiesImported)' != 'true'" />
 
   <!-- The VcpkgBootstrap target runs before VcpkgInstallManifestDependencies target and - if $(_ZVcpkgExecutable) is
   out-of-date with respect to $(_ZVcpkgRoot)\scripts\vcpkg-tool-metadata.txt - it invokes the

--- a/scripts/buildsystems/msbuild/support/GetGlobalProperties.task
+++ b/scripts/buildsystems/msbuild/support/GetGlobalProperties.task
@@ -1,4 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Include-guard sentinel so this file can be imported from multiple places without triggering MSB4011. -->
+  <PropertyGroup>
+    <_ZVcpkgGetGlobalPropertiesImported>true</_ZVcpkgGetGlobalPropertiesImported>
+  </PropertyGroup>
+
   <!-- Define the GetGlobalProperties task for retrieving the Global Properties from the current MSBuild engine.
 
   The task has a single output parameter - GlobalPropertyNames - which is a semi-colon delimited list of the global

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -180,7 +180,7 @@
           Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true'"
   />
   <Import Project="$(MSBuildThisFileDirectory)support\GetGlobalProperties.task"
-          Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true'"
+          Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true' and '$(_ZVcpkgGetGlobalPropertiesImported)' != 'true'"
   />
 
   <Target Name="VcpkgInstallManifestDependencies" BeforeTargets="ClCompile"


### PR DESCRIPTION
In reviewing https://github.com/microsoft/vcpkg/pull/52360 I got this warning:

```console
D:\vcpkg\scripts\buildsystems\msbuild\vcpkg.targets(182,3): warning MSB4011: "D:\vcpkg\scripts\buildsystems\msbuild\support\GetGlobalProperties.task" cannot be imported again. It was already imported at "D:\vcpkg\scripts\buildsystems\msbuild\support\Bootstrap.targets (2,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\vcpkg\scripts\buildsystems\msbuild\test\applocal-repro\hello-app\hello-app.vcxproj]
```

probably introduced in https://github.com/microsoft/vcpkg/pull/41605 or https://github.com/microsoft/vcpkg/pull/51348 . This change makes importing that idempotent by setting a property and only importing if the property is unset.

This change (but not this message) written by Claude Opus 4.8.
