### PR TITLE
[bbstrader] Update to 2.1.0

### DIFF
--- a/ports/bbstrader/portfile.cmake
+++ b/ports/bbstrader/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bbalouki/bbstrader
     REF "v${VERSION}"
-    SHA512 fca8d2f667ec5d7e1ce527a8e397a6d5a53a83c988c5310e2f03b320f80aea303cb01028a3c1a7a2f6396ee2cd6aa9c7819a21c67c13ea5647de93e76cbb68e0
+    SHA512 3581bae8c1b7eea3fc53ffa0f1da6ef07a05437c15b102eaecb238c63eec20ec7baa776932dc86888f301624f844a1bae62750cdd39911a9aeead46fb886706e
     HEAD_REF main
 )
 

--- a/ports/bbstrader/vcpkg.json
+++ b/ports/bbstrader/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bbstrader",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "High-performance MetaTrader 5 C++/Python Bridge",
   "homepage": "https://github.com/bbalouki/bbstrader",
   "license": "MIT",

--- a/versions/b-/bbstrader.json
+++ b/versions/b-/bbstrader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1df18faa132e70a44db8d83191f9639e0bdcef5d",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "486769d11a898c0e98339a8bf37f6a897c980b16",
       "version": "2.0.8",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -653,7 +653,7 @@
       "port-version": 0
     },
     "bbstrader": {
-      "baseline": "2.0.8",
+      "baseline": "2.1.0",
       "port-version": 0
     },
     "bcg729": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.1.0
