### PR TITLE
[libnice,libnice-gst] Update to 0.1.23

### DIFF
--- a/ports/libnice-gst/portfile.cmake
+++ b/ports/libnice-gst/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libnice/libnice
-    REF 0.1.22
-    SHA512 545c759a827e039d0aed262a4ec31b17610f7e67d93389c939763ed3d99530a4a6c3d13864ff05a2011fb3c3847ce3380a988e554de0f92b1348ebb76f5e3da4
+    REF "${VERSION}"
+    SHA512 6044bcbda2a247bbaa6e5364b25cff82952ffc44d6fbc434825c0ad05935ebcb04eb08eedca9175431f01a4cff50c0c7a0aad7c287f42a9639724aba202c87a0
     HEAD_REF master
     PATCHES
        skip_libnice.patch

--- a/ports/libnice-gst/vcpkg.json
+++ b/ports/libnice-gst/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnice-gst",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Gstreamer Libnice plugins.",
   "homepage": "https://nice.freedesktop.org",
   "license": "LGPL-2.1-only AND MPL-1.1",

--- a/ports/libnice/portfile.cmake
+++ b/ports/libnice/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libnice/libnice
-    REF 0.1.22
-    SHA512 545c759a827e039d0aed262a4ec31b17610f7e67d93389c939763ed3d99530a4a6c3d13864ff05a2011fb3c3847ce3380a988e554de0f92b1348ebb76f5e3da4
+    REF "${VERSION}"
+    SHA512 6044bcbda2a247bbaa6e5364b25cff82952ffc44d6fbc434825c0ad05935ebcb04eb08eedca9175431f01a4cff50c0c7a0aad7c287f42a9639724aba202c87a0
     HEAD_REF master
 )
 

--- a/ports/libnice/vcpkg.json
+++ b/ports/libnice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnice",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Libnice is an implementation of the IETF's Interactive Connectivity Establishment (ICE) standard (RFC 5245) and the Session Traversal Utilities for NAT (STUN) standard (RFC 5389).",
   "homepage": "https://nice.freedesktop.org",
   "license": "LGPL-2.1-only AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5373,11 +5373,11 @@
       "port-version": 0
     },
     "libnice": {
-      "baseline": "0.1.22",
+      "baseline": "0.1.23",
       "port-version": 0
     },
     "libnice-gst": {
-      "baseline": "0.1.22",
+      "baseline": "0.1.23",
       "port-version": 0
     },
     "libnick": {

--- a/versions/l-/libnice-gst.json
+++ b/versions/l-/libnice-gst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b274b379afaf298e2431c38ab2a3837897737a3e",
+      "version": "0.1.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "040d334c5cb1a71a7ffb8059202fa84c86bce0f0",
       "version": "0.1.22",
       "port-version": 0

--- a/versions/l-/libnice.json
+++ b/versions/l-/libnice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ac2407332b804cb587bf0ec6dc9d02f69d0ae55",
+      "version": "0.1.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f073aeceab2d83e6e682795493eb97c042068f0",
       "version": "0.1.22",
       "port-version": 0


### PR DESCRIPTION
Split out from #52375

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
