### PR TITLE
[libhat] update to 0.10.0

### DIFF
--- a/ports/libhat/portfile.cmake
+++ b/ports/libhat/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BasedInc/libhat
     REF "v${VERSION}"
-    SHA512 68ce4d66f92553eb0f3e0f26c0274bc048d735936a68abf2fcb2ce7766dcdab73fb5dc0d8bbf249e5b36bd7a2eb2db06878eaffcd16d4bcac839953506704c8d
+    SHA512 250381ddedb927ef38fa17a7dadfabe746986e533282f311b6b5846de7ce695066b2ebaf188b3d8e53beb71b72ebfbb5f35087fd10e355afe45a5cb3bfcbebc3
     HEAD_REF master
     PATCHES
         0001-CMakeLists.patch

--- a/ports/libhat/vcpkg.json
+++ b/ports/libhat/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libhat",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A high-performance, modern, C++20 library designed around game hacking.",
   "homepage": "https://github.com/BasedInc/libhat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5121,7 +5121,7 @@
       "port-version": 0
     },
     "libhat": {
-      "baseline": "0.9.0",
+      "baseline": "0.10.0",
       "port-version": 0
     },
     "libhdfs3": {

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f231de7711e697521d1b7bc84bbd9223984eedcf",
+      "version": "0.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a23e41e2d3791f243c9b83d024c704e74a058f4a",
       "version": "0.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/BasedInc/libhat/releases/tag/v0.10.0
