### PR TITLE
[webrtc-audio-processing] Add new port v2.1

### DIFF
--- a/ports/webrtc-audio-processing/fix-abseil-nullability-compat.patch
+++ b/ports/webrtc-audio-processing/fix-abseil-nullability-compat.patch
@@ -1,0 +1,27 @@
+diff --git a/webrtc/api/scoped_refptr.h b/webrtc/api/scoped_refptr.h
+--- a/webrtc/api/scoped_refptr.h
++++ b/webrtc/api/scoped_refptr.h
+@@ -67,7 +67,22 @@
+ #include <utility>
+ 
+ #include "absl/base/nullability.h"
+-
++// abseil >= 20250814 removed the Nullable<T>/Nonnull<T> type aliases, replacing
++// them with absl_nullable/absl_nonnull macros. ABSL_POINTERS_DEFAULT_NONNULL is
++// defined only in the new-style headers. Re-add the aliases as identity templates
++// so the webrtc source compiles against either abseil generation. Remove this
++// patch once webrtc-audio-processing is updated to use the new macro forms.
++#ifdef ABSL_POINTERS_DEFAULT_NONNULL
++namespace absl {
++template <typename T>
++using Nullable = T;
++template <typename T>
++using Nonnull = T;
++template <typename T>
++using NullabilityUnknown = T;
++}  // namespace absl
++#endif
++
+ namespace webrtc {
+ 
+ template <class T>

--- a/ports/webrtc-audio-processing/fix-asm-windows-arm.patch
+++ b/ports/webrtc-audio-processing/fix-asm-windows-arm.patch
@@ -1,5 +1,5 @@
 diff --git a/webrtc/system_wrappers/source/denormal_disabler.cc b/webrtc/system_wrappers/source/denormal_disabler.cc
-index bb9c056..82e65ee 100644
+index bb9c056..dbd4a3b 100644
 --- a/webrtc/system_wrappers/source/denormal_disabler.cc
 +++ b/webrtc/system_wrappers/source/denormal_disabler.cc
 @@ -41,11 +41,12 @@ constexpr int kDenormalBitMask = 1 << 24;
@@ -18,3 +18,15 @@ index bb9c056..82e65ee 100644
    asm volatile("mrs %x[result], FPCR" : [result] "=r"(result));
  #endif
    return result;
+@@ -56,9 +57,9 @@ int ReadStatusWord() {
+ void SetStatusWord(int status_word) {
+ #if defined(WEBRTC_DENORMAL_DISABLER_X86_SUPPORTED)
+   asm volatile("ldmxcsr %0" : : "m"(status_word));
+-#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_32_BITS)
++#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_32_BITS) && (defined(__GNUC__) || defined(__clang__))
+   asm volatile("vmsr FPSCR, %[src]" : : [src] "r"(status_word));
+-#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_64_BITS)
++#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_64_BITS) && (defined(__GNUC__) || defined(__clang__))
+   asm volatile("msr FPCR, %x[src]" : : [src] "r"(status_word));
+ #endif
+ }

--- a/ports/webrtc-audio-processing/fix-asm-windows-arm.patch
+++ b/ports/webrtc-audio-processing/fix-asm-windows-arm.patch
@@ -1,0 +1,20 @@
+diff --git a/webrtc/system_wrappers/source/denormal_disabler.cc b/webrtc/system_wrappers/source/denormal_disabler.cc
+index bb9c056..82e65ee 100644
+--- a/webrtc/system_wrappers/source/denormal_disabler.cc
++++ b/webrtc/system_wrappers/source/denormal_disabler.cc
+@@ -41,11 +41,12 @@ constexpr int kDenormalBitMask = 1 << 24;
+ // architectures and compilers. Otherwise returns `kUnspecifiedStatusWord`.
+ int ReadStatusWord() {
+   int result = kUnspecifiedStatusWord;
+-#if defined(WEBRTC_DENORMAL_DISABLER_X86_SUPPORTED)
++  #if defined(WEBRTC_DENORMAL_DISABLER_X86_SUPPORTED)
+   asm volatile("stmxcsr %0" : "=m"(result));
+-#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_32_BITS)
++// Vcpkg uses MSVC on Windows, which doesn't support asm; manually disable it on Windows builds to match x86 behavior.
++#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_32_BITS) && (defined(__GNUC__) || defined(__clang__))
+   asm volatile("vmrs %[result], FPSCR" : [result] "=r"(result));
+-#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_64_BITS)
++#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_64_BITS) && (defined(__GNUC__) || defined(__clang__))
+   asm volatile("mrs %x[result], FPCR" : [result] "=r"(result));
+ #endif
+   return result;

--- a/ports/webrtc-audio-processing/fix-asm-windows-arm.patch
+++ b/ports/webrtc-audio-processing/fix-asm-windows-arm.patch
@@ -1,13 +1,10 @@
 diff --git a/webrtc/system_wrappers/source/denormal_disabler.cc b/webrtc/system_wrappers/source/denormal_disabler.cc
-index bb9c056..dbd4a3b 100644
+index bb9c056..dd22439 100644
 --- a/webrtc/system_wrappers/source/denormal_disabler.cc
 +++ b/webrtc/system_wrappers/source/denormal_disabler.cc
-@@ -41,11 +41,12 @@ constexpr int kDenormalBitMask = 1 << 24;
- // architectures and compilers. Otherwise returns `kUnspecifiedStatusWord`.
- int ReadStatusWord() {
+@@ -43,9 +43,10 @@ int ReadStatusWord() {
    int result = kUnspecifiedStatusWord;
--#if defined(WEBRTC_DENORMAL_DISABLER_X86_SUPPORTED)
-+  #if defined(WEBRTC_DENORMAL_DISABLER_X86_SUPPORTED)
+ #if defined(WEBRTC_DENORMAL_DISABLER_X86_SUPPORTED)
    asm volatile("stmxcsr %0" : "=m"(result));
 -#elif defined(WEBRTC_ARCH_ARM_FAMILY) && defined(WEBRTC_ARCH_32_BITS)
 +// Vcpkg uses MSVC on Windows, which doesn't support asm; manually disable it on Windows builds to match x86 behavior.

--- a/ports/webrtc-audio-processing/fix-gcc15-missing-cstdint.patch
+++ b/ports/webrtc-audio-processing/fix-gcc15-missing-cstdint.patch
@@ -1,0 +1,24 @@
+diff --git a/webrtc/modules/audio_processing/aec3/multi_channel_content_detector.h b/webrtc/modules/audio_processing/aec3/multi_channel_content_detector.h
+index 2b2f3b8..feb29fd 100644
+--- a/webrtc/modules/audio_processing/aec3/multi_channel_content_detector.h
++++ b/webrtc/modules/audio_processing/aec3/multi_channel_content_detector.h
+@@ -12,6 +12,7 @@
+ #define MODULES_AUDIO_PROCESSING_AEC3_MULTI_CHANNEL_CONTENT_DETECTOR_H_
+ 
+ #include <stddef.h>
++#include <cstdint>
+ 
+ #include <memory>
+ #include <optional>
+diff --git a/webrtc/rtc_base/trace_event.h b/webrtc/rtc_base/trace_event.h
+index 2aee713..f88a68e 100644
+--- a/webrtc/rtc_base/trace_event.h
++++ b/webrtc/rtc_base/trace_event.h
+@@ -28,6 +28,7 @@
+ 
+ #if !defined(RTC_USE_PERFETTO)
+ #include <string>
++#include <cstdint>
+ 
+ #include "rtc_base/event_tracer.h"
+ 

--- a/ports/webrtc-audio-processing/portfile.cmake
+++ b/ports/webrtc-audio-processing/portfile.cmake
@@ -4,8 +4,9 @@ vcpkg_from_gitlab(
     REPO "pulseaudio/webrtc-audio-processing"
     REF "v2.1"
     SHA512 6851bf40b62a8f642eaa5e3e108a8331f43c0d6eb5e6d351e3252d6869066c991bd9eca6ba3a7f762bdb44251a253da05cf15a76fc1c55ca815f5a4e39cf5d4a
+    PATCHES
+        fix-abseil-nullability-compat.patch
 )
-# TODO: patches
 
 set(MESON_OPTIONS "")
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/webrtc-audio-processing/portfile.cmake
+++ b/ports/webrtc-audio-processing/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "pulseaudio/webrtc-audio-processing"
+    REF "v2.1"
+    SHA512 6851bf40b62a8f642eaa5e3e108a8331f43c0d6eb5e6d351e3252d6869066c991bd9eca6ba3a7f762bdb44251a253da05cf15a76fc1c55ca815f5a4e39cf5d4a
+)
+# TODO: patches
+
+set(MESON_OPTIONS "")
+if(VCPKG_TARGET_IS_WINDOWS)
+    # Designated initializers in the WebRTC source require C++20 on MSVC
+    list(APPEND MESON_OPTIONS "-Dcpp_std=vc++20")
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${MESON_OPTIONS}
+)
+
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Remove bin dirs for static builds or non-Windows (no DLL)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/webrtc-audio-processing/portfile.cmake
+++ b/ports/webrtc-audio-processing/portfile.cmake
@@ -5,7 +5,16 @@ vcpkg_from_gitlab(
     REF "v2.1"
     SHA512 6851bf40b62a8f642eaa5e3e108a8331f43c0d6eb5e6d351e3252d6869066c991bd9eca6ba3a7f762bdb44251a253da05cf15a76fc1c55ca815f5a4e39cf5d4a
     PATCHES
+        # Fixed in master, not yet shipped: https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/commit/c8896801dfbfe03b56f85c1533abc077ff74a533
         fix-abseil-nullability-compat.patch
+
+        # Fixed in master, not yet shipped: https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/commit/e9c78dc4712fa6362b0c839ad57b6b46dce1ba83
+        fix-gcc15-missing-cstdint.patch
+
+        # WebRTC typically builds with clang, but VCPKG typically builds with
+        # MSVC on Windows. Avoid some clang-specific assembly code in that
+        # scenario, with the same fallback used for x86.
+        fix-asm-windows-arm.patch
 )
 
 set(MESON_OPTIONS "")

--- a/ports/webrtc-audio-processing/usage
+++ b/ports/webrtc-audio-processing/usage
@@ -1,0 +1,5 @@
+webrtc-audio-processing provides pkg-config integration (no CMake config package):
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(WEBRTC_APM REQUIRED IMPORTED_TARGET webrtc-audio-processing-2)
+    target_link_libraries(main PRIVATE PkgConfig::WEBRTC_APM)

--- a/ports/webrtc-audio-processing/vcpkg.json
+++ b/ports/webrtc-audio-processing/vcpkg.json
@@ -1,0 +1,16 @@
+
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "name": "webrtc-audio-processing",
+    "version": "2.1",
+    "description": "Extracted AudioProcessing module from WebRTC for easy reuse",
+    "homepage": "https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/",
+    "license": "BSD-3-Clause",
+    "dependencies": [
+        "abseil",
+        {
+            "name": "vcpkg-tool-meson",
+            "host": true
+        }
+    ]
+}

--- a/ports/webrtc-audio-processing/vcpkg.json
+++ b/ports/webrtc-audio-processing/vcpkg.json
@@ -5,7 +5,7 @@
     "version": "2.1",
     "description": "Extracted AudioProcessing module from WebRTC for easy reuse",
     "homepage": "https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/",
-    "license": "BSD-3-Clause",
+    "license": "BSD-3-Clause AND Apache-2.0",
     "dependencies": [
         "abseil",
         {

--- a/ports/webrtc-audio-processing/vcpkg.json
+++ b/ports/webrtc-audio-processing/vcpkg.json
@@ -1,16 +1,15 @@
-
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-    "name": "webrtc-audio-processing",
-    "version": "2.1",
-    "description": "Extracted AudioProcessing module from WebRTC for easy reuse",
-    "homepage": "https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/",
-    "license": "BSD-3-Clause AND Apache-2.0",
-    "dependencies": [
-        "abseil",
-        {
-            "name": "vcpkg-tool-meson",
-            "host": true
-        }
-    ]
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "webrtc-audio-processing",
+  "version": "2.1",
+  "description": "Extracted AudioProcessing module from WebRTC for easy reuse",
+  "homepage": "https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/",
+  "license": "BSD-3-Clause AND Apache-2.0",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10860,6 +10860,10 @@
       "baseline": "2026-03-17",
       "port-version": 1
     },
+    "webrtc-audio-processing": {
+      "baseline": "2.1",
+      "port-version": 0
+    },
     "webthing-cpp": {
       "baseline": "1.2.0",
       "port-version": 0

--- a/versions/w-/webrtc-audio-processing.json
+++ b/versions/w-/webrtc-audio-processing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2c826a6c7ce50df7cb4af8de267e1add7b3348b6",
+      "git-tree": "435630a78fa2c73e466599348ee6a9258cf6848d",
       "version": "2.1",
       "port-version": 0
     }

--- a/versions/w-/webrtc-audio-processing.json
+++ b/versions/w-/webrtc-audio-processing.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2c826a6c7ce50df7cb4af8de267e1add7b3348b6",
+      "version": "2.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This port adds [`webrtc-audio-processing`](https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/) ([repology](https://repology.org/project/webrtc-audio-processing/versions)), a easier-to-package subset of WebRTC for audio processing (AudioProcessing). The `webrtc` package is already present in vcpkg, but `webrtc-audio-processing` is a well-maintained, much-faster-building subset used in several places.

Worth noting:

* The small abseil compatibility patch is designed to gracefully handle the more-recent versions of Abseil present in vcpkg. As of Aug 2025, upstream [has a compat fix](https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/commit/c8896801dfbfe03b56f85c1533abc077ff74a533), but that has not been deployed in an official release yet. The patch should be removable when they cut a new release.
* I wrote all of this PR writeup & most of this patch myself, following the guidance on MSDN; Claude assisted me in this & in generating the patch. Thank you for your time reviewing it.

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] ~~The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form~~.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

## Also tested

* [x] Builds in simple test repo: [citelao/webrtc-audio-processing-test](https://github.com/citelao/webrtc-audio-processing-test)
* [x] Builds in Mumble app when testing (no source link yet).
