### PR TITLE
[safetyhook] update to 0.7.0

### DIFF
--- a/ports/safetyhook/portfile.cmake
+++ b/ports/safetyhook/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cursey/safetyhook
     REF "v${VERSION}"
-    SHA512 6b62bbd3cfa8e603bddf19d31f4d58fe8eb6df41f31c8213fc1370d23e83d0fea0b482f0d512ba7143e529f4a60c57247c4902d59612ff06c036cb1b044ad2a4
+    SHA512 863aad37f9236f151be6a2e6f29d962cd2d356c6ff80a1e9e5a4f6d6a22c1dddbd52462ce48203ae67ae124f7d71eb60f6e2829c8eba417bb6b5569aab5683f2
     HEAD_REF main
 )
 

--- a/ports/safetyhook/vcpkg.json
+++ b/ports/safetyhook/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "safetyhook",
-  "version-semver": "0.6.10",
+  "version-semver": "0.7.0",
   "description": "C++23 procedure hooking library.",
   "homepage": "https://github.com/cursey/safetyhook",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9005,7 +9005,7 @@
       "port-version": 0
     },
     "safetyhook": {
-      "baseline": "0.6.10",
+      "baseline": "0.7.0",
       "port-version": 0
     },
     "sail": {

--- a/versions/s-/safetyhook.json
+++ b/versions/s-/safetyhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a17e96912661f65ecc4ffa64293521b90d9b06a",
+      "version-semver": "0.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c101f52a8862a2d50533e7bc060ac554aff88a36",
       "version-semver": "0.6.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.