### PR TITLE
[libgit2] Don't compile the static lib with /GL (avoids forcing /LTCG on consumers)

### DIFF
--- a/ports/libgit2/no-static-whole-program-optimization.diff
+++ b/ports/libgit2/no-static-whole-program-optimization.diff
@@ -1,0 +1,40 @@
+diff --git a/cmake/DefaultCFlags.cmake b/cmake/DefaultCFlags.cmake
+index 5abe0c8..ab1b7c2 100644
+--- a/cmake/DefaultCFlags.cmake
++++ b/cmake/DefaultCFlags.cmake
+@@ -50,13 +50,19 @@ if(MSVC)
+ 	# /Oy - Enable frame pointer omission (FPO) (otherwise CMake will automatically turn it off)
+ 	# /GL - Link time code generation (whole program optimization)
+ 	# /Gy - Function-level linking
+-	set(CMAKE_C_FLAGS_RELEASE "/DNDEBUG /O2 /Oy /GL /Gy ${CRT_FLAG_RELEASE}")
++	# /GL pays off only when the matching link runs /LTCG; a static libgit2 archive
++	# does no LTCG, so /GL would just force /LTCG onto every consumer. Shared/exe only.
++	if(BUILD_SHARED_LIBS)
++		set(GIT_WPO_C " /GL")
++		set(GIT_WPO_LINK " /LTCG")
++	endif()
++	set(CMAKE_C_FLAGS_RELEASE "/DNDEBUG /O2 /Oy${GIT_WPO_C} /Gy ${CRT_FLAG_RELEASE}")
+ 
+ 	# /Oy- - Disable frame pointer omission (FPO)
+-	set(CMAKE_C_FLAGS_RELWITHDEBINFO "/DNDEBUG /Zi /O2 /Oy- /GL /Gy ${CRT_FLAG_RELEASE}")
++	set(CMAKE_C_FLAGS_RELWITHDEBINFO "/DNDEBUG /Zi /O2 /Oy-${GIT_WPO_C} /Gy ${CRT_FLAG_RELEASE}")
+ 
+ 	# /O1 - Optimize for size
+-	set(CMAKE_C_FLAGS_MINSIZEREL "/DNDEBUG /O1 /Oy /GL /Gy ${CRT_FLAG_RELEASE}")
++	set(CMAKE_C_FLAGS_MINSIZEREL "/DNDEBUG /O1 /Oy${GIT_WPO_C} /Gy ${CRT_FLAG_RELEASE}")
+ 
+ 	# /IGNORE:4221 - Ignore empty compilation units
+ 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /IGNORE:4221")
+@@ -78,9 +84,9 @@ if(MSVC)
+ 	# /INCREMENTAL:NO - Required to use /LTCG
+ 	# /DEBUGTYPE:cv,fixup - Additional data embedded in the PDB (requires /INCREMENTAL:NO, so not on for Debug)
+ 	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "/DEBUG")
+-	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/RELEASE /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
+-	set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /RELEASE /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO /DEBUGTYPE:cv,fixup")
+-	set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "/RELEASE /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
++	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/RELEASE${GIT_WPO_LINK} /OPT:REF /OPT:ICF /INCREMENTAL:NO")
++	set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /RELEASE${GIT_WPO_LINK} /OPT:REF /OPT:ICF /INCREMENTAL:NO /DEBUGTYPE:cv,fixup")
++	set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "/RELEASE${GIT_WPO_LINK} /OPT:REF /OPT:ICF /INCREMENTAL:NO")
+ 
+ 	# Same linker settings for DLL as EXE
+ 	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         cli-include-dirs.diff
         dependencies.diff
         mingw-winhttp.diff
+        no-static-whole-program-optimization.diff # don't /GL a static lib; it forces /LTCG on consumers
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/cmake/FindPCRE.cmake"

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libgit2",
   "version-semver": "1.9.4",
+  "port-version": 1,
   "description": "A C library implementing the Git core methods with a solid API",
   "homepage": "https://github.com/libgit2/libgit2",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5074,7 +5074,7 @@
     },
     "libgit2": {
       "baseline": "1.9.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libgme": {
       "baseline": "0.6.3",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8aab79e9e804ee68c12b5c456f7057b7621a6d5",
+      "version-semver": "1.9.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "ec1fe1faf133c35900f219d53c40e9eef8e16208",
       "version-semver": "1.9.4",
       "port-version": 0


### PR DESCRIPTION
Adds a patch so the **static** `git2.lib` is no longer compiled with `/GL`. A static archive performs no LTCG, so the `/GL` objects force `/LTCG` onto **every consumer's** link (the link restarts and emits `... restarting link with /LTCG ...`) and bloat the archive (≈82 MB → 5.4 MB here). The patch gates `/GL` (and the matching `/LTCG`) on `BUILD_SHARED_LIBS`.

Only `*-static` triplets are affected; the default dynamic build is unchanged.

### Upstream

The same fix is filed upstream and should land there, after which this patch can be dropped on a version bump:

- PR: https://github.com/libgit2/libgit2/pull/7295
- Issue: https://github.com/libgit2/libgit2/issues/7294

### Verification

`libgit2[core,pcre2]:x64-windows-static` (release), before vs after:

| | before | after |
|---|---|---|
| `git2.lib` | ≈82 MB | 5.4 MB |
| `/GL` (ANON) objects | 184 | 0 |
| consumer `restarting link with /LTCG` | yes | no |

- [x] `port-version` bumped (0 → 1); `versions/` updated via `x-add-version`.
- [x] Patch filed upstream (linked above).
