### PR TITLE
[rocksdb] Update to 11.1.1

### DIFF
--- a/ports/rocksdb/0001-fix-dependencies.patch
+++ b/ports/rocksdb/0001-fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d1c4c27a0..681438814 100644
+index 9523fe3e7..ad90f6ef5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -111,7 +111,7 @@ endif()
+@@ -106,7 +106,7 @@ endif()
  
  include(CMakeDependentOption)
  
@@ -11,7 +11,7 @@ index d1c4c27a0..681438814 100644
    option(WITH_GFLAGS "build with GFlags" OFF)
    option(WITH_XPRESS "build with windows built in compression" OFF)
    option(ROCKSDB_SKIP_THIRDPARTY "skip thirdparty.inc" OFF)
-@@ -165,10 +165,7 @@ else()
+@@ -160,10 +160,7 @@ else()
    endif()
  
    if(WITH_SNAPPY)
@@ -23,7 +23,7 @@ index d1c4c27a0..681438814 100644
      add_definitions(-DSNAPPY)
      list(APPEND THIRDPARTY_LIBS Snappy::snappy)
    endif()
-@@ -192,16 +189,19 @@ else()
+@@ -187,16 +184,19 @@ else()
    endif()
  
    if(WITH_LZ4)
@@ -47,7 +47,7 @@ index d1c4c27a0..681438814 100644
    endif()
  endif()
  
-@@ -352,11 +352,10 @@ int main() {
+@@ -347,11 +347,10 @@ int main() {
  endif()
  
  if (WITH_LIBURING)
@@ -63,7 +63,7 @@ index d1c4c27a0..681438814 100644
  endif()
  
  # Reset the required flags
-@@ -414,17 +413,16 @@ endif()
+@@ -409,17 +408,16 @@ endif()
  
  option(WITH_NUMA "build with NUMA policy support" OFF)
  if(WITH_NUMA)
@@ -85,7 +85,7 @@ index d1c4c27a0..681438814 100644
  endif()
  
  # Stall notifications eat some performance from inserts
-@@ -1388,8 +1386,6 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
+@@ -1289,8 +1287,6 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
      endforeach()
    endforeach()
  

--- a/ports/rocksdb/0002-fix-android.patch
+++ b/ports/rocksdb/0002-fix-android.patch
@@ -1,8 +1,8 @@
 diff --git a/env/io_posix.h b/env/io_posix.h
-index 729e2d893..da3e0ac78 100644
+index bca0c5836..395797d7e 100644
 --- a/env/io_posix.h
 +++ b/env/io_posix.h
-@@ -46,7 +46,7 @@
+@@ -40,7 +40,7 @@
  // For non linux platform, the following macros are used only as place
  // holder.
  #if !(defined OS_LINUX) && !(defined OS_FREEBSD) && !(defined CYGWIN) && \

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
   REF "v${VERSION}"
-  SHA512 a4aeac5a440cbdc5ef433f7ea1ebb445c04893663b8f287179752dfcd26b8c9ef6a05a96781aa9f748800a93e38643b7a7a72a6d691ae57124e9291efb2f0935
+  SHA512 3007a2747d2ef1efabf6e2a3bff0b7319416e5f9dbf5dc6e64bc3ea1c996bdd4eb25f3bd71f6d2fe1bf2c5a0a68758841d10696404201b65aebc9d77ccb57911
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "11.0.4",
-  "port-version": 1,
+  "version": "11.1.1",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8889,8 +8889,8 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "11.0.4",
-      "port-version": 1
+      "baseline": "11.1.1",
+      "port-version": 0
     },
     "rp-ntuples": {
       "baseline": "0.1.4",

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d8882f78c6ee377cd1b85fee786d9795493d01e",
+      "version": "11.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "be8b7958e01ec5a64ac296a7882e3b00c69c9545",
       "version": "11.0.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
