### PR TITLE
[ecm] update to 6.27.0

### DIFF
--- a/ports/ecm/fix_generateqmltypes.patch
+++ b/ports/ecm/fix_generateqmltypes.patch
@@ -1,5 +1,5 @@
 diff --git a/modules/ECMGenerateQmlTypes.cmake b/modules/ECMGenerateQmlTypes.cmake
-index d6e124266308028b8533203da63f572f6e99b308..7d7cecb5201521019764102eba0da2abf8b4d911 100644
+index f95ea29..1dbfef4 100644
 --- a/modules/ECMGenerateQmlTypes.cmake
 +++ b/modules/ECMGenerateQmlTypes.cmake
 @@ -1,4 +1,5 @@
@@ -18,9 +18,9 @@ index d6e124266308028b8533203da63f572f6e99b308..7d7cecb5201521019764102eba0da2ab
 -test named qmltypes-pluginname-version that makes sure that it doesn't need updating.
 +This function installs the file in DESTINATION folder.
  
- 
- Since 5.33.0
-@@ -40,7 +38,7 @@ function(ecm_generate_qmltypes)
+ With Qt6 prefer using qt_add_qml_module()/ecm_add_qml_module() and declarative
+ type registration, which do this automatically.
+@@ -43,7 +41,7 @@ function(ecm_generate_qmltypes)
      set(targetname "qmltypes-${ARG_UNPARSED_ARGUMENTS}")
      string(REPLACE ";" - targetname "${targetname}")
  

--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/extra-cmake-modules
     REF "v${VERSION}"
-    SHA512 87616de2e889d0129baed2f7311a3371ab08de2777a58a66294dbb48ba878f8527c79d0a13d1238f6d32b1faf6edcc23eebc51c3e6e6634e6a504f5b7c42b003
+    SHA512 789f7a876acd2187b1363c1d863bf3a2726a9f1ffe08a2e2e4a2d8b41fb054fb7b65cd078619205faed7b59f61c3af78b08ac778a37390e21603646a800cb093
     HEAD_REF master
     PATCHES
         fix_generateqmltypes.patch # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/201

--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ecm",
-  "version": "6.26.0",
+  "version": "6.27.0",
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://invent.kde.org/frameworks/extra-cmake-modules",
   "documentation": "https://api.kde.org/ecm/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2765,7 +2765,7 @@
       "port-version": 1
     },
     "ecm": {
-      "baseline": "6.26.0",
+      "baseline": "6.27.0",
       "port-version": 0
     },
     "ecos": {

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e0c7944f8a64ba368440318a4a583af715fb0e9",
+      "version": "6.27.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7e62051a319d098b02954f6ff36cd9b4aeab730e",
       "version": "6.26.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/KDE/extra-cmake-modules/releases/tag/v6.27.0

