### PR TITLE
[qe6502] Add new port

### DIFF
--- a/ports/qe6502/portfile.cmake
+++ b/ports/qe6502/portfile.cmake
@@ -32,6 +32,20 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string(
+        "${CURRENT_PACKAGES_DIR}/include/qe6502/qe6502_version.h"
+        "#endif /* QE6502_VERSION_H */"
+        "#ifndef QE6502_SHARED\n#   define QE6502_SHARED 1\n#endif\n\n#ifndef QE6502_CPP_SHARED\n#   define QE6502_CPP_SHARED 1\n#endif\n\n#endif /* QE6502_VERSION_H */"
+    )
+else()
+    vcpkg_replace_string(
+        "${CURRENT_PACKAGES_DIR}/include/qe6502/qe6502_version.h"
+        "#endif /* QE6502_VERSION_H */"
+        "#ifndef QE6502_STATIC\n#   define QE6502_STATIC 1\n#endif\n\n#endif /* QE6502_VERSION_H */"
+    )
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/qe6502/portfile.cmake
+++ b/ports/qe6502/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nnqe/qe6502
+    REF v1.0.0
+    SHA512 035dd6c9ff345f112eb086593d145f7ff45785f6bb18f6f2f053eb9e3f869f37c212d3a118e24aa374daa72d8eba89d67f0ffc4f98c3e74af839ee51c3a1057c
+    HEAD_REF main
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(QE6502_BUILD_STATIC OFF)
+    set(QE6502_BUILD_SHARED ON)
+else()
+    set(QE6502_BUILD_STATIC ON)
+    set(QE6502_BUILD_SHARED OFF)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DQE6502_BUILD_STATIC=${QE6502_BUILD_STATIC}
+        -DQE6502_BUILD_SHARED=${QE6502_BUILD_SHARED}
+        -DQE6502_BUILD_CPP=ON
+        -DQE6502_BUILD_TESTS=OFF
+        -DQE6502_BUILD_TOOLS=OFF
+        -DQE6502_BUILD_CSHARP=OFF
+        -DQE6502_BUILD_RUST=OFF
+        -DQE6502_BUILD_JAVA=OFF
+        -DQE6502_BUILD_PYTHON=OFF
+        -DQE6502_BUILD_WASM=OFF
+        -DQE6502_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME qe6502
+    CONFIG_PATH lib/cmake/qe6502
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qe6502/vcpkg.json
+++ b/ports/qe6502/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "qe6502",
+  "version": "1.0.0",
+  "description": "Cycle-oriented MOS 6502/65C02 CPU emulation core with C and C++ APIs",
+  "homepage": "https://github.com/nnqe/qe6502",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8132,6 +8132,10 @@
       "baseline": "0.1.9",
       "port-version": 1
     },
+    "qe6502": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "qgis-o2": {
       "baseline": "1.1",
       "port-version": 0

--- a/versions/q-/qe6502.json
+++ b/versions/q-/qe6502.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ebdcabf82f27c66cfef04387993e2104744685c",
+      "git-tree": "b6daba1839eee882c4c37536f2c88044873a0b05",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/q-/qe6502.json
+++ b/versions/q-/qe6502.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7ebdcabf82f27c66cfef04387993e2104744685c",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds qe6502 as a new port.

qe6502 is a cycle-oriented MOS 6502/65C02 CPU emulation core. It provides a fast native C API, a stable shared C ABI, and C++ bindings. The upstream project also includes optional bindings and harnesses for C#, Rust, Java, Python, and WebAssembly; this vcpkg port packages the native C/C++ library components.

Local testing:
- `./vcpkg install qe6502`
- `./vcpkg install qe6502 --triplet x64-linux-dynamic`