### PR TITLE
[slick-queue] Update to 1.5.0

### DIFF
--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-queue
     REF "v${VERSION}"
-    SHA512 216300e638d0cf6bf5775f66d0466446c1fd5b63da7506cc4dec00c520435feb0bb564c99170e786cbd6361a781d1de63b609f82aeb83a722e325f4e9d99503c
+    SHA512 d0dc83f489f45d913f1b4021c3f7b1a863d2c62b33284c38d2e14ba892743dfef9529a1d549ba721f558fe209ff4070ae8af3ac401cbd3fd2940c57ca864fc48
     HEAD_REF main
     PATCHES
         slick-shm.patch

--- a/ports/slick-queue/vcpkg.json
+++ b/ports/slick-queue/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-queue",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A C++ Lock-Free MPMC queue - header-only library for high throughput concurrent messaging with optional shared memory support",
   "homepage": "https://github.com/SlickQuant/slick-queue",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9385,7 +9385,7 @@
       "port-version": 0
     },
     "slick-queue": {
-      "baseline": "1.4.1",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "slick-shm": {

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d555c6ba4f83266898693fc8b55a25d8c8c60c5",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e748ce9fa5d5334dbbb5271ef562588592cc642b",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.5.0
