### PR TITLE
[pdal, pdal-dimbuilder] update to 2.10.2

### DIFF
--- a/ports/pdal-dimbuilder/disable-tests.patch
+++ b/ports/pdal-dimbuilder/disable-tests.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/macros.cmake b/cmake/macros.cmake
+index 4822ad4..dfd5517 100644
+--- a/cmake/macros.cmake
++++ b/cmake/macros.cmake
+@@ -193,9 +193,6 @@ endmacro(PDAL_ADD_PLUGIN)
+ #    INCLUDES header file directories
+ #
+ 
+-if(NOT TARGET GTest::gtest)
+-    include (${PDAL_CMAKE_DIR}/gtest.cmake)
+-endif()
+ 
+ macro(PDAL_ADD_TEST _name)
+ 

--- a/ports/pdal-dimbuilder/portfile.cmake
+++ b/ports/pdal-dimbuilder/portfile.cmake
@@ -9,10 +9,11 @@ vcpkg_from_github(
     #[[
         Attention: pdal must be updated together with pdal-dimbuilder
     #]]
-    SHA512 051e0a8ee2f03ad6eaf55b5843a41626ebc6d2517cf9eeedffda52878fbb9b7d854ea24174e2b3434f69ef41ab244e20e250f6c2c1083325b496489526fb8fea
+    SHA512 e581f36a1712a6df3e22ed5d40b69d5954e20af52b51a98889a0fbd942d8960a379bec45d9b5524ba29ba48e9722c926eb22b4754545088ada8766e85c106027
     HEAD_REF master
     PATCHES
         namespace-nl.diff
+        disable-tests.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/vendor")
 

--- a/ports/pdal-dimbuilder/vcpkg.json
+++ b/ports/pdal-dimbuilder/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pdal-dimbuilder",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "A tool used by the PDAL build process",
   "homepage": "https://pdal.org/",
   "license": "BSD-3-Clause",

--- a/ports/pdal/dependencies.diff
+++ b/ports/pdal/dependencies.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1ab7ea7..2219211 100644
+index 09eb3b0..95c1dbe 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -161,12 +161,9 @@ if (WITH_TESTS)
+@@ -163,12 +163,9 @@ if (WITH_TESTS)
  endif()
  add_subdirectory(dimbuilder)
  add_subdirectory(vendor/arbiter)
@@ -15,7 +15,7 @@ index 1ab7ea7..2219211 100644
  add_subdirectory(tools)
  add_subdirectory(apps)
  
-@@ -230,12 +227,13 @@ add_library(PDAL::PDAL ALIAS ${PDAL_LIB_NAME})
+@@ -232,12 +229,13 @@ add_library(PDAL::PDAL ALIAS ${PDAL_LIB_NAME})
  
  
  
@@ -31,7 +31,15 @@ index 1ab7ea7..2219211 100644
  target_include_directories(${PDAL_LIB_NAME}
      PRIVATE
          ${ROOT_DIR}
-@@ -270,6 +268,9 @@ target_link_libraries(${PDAL_LIB_NAME}
+@@ -264,6 +262,7 @@ target_link_libraries(${PDAL_LIB_NAME}
+         ${PDAL_LEPCC_LIB_NAME}
+         ${PDAL_LAZPERF_LIB_NAME}
+         ${BACKTRACE_LIBRARIES}
++        ${UTFCPP_LIB_NAME}
+        "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>"
+     PUBLIC
+         ${WINSOCK_LIBRARY}
+@@ -272,6 +271,9 @@ target_link_libraries(${PDAL_LIB_NAME}
          ${WINSOCK_LIBRARY}
  )
  
@@ -41,7 +49,7 @@ index 1ab7ea7..2219211 100644
  if (ZSTD_FOUND)
      target_link_libraries(${PDAL_LIB_NAME}
          PRIVATE
-@@ -304,9 +305,6 @@ target_include_directories(${PDAL_LIB_NAME}
+@@ -306,9 +308,6 @@ target_include_directories(${PDAL_LIB_NAME}
      INTERFACE
          $<INSTALL_INTERFACE:include>)
  
@@ -51,6 +59,7 @@ index 1ab7ea7..2219211 100644
  
  if(WIN32)
      target_compile_definitions(${PDAL_LIB_NAME}
+
 diff --git a/cmake/h3.cmake b/cmake/h3.cmake
 index 398ad6d..fb3c9ad 100644
 --- a/cmake/h3.cmake
@@ -76,7 +85,7 @@ index 1f9f996..aeb598c 100644
 +find_package(nlohmann_json_schema_validator CONFIG REQUIRED)
 +set(JSON_SCHEMA_LIB_NAME nlohmann_json_schema_validator::validator)
 diff --git a/cmake/utfcpp.cmake b/cmake/utfcpp.cmake
-index 6543ff6..dc6fac8 100644
+index 6543ff6..e7ab077 100644
 --- a/cmake/utfcpp.cmake
 +++ b/cmake/utfcpp.cmake
 @@ -1,6 +1,7 @@
@@ -84,9 +93,10 @@ index 6543ff6..dc6fac8 100644
  # UTF CPP
  #
 -set(UTFCPP_INCLUDE_DIR ${PDAL_VENDOR_DIR}/utfcpp/source)
+-set(UTFCPP_LIB_NAME utf8::cpp)
 +find_package(utf8cpp CONFIG REQUIRED)
-+set(UTFCPP_INCLUDE_DIR "")
- set(UTFCPP_LIB_NAME utf8::cpp)
++set(UTFCPP_INCLUDE_DIR "${utf8cpp_INCLUDE_DIRS}")
++set(UTFCPP_LIB_NAME utf8::cpp utf8cpp::utf8cpp)
  
 diff --git a/pdal/JsonFwd.hpp b/pdal/JsonFwd.hpp
 index 507c456..6b502d0 100644
@@ -187,7 +197,7 @@ index a328f34..bedb367 100644
          params.sorted = true;
  
 diff --git a/plugins/e57/CMakeLists.txt b/plugins/e57/CMakeLists.txt
-index a94ab26..1d15330 100644
+index 5358575..7ec9e05 100644
 --- a/plugins/e57/CMakeLists.txt
 +++ b/plugins/e57/CMakeLists.txt
 @@ -7,7 +7,7 @@ if (STANDALONE)

--- a/ports/pdal/find-library-suffix.diff
+++ b/ports/pdal/find-library-suffix.diff
@@ -1,10 +1,10 @@
 diff --git a/cmake/libraries.cmake b/cmake/libraries.cmake
-index 6847cf6..47e9748 100644
+index a2faed6..09bea7d 100644
 --- a/cmake/libraries.cmake
 +++ b/cmake/libraries.cmake
-@@ -2,7 +2,6 @@
- 
- set(PDAL_LIB_TYPE "SHARED")
+@@ -6,7 +6,6 @@ else ()
+   set(PDAL_LIB_TYPE "STATIC")
+ endif ()
  if (WIN32)
 -    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_IMPORT_LIBRARY_SUFFIX})
  endif()

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     #[[
         Attention: pdal-dimbuilder must be updated together with pdal
     #]]
-    SHA512 051e0a8ee2f03ad6eaf55b5843a41626ebc6d2517cf9eeedffda52878fbb9b7d854ea24174e2b3434f69ef41ab244e20e250f6c2c1083325b496489526fb8fea
+    SHA512 e581f36a1712a6df3e22ed5d40b69d5954e20af52b51a98889a0fbd942d8960a379bec45d9b5524ba29ba48e9722c926eb22b4754545088ada8766e85c106027
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pdal",
-  "version": "2.10.1",
-  "port-version": 1,
+  "version": "2.10.2",
   "description": "PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.",
   "homepage": "https://pdal.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7697,15 +7697,15 @@
       "port-version": 1
     },
     "pdal": {
-      "baseline": "2.10.1",
-      "port-version": 1
+      "baseline": "2.10.2",
+      "port-version": 0
     },
     "pdal-c": {
       "baseline": "2.2.0",
       "port-version": 0
     },
     "pdal-dimbuilder": {
-      "baseline": "2.10.1",
+      "baseline": "2.10.2",
       "port-version": 0
     },
     "pdcurses": {

--- a/versions/p-/pdal-dimbuilder.json
+++ b/versions/p-/pdal-dimbuilder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5d50e54742d3df148321249eaa00845aa71441f",
+      "version": "2.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "26e045a8b7862434133cd2458c084e11d9e3a489",
       "version": "2.10.1",
       "port-version": 0

--- a/versions/p-/pdal.json
+++ b/versions/p-/pdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f862a6f3e27b8d6a49578671b8e1ece632d8063a",
+      "version": "2.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "20de08b78885faf9ab1e155bff63a62a627df473",
       "version": "2.10.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/PDAL/PDAL/releases/tag/2.10.2
