### PR TITLE
[libwandio] update to 4.2.7-1

### DIFF
--- a/ports/libwandio/portfile.cmake
+++ b/ports/libwandio/portfile.cmake
@@ -10,9 +10,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wanduow/wandio
     REF ${VERSION}
-    SHA512 931bdfe91c8923de52217873d5a12568bcac97b2ab7e4e50f48cd9999d7b3887175885c3f56250b0cd822584bbf4a9262b017ab57ed599ddd288abda1fad9885
+    SHA512 6468a6f22f7536b78c27d9c4399454ac0f471ea94c832869b5dad1b334edb8d66ebe931a0614ccc052b21a85fb21310fa9410850ad0ebbb4d722e3036990ffea
     HEAD_REF master
-    PATCHES configure.lib.patch # This is how configure.ac files with dependencies get fixed. 
+    PATCHES configure.lib.patch # This is how configure.ac files with dependencies get fixed.
             configure.patch
             ${PATCHES}
 )

--- a/ports/libwandio/vcpkg.json
+++ b/ports/libwandio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libwandio",
-  "version": "4.2.6-1",
-  "port-version": 2,
+  "version": "4.2.7-1",
   "description": "C library for simple and efficient file IO.",
   "homepage": "https://github.com/wanduow/wandio",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5901,8 +5901,8 @@
       "port-version": 2
     },
     "libwandio": {
-      "baseline": "4.2.6-1",
-      "port-version": 2
+      "baseline": "4.2.7-1",
+      "port-version": 0
     },
     "libwebm": {
       "baseline": "1.0.0.32",

--- a/versions/l-/libwandio.json
+++ b/versions/l-/libwandio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52188943ec3b3dcf51cecb214ce8b047d1999d23",
+      "version": "4.2.7-1",
+      "port-version": 0
+    },
+    {
       "git-tree": "04bcbb0fc4d2640814fae356a29c2549bdfcfbe8",
       "version": "4.2.6-1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/LibtraceTeam/wandio/releases/tag/4.2.7-1
