### PR TITLE
[slick-dynamic-buffer] Add new port

### DIFF
--- a/ports/slick-dynamic-buffer/portfile.cmake
+++ b/ports/slick-dynamic-buffer/portfile.cmake
@@ -1,0 +1,26 @@
+set(VCPKG_BUILD_TYPE release) # header only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SlickQuant/slick-dynamic-buffer
+    REF "v${VERSION}"
+    SHA512 28a29f9279317e28a0eaec41968cf521ebabef5cc995e07f796be8205b2f9648d3a73ca0f103003d0dfb440ba35b17bc78622e6012bd36e635fab8479d6b4463
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SLICK_DYNAMIC_BUFFER_TESTS=OFF
+        -DCMAKE_REQUIRE_FIND_PACKAGE_slick-stream-buffer=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH lib/cmake/slick-dynamic-buffer
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/slick-dynamic-buffer/vcpkg.json
+++ b/ports/slick-dynamic-buffer/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "slick-dynamic-buffer",
+  "version": "1.0.0",
+  "description": "Header-only Boost.Asio DynamicBuffer adapter for slick-stream-buffer - zero-copy fan-out of received network bytes to lock-free SPMC consumers across threads and processes",
+  "homepage": "https://github.com/SlickQuant/slick-dynamic-buffer",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "boost-asio",
+      "version>=": "1.84.0#1"
+    },
+    {
+      "name": "slick-stream-buffer",
+      "version>=": "1.0.4"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9372,6 +9372,10 @@
       "baseline": "2025-12-18",
       "port-version": 0
     },
+    "slick-dynamic-buffer": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "slick-logger": {
       "baseline": "1.0.9",
       "port-version": 0

--- a/versions/s-/slick-dynamic-buffer.json
+++ b/versions/s-/slick-dynamic-buffer.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "41c6e65dfd771fb857795b32aa3c4deab3002829",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="986" height="650" alt="image" src="https://github.com/user-attachments/assets/0faa6641-0995-4f6c-b9ed-4f2d77f14b67" />
