### PR TITLE
[msolve] Update to 0.10.0

### DIFF
--- a/ports/msolve/fix-android.patch
+++ b/ports/msolve/fix-android.patch
@@ -1,16 +1,33 @@
-diff --git a/configure.ac b/configure.ac
---- a/configure.ac
-+++ b/configure.ac
-@@ -73,11 +73,9 @@
- AX_GCC_BUILTIN([__builtin_clzll])
- AX_GCC_BUILTIN([__builtin_clzl])
+diff --git a/src/neogb/tools.c b/src/neogb/tools.c
+index 1c85fe6..28b6ebd 100644
+--- a/src/neogb/tools.c
++++ b/src/neogb/tools.c
+@@ -20,6 +20,10 @@
  
- # Checks for library functions.
--AC_FUNC_MALLOC
--AC_FUNC_REALLOC
--AC_CHECK_FUNCS([floor getdelim gettimeofday memmove memset pow sqrt strchr strstr strtol])
-+AC_CHECK_FUNCS([floor getdelim gettimeofday memmove memset malloc realloc pow sqrt strchr strstr strtol])
+ #include "tools.h"
  
- AC_CONFIG_HEADERS([config.h])
- AC_CONFIG_FILES([
-  Makefile
++#if defined(__ANDROID__) && __ANDROID_API__ < 29
++#include <sys/time.h>
++#endif
++
+ /* cpu time */
+ double cputime(void)
+ {
+@@ -32,10 +36,17 @@ double cputime(void)
+ /* wall time */
+ double realtime(void)
+ {
++#if defined(__ANDROID__) && __ANDROID_API__ < 29
++	struct timeval t;
++	gettimeofday(&t, NULL);
++	t.tv_sec -= (2017 - 1970)*3600*24*365;
++	return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
++#else
+ 	struct timespec t;
+ 	timespec_get(&t, TIME_UTC);
+ 	t.tv_sec -= (2017 - 1970)*3600*24*365;
+ 	return (1. + (double)t.tv_nsec + ((double)t.tv_sec*1000000000.)) / 1000000000.;
++#endif
+ }
+ 
+ static void construct_trace(

--- a/ports/msolve/portfile.cmake
+++ b/ports/msolve/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO algebraic-solving/msolve
     REF "v${VERSION}"
-    SHA512 e45fda8b8d7bcb4e443b5268875ddd5a9a88a65bf04b563d66b512500dec6508ad27c4ebfcba8a73868d20e92213d49dc8ac54cf3f00a326a3328901eb15c9b7
+    SHA512 d51e63aa411a6d532812b725d39d546b58e0198aaf5e5ccf7796d616438edd280c340db735c5330bbc8aa2acdfe354f34c64ac7663f1c0014cf1f483e09aab35
     HEAD_REF master
     PATCHES
         fix-android.patch

--- a/ports/msolve/vcpkg.json
+++ b/ports/msolve/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "msolve",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Computer algebra algorithms for solving polynomial systems",
   "homepage": "https://msolve.lip6.fr/",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6801,7 +6801,7 @@
       "port-version": 0
     },
     "msolve": {
-      "baseline": "0.9.5",
+      "baseline": "0.10.0",
       "port-version": 0
     },
     "msquic": {

--- a/versions/m-/msolve.json
+++ b/versions/m-/msolve.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "079047c399f9979e83180e9765c799a9ddde5a55",
+      "version": "0.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ebcfe14e8a393c88b09451589134652c00a6f731",
       "version": "0.9.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.10.0
