### PR TITLE
[kineto, rocksdb, sleef] CI Fixes 2026-06-15

### DIFF
--- a/ports/kineto/portfile.cmake
+++ b/ports/kineto/portfile.cmake
@@ -12,6 +12,11 @@ vcpkg_from_github(
 file(INSTALL "${SOURCE_PATH}/libkineto/include/"
      DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
+# Avoid taking extremely common name "Config.h" which breaks many projects that assume it is their
+# internal config.h header.
+file(RENAME "${CURRENT_PACKAGES_DIR}/include/Config.h" "${CURRENT_PACKAGES_DIR}/include/KinetoConfig.h")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/IActivityProfiler.h" "#include \"Config.h\"" "#include \"KinetoConfig.h\"")
+
 # Provide cmake config
 configure_file(
     "${CMAKE_CURRENT_LIST_DIR}/unofficial-kineto-config.cmake.in"

--- a/ports/kineto/vcpkg.json
+++ b/ports/kineto/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kineto",
   "version-date": "2026-04-10",
+  "port-version": 1,
   "description": "Kineto: PyTorch profiler library (headers)",
   "homepage": "https://github.com/pytorch/kineto",
   "license": "BSD-3-Clause",

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -26,6 +26,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     "tbb" WITH_TBB
 )
 
+if(WITH_LIBURING)
+  vcpkg_find_acquire_program(PKGCONFIG)
+  vcpkg_list(APPEND FEATURE_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rocksdb",
   "version": "11.1.1",
+  "port-version": 1,
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1081,7 +1081,6 @@ simd:arm-neon-android=fail
 simd:arm64-android=fail
 simd:arm64-linux=fail
 simd:x64-android=fail
-sleef:arm64-linux=fail
 sleepy-discord:arm-neon-android=fail # std::string issue, https://github.com/microsoft/vcpkg/pull/41293#issuecomment-2942853561
 sleepy-discord:arm64-android=fail
 sleepy-discord:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4542,7 +4542,7 @@
     },
     "kineto": {
       "baseline": "2026-04-10",
-      "port-version": 0
+      "port-version": 1
     },
     "kissfft": {
       "baseline": "131.2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8894,7 +8894,7 @@
     },
     "rocksdb": {
       "baseline": "11.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "rp-ntuples": {
       "baseline": "0.1.4",

--- a/versions/k-/kineto.json
+++ b/versions/k-/kineto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3b00a1f695b1dbcfe59a508a329e28b09c47600",
+      "version-date": "2026-04-10",
+      "port-version": 1
+    },
+    {
       "git-tree": "08baafb63c6518047e9bf66b05be344c7f844797",
       "version-date": "2026-04-10",
       "port-version": 0

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4163c835824288a256d114ab8d31853ebb8d565",
+      "version": "11.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "7d8882f78c6ee377cd1b85fee786d9795493d01e",
       "version": "11.1.1",
       "port-version": 0


### PR DESCRIPTION
1. https://github.com/microsoft/vcpkg/pull/52108 took "include/Config.h" which broke downstream things on Windows like librsync, libgta.
2. rocksdb wants pkgconfig on Linux and accidentally tried to use the arm64 copy if pkgconf installed first.
3. PASSING, REMOVE FROM FAIL LIST: sleef:arm64-linux

Fixes regressions reported in https://dev.azure.com/vcpkg/public/_build/results?buildId=133175