### PR TITLE
[redisx] Fix name in pkgconfig

### DIFF
--- a/ports/redisx/pkgconfig.patch
+++ b/ports/redisx/pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/redisx.pc.in b/cmake/redisx.pc.in
+index 9f6386e..9506a37 100644
+--- a/cmake/redisx.pc.in
++++ b/cmake/redisx.pc.in
+@@ -3,7 +3,7 @@ exec_prefix=${prefix}
+ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+-Name: supernovas
++Name: redisx
+ Description: @PROJECT_DESCRIPTION@
+ Version: @PROJECT_VERSION@
+ URL: @PROJECT_HOMEPAGE_URL@

--- a/ports/redisx/portfile.cmake
+++ b/ports/redisx/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 2438cc052c2dc58acab3d0349cf6b4549cd1fe7030a4d2d8a9b935240ed1dba21d01425d8dd365847dcf662fd7ec71a05ce80fc4ab8f25ae7760d37e36999198
     HEAD_REF main
+    PATCHES pkgconfig.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/redisx/vcpkg.json
+++ b/ports/redisx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "redisx",
   "version": "1.0.4",
+  "port-version": 1,
   "description": "A free and independent Redis / Valkey client library for C/C++",
   "homepage": "https://sigmyne.github.io/redisx/",
   "documentation": "https://sigmyne.github.io/redisx/doc/html/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8754,7 +8754,7 @@
     },
     "redisx": {
       "baseline": "1.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "refl-cpp": {
       "baseline": "0.12.4",

--- a/versions/r-/redisx.json
+++ b/versions/r-/redisx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64ba5c6b88e07866add9b8e3a27b8c06a616b2b4",
+      "version": "1.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "73358f0b64b155f7661c70ea51d734a1b13ab531",
       "version": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
This PR fixes the incorrect pkgconfig name, noted by @BillyONeal in [redisx Issue #39](https://github.com/Sigmyne/redisx/issues/39).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

