### PR TITLE
[kleidiai] Update to 1.26.0

### DIFF
--- a/ports/kleidiai/portfile.cmake
+++ b/ports/kleidiai/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ARM-software/kleidiai
     REF "v${VERSION}"
-    SHA512 280bab1c123dec04d85da6a5fe4d1fc6a6698a6f1f664df635771e80de3de37cb837e7a970cc24b6478c6fb95dafb550b1e70033a7edf2ad28aa4fdbc82c918b
+    SHA512 bdb2fa30025d7cd885ab143df98f70c454e2ff7a5d94be6ac99cfa66dafa4a8dcd83f07652b285ef61ed8523bdb0d4c313b506cd1c71347d5400e935783fc459
     HEAD_REF main
 )
 

--- a/ports/kleidiai/vcpkg.json
+++ b/ports/kleidiai/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kleidiai",
-  "version-semver": "1.25.0",
+  "version-semver": "1.26.0",
   "description": "Arm's KleidiAI library for efficient neural network inference.",
   "homepage": "https://github.com/ARM-software/kleidiai",
   "license": "Apache-2.0 OR BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4557,7 +4557,7 @@
       "port-version": 1
     },
     "kleidiai": {
-      "baseline": "1.25.0",
+      "baseline": "1.26.0",
       "port-version": 0
     },
     "klein": {

--- a/versions/k-/kleidiai.json
+++ b/versions/k-/kleidiai.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8cb84202512af2c647e02d6bf2c13eee9cf6c28",
+      "version-semver": "1.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "33ca082c0c22e621f7b3aefca2ccf96531e03a62",
       "version-semver": "1.25.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.26.0
