### PR TITLE
[simpleini] Update to 4.26

### DIFF
--- a/ports/ecal/0001-disable-app-plugins.patch
+++ b/ports/ecal/0001-disable-app-plugins.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4f2fc25d2..e82e353e0 100644
+index 4f2fc25d2..b256fe571 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -357,8 +357,10 @@ endif()

--- a/ports/ecal/0002-fix-build.patch
+++ b/ports/ecal/0002-fix-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e82e353e0..19d8f2a93 100644
+index b256fe571..8c4b8d526 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -26,7 +26,8 @@ endif (POLICY CMP0077)
@@ -77,38 +77,36 @@ index 04f1a1b9a..58df32705 100644
  target_include_directories(${PROJECT_NAME} PUBLIC 
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 diff --git a/ecal/core/CMakeLists.txt b/ecal/core/CMakeLists.txt
-index f18dd6291..8655d134a 100644
+index f18dd6291..58289c09b 100644
 --- a/ecal/core/CMakeLists.txt
 +++ b/ecal/core/CMakeLists.txt
-@@ -20,8 +20,6 @@ project(core VERSION ${eCAL_VERSION_STRING})
+@@ -20,8 +20,7 @@ project(core VERSION ${eCAL_VERSION_STRING})
  
  find_package(Threads      REQUIRED)
  find_package(asio         REQUIRED)
 -find_package(tclap        REQUIRED)
 -find_package(simpleini    REQUIRED)
++find_package(SimpleIni CONFIG REQUIRED)
  find_package(tcp_pubsub   REQUIRED)
  if (ECAL_NPCAP_SUPPORT)
    find_package(udpcap REQUIRED)
-@@ -549,8 +547,6 @@ target_link_libraries(${PROJECT_NAME}
+@@ -549,8 +548,7 @@ target_link_libraries(${PROJECT_NAME}
      $<$<BOOL:${WIN32}>:wsock32>
      $<$<BOOL:${QNXNTO}>:socket>
      asio::asio
 -    tclap::tclap
 -    simpleini::simpleini
++    SimpleIni::SimpleIni
      eCAL::core_pb
      Threads::Threads
      eCAL::ecal-utils
-@@ -558,6 +554,14 @@ target_link_libraries(${PROJECT_NAME}
+@@ -558,6 +556,10 @@ target_link_libraries(${PROJECT_NAME}
      ecal_service
  )
  
 +# tclap is header only and only used for implementation
 +find_path(TCLAP_INCLUDE_DIRS "tclap/Arg.h")
 +target_include_directories(${PROJECT_NAME}  PRIVATE ${TCLAP_INCLUDE_DIRS})
-+
-+# simpleini is header only and only used for implementation
-+find_path(SIMPLEINI_INCLUDE_DIRS "ConvertUTF.c")
-+target_include_directories(${PROJECT_NAME} PRIVATE ${SIMPLEINI_INCLUDE_DIRS})
 +
  set_property(TARGET ${PROJECT_NAME}   PROPERTY FOLDER ecal/core)
  set_property(TARGET ${PROJECT_NAME}_c PROPERTY FOLDER ecal/core)

--- a/ports/ecal/0003-fix-dependencies.patch
+++ b/ports/ecal/0003-fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/contrib/ecalhdf5/CMakeLists.txt b/contrib/ecalhdf5/CMakeLists.txt
-index c167bacd4..45e754340 100644
+index 3b7eb705a..1c7f4598c 100644
 --- a/contrib/ecalhdf5/CMakeLists.txt
 +++ b/contrib/ecalhdf5/CMakeLists.txt
 @@ -18,9 +18,14 @@

--- a/ports/ecal/0004-install-cmake-files-to-share.patch
+++ b/ports/ecal/0004-install-cmake-files-to-share.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 19d8f2a93..dca8948be 100644
+index 8c4b8d526..255113836 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -277,7 +277,7 @@ set(eCAL_install_app_dir           ${CMAKE_INSTALL_BINDIR})
@@ -12,10 +12,10 @@ index 19d8f2a93..dca8948be 100644
  set(eCAL_install_doc_dir           ${CMAKE_INSTALL_DOCDIR})
  set(eCAL_install_include_dir       ${CMAKE_INSTALL_INCLUDEDIR})
 diff --git a/thirdparty/cmakefunctions/cmake_functions/CMakeLists.txt b/thirdparty/cmakefunctions/cmake_functions/CMakeLists.txt
-index 6ed0d1a14..9a833a1f9 100644
+index 6ed0d1a14..8392f6043 100644
 --- a/thirdparty/cmakefunctions/cmake_functions/CMakeLists.txt
 +++ b/thirdparty/cmakefunctions/cmake_functions/CMakeLists.txt
-@@ -4,12 +4,8 @@ include(cmake_functions.cmake)
+@@ -4,12 +4,7 @@ include(cmake_functions.cmake)
  
  project(CMakeFunctions VERSION 0.4.1)
  
@@ -25,8 +25,7 @@ index 6ed0d1a14..9a833a1f9 100644
 -else (MSVC)
 -set(cmake_functions_install_cmake_dir   lib/cmake/${PROJECT_NAME}-${PROJECT_VERSION})
 -endif (MSVC)
-+set(cmake_functions_install_cmake_dir "share/${PROJECT_NAME}")
-+
++set(cmake_functions_install_cmake_dir   "share/${PROJECT_NAME}")
  set(cmake_functions_config              ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake)
  set(cmake_functions_config_version      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake)
  

--- a/ports/ecal/0006-use-find_dependency-in-cmake-config.patch
+++ b/ports/ecal/0006-use-find_dependency-in-cmake-config.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/eCALConfig.cmake.in b/cmake/eCALConfig.cmake.in
-index 704da4de8..e8cfb765c 100644
+index 704da4de8..08fd3c766 100644
 --- a/cmake/eCALConfig.cmake.in
 +++ b/cmake/eCALConfig.cmake.in
-@@ -25,12 +25,21 @@ set(eCAL_VERSION_MAJOR  @eCAL_VERSION_MAJOR@)
+@@ -25,12 +25,22 @@ set(eCAL_VERSION_MAJOR  @eCAL_VERSION_MAJOR@)
  set(eCAL_VERSION_MINOR  @eCAL_VERSION_MINOR@)
  set(eCAL_VERSION_PATCH  @eCAL_VERSION_PATCH@)
  set(eCAL_VERSION_STRING @eCAL_VERSION_STRING@)
@@ -15,6 +15,7 @@ index 704da4de8..e8cfb765c 100644
 -find_package(Protobuf REQUIRED)
 +include(CMakeFindDependencyMacro)
 +find_dependency(Protobuf CONFIG)
++find_dependency(SimpleIni CONFIG)
 +
 +# Ensure transitive dependencies are present for static builds
 +if(NOT eCAL_IS_SHARED)
@@ -25,7 +26,7 @@ index 704da4de8..e8cfb765c 100644
  
  include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_add_functions.cmake")
  include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_helper_functions.cmake")
-@@ -44,6 +53,6 @@ include("@PACKAGE_eCAL_install_cmake_dir@/eCALTargets.cmake")
+@@ -44,6 +54,6 @@ include("@PACKAGE_eCAL_install_cmake_dir@/eCALTargets.cmake")
  #  list(APPEND CMAKE_PREFIX_PATH "${PACKAGE_PREFIX_DIR}/../../../../cmake")
  #endif()
  

--- a/ports/ecal/0007-allow-static-build-of-core.patch
+++ b/ports/ecal/0007-allow-static-build-of-core.patch
@@ -1,8 +1,8 @@
 diff --git a/ecal/core/CMakeLists.txt b/ecal/core/CMakeLists.txt
-index 8655d134a..03d0f7c81 100644
+index 58289c09b..2d22fdc48 100644
 --- a/ecal/core/CMakeLists.txt
 +++ b/ecal/core/CMakeLists.txt
-@@ -449,7 +449,7 @@ set(ecal_header_public
+@@ -450,7 +450,7 @@ set(ecal_header_public
      ${ecal_header_msg}
  )
  
@@ -11,7 +11,7 @@ index 8655d134a..03d0f7c81 100644
      ${ecal_config_src}
      ${ecal_io_mtx_src}
      ${ecal_io_mtx_linux_src}
-@@ -483,7 +483,7 @@ if(UNIX)
+@@ -484,7 +484,7 @@ if(UNIX)
    set_source_files_properties(src/util/convert_utf.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
  endif()
  
@@ -20,7 +20,7 @@ index 8655d134a..03d0f7c81 100644
  
  add_library(eCAL::${PROJECT_NAME}   ALIAS ${PROJECT_NAME})
  add_library(eCAL::${PROJECT_NAME}_c ALIAS ${PROJECT_NAME}_c)
-@@ -514,6 +514,11 @@ target_compile_definitions(${PROJECT_NAME}
+@@ -515,6 +515,11 @@ target_compile_definitions(${PROJECT_NAME}
      ECALC_NO_DEPRECATION_WARNINGS
  )
  
@@ -32,7 +32,7 @@ index 8655d134a..03d0f7c81 100644
  if(ECAL_NPCAP_SUPPORT)
    target_compile_definitions(${PROJECT_NAME}
      PRIVATE ECAL_NPCAP_SUPPORT)
-@@ -565,8 +570,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${SIMPLEINI_INCLUDE_DIRS})
+@@ -563,8 +568,8 @@ target_include_directories(${PROJECT_NAME}  PRIVATE ${TCLAP_INCLUDE_DIRS})
  set_property(TARGET ${PROJECT_NAME}   PROPERTY FOLDER ecal/core)
  set_property(TARGET ${PROJECT_NAME}_c PROPERTY FOLDER ecal/core)
  
@@ -44,7 +44,7 @@ index 8655d134a..03d0f7c81 100644
  install(DIRECTORY
     "include/" DESTINATION "${INSTALL_INCLUDE_DIR}" COMPONENT sdk
 diff --git a/ecal/core/include/ecal/ecal_os.h b/ecal/core/include/ecal/ecal_os.h
-index 2b051d893..f24cdc325 100644
+index 2b051d893..2d74a098f 100644
 --- a/ecal/core/include/ecal/ecal_os.h
 +++ b/ecal/core/include/ecal/ecal_os.h
 @@ -47,7 +47,7 @@
@@ -67,11 +67,8 @@ index 2b051d893..f24cdc325 100644
        #define ECALC_API_DEPRECATED __declspec(dllimport deprecated)
      #endif /* eCAL_EXPORTS */
 +    #else
-+      #define ECALC_API_DEPRECATED  
++      #define ECALC_API_DEPRECATED
 +    #endif
    #elif defined(__GNUC__) || defined(__clang__)
      #define ECALC_API_DEPRECATED __attribute__((deprecated))
    #else
--- 
-2.45.0.windows.1
-

--- a/ports/ecal/vcpkg.json
+++ b/ports/ecal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ecal",
   "version-semver": "5.13.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "eCAL - enhanced Communication Abstraction Layer",
   "homepage": "https://eclipse-ecal.github.io/ecal/",
   "license": "Apache-2.0",

--- a/ports/simpleini/disable-tests.patch
+++ b/ports/simpleini/disable-tests.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df52d29..fd3044f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,10 +57,3 @@ install(FILES
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+ )
+ 
+-# only build tests when top level
+-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+-	include(CTest)
+-	if(BUILD_TESTING)
+-		add_subdirectory(tests)
+-	endif()
+-endif()

--- a/ports/simpleini/portfile.cmake
+++ b/ports/simpleini/portfile.cmake
@@ -1,19 +1,20 @@
-# header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brofield/simpleini
     REF "v${VERSION}"
-    SHA512 b937c18a7b6277d77ca7ebfb216af4984810f77af4c32d101b7685369a4bd5eb61406223f82698e167e6311a728d07415ab59639fdf19eff71ad6dc2abfda989
+    SHA512 a62c5748efe2473aae5bddab96ba9114d981a72f5b0d1a44d563daa085d5c231ed8c447794691d9bd67e1e0c6bfb44e4a8736be75fee59967d0c67ce3a59bb6e
     HEAD_REF master
+    PATCHES
+        disable-tests.patch
 )
 
-# Install codes
-set(SIMPLEINI_SOURCE ${SOURCE_PATH}/SimpleIni.h
-                     ${SOURCE_PATH}/ConvertUTF.h
-                     ${SOURCE_PATH}/ConvertUTF.c
-)
+set(VCPKG_BUILD_TYPE release) # header-only port
 
-file(INSTALL ${SIMPLEINI_SOURCE} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SimpleIni PACKAGE_NAME SimpleIni)
 
-# copyright
-file(INSTALL "${SOURCE_PATH}/LICENCE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENCE.txt")

--- a/ports/simpleini/vcpkg.json
+++ b/ports/simpleini/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "simpleini",
-  "version": "4.25",
+  "version": "4.26",
   "description": "Cross-platform C++ library providing a simple API to read and write INI-style configuration files",
   "homepage": "https://github.com/brofield/simpleini",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2750,7 +2750,7 @@
     },
     "ecal": {
       "baseline": "5.13.4",
-      "port-version": 1
+      "port-version": 2
     },
     "ecaludp": {
       "baseline": "0.1.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9345,7 +9345,7 @@
       "port-version": 1
     },
     "simpleini": {
-      "baseline": "4.25",
+      "baseline": "4.26",
       "port-version": 0
     },
     "simsimd": {

--- a/versions/e-/ecal.json
+++ b/versions/e-/ecal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3fad913e35db30aa3181ac6e7ff7d94c6d45774",
+      "version-semver": "5.13.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "aafc1eb6023b6eb1a41c4a22bb72003b9b281f4c",
       "version-semver": "5.13.4",
       "port-version": 1

--- a/versions/s-/simpleini.json
+++ b/versions/s-/simpleini.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11e04f01aa0c87a74f9581cc81358e373dcbd317",
+      "version": "4.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "06c790643704fb4cf135f9003b3deba428684237",
       "version": "4.25",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 4.26
