### PR TITLE
[slick-stream-buffer-multiplexer] Add new port

### DIFF
--- a/ports/slick-stream-buffer-multiplexer/portfile.cmake
+++ b/ports/slick-stream-buffer-multiplexer/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-stream-buffer-multiplexer
     REF "v${VERSION}"
-    SHA512 935b3d516e996f6d25948ba8a54c1b7f70f7f0e3f517e36481fdf0196c2c5cfc2841f86e891f3df9517746b7fb605db47cdded1b8ff78d9482ddaa621db43a34
+    SHA512 145ee9a3c7fff3c3ee34b6982ddbde5f4ba68d838830ebee8902ff17e80ba842a3ece9295cf7e6e7f3238a7d72c05449b02731f8f08340d72920d720a98689cb
     HEAD_REF main
     PATCHES
         slick-dependencies-fetching.patch

--- a/ports/slick-stream-buffer-multiplexer/portfile.cmake
+++ b/ports/slick-stream-buffer-multiplexer/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-stream-buffer-multiplexer
     REF "v${VERSION}"
-    SHA512 4100f3677f7b4e9930f4f051ea16015facac16f22522ef2a1ad56ae410f4d816e07b66591105354e14f20c14641bbeab6b85eaf036d8bf43843fc70b1e9d0b3b
+    SHA512 935b3d516e996f6d25948ba8a54c1b7f70f7f0e3f517e36481fdf0196c2c5cfc2841f86e891f3df9517746b7fb605db47cdded1b8ff78d9482ddaa621db43a34
     HEAD_REF main
     PATCHES
         slick-dependencies-fetching.patch

--- a/ports/slick-stream-buffer-multiplexer/portfile.cmake
+++ b/ports/slick-stream-buffer-multiplexer/portfile.cmake
@@ -1,0 +1,27 @@
+set(VCPKG_BUILD_TYPE release) # header only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SlickQuant/slick-stream-buffer-multiplexer
+    REF "v${VERSION}"
+    SHA512 4100f3677f7b4e9930f4f051ea16015facac16f22522ef2a1ad56ae410f4d816e07b66591105354e14f20c14641bbeab6b85eaf036d8bf43843fc70b1e9d0b3b
+    HEAD_REF main
+    PATCHES
+      slick-dependencies-fetching.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SLICK_STREAM_BUFFER_MULTIPLEXER_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH lib/cmake/slick-stream-buffer-multiplexer
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/slick-stream-buffer-multiplexer/portfile.cmake
+++ b/ports/slick-stream-buffer-multiplexer/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     SHA512 4100f3677f7b4e9930f4f051ea16015facac16f22522ef2a1ad56ae410f4d816e07b66591105354e14f20c14641bbeab6b85eaf036d8bf43843fc70b1e9d0b3b
     HEAD_REF main
     PATCHES
-      slick-dependencies-fetching.patch
+        slick-dependencies-fetching.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
+++ b/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11cb8e4..0a04799 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,9 +10,9 @@ set(CMAKE_CXX_STANDARD 20)
+ # Options:
+ option(BUILD_SLICK_STREAM_BUFFER_MULTIPLEXER_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL})
+ 
+-find_package(slick-stream-buffer 1.0.4 CONFIG QUIET)
++find_package(slick-stream-buffer CONFIG REQUIRED)
+ 
+-if (NOT slick-stream-buffer_FOUND)
++if (FALSE)
+     include(FetchContent)
+ 
+     # Disable slick-stream-buffer tests and examples, but allow installation
+@@ -27,9 +27,9 @@ else()
+     message(STATUS "slick-stream-buffer: ${slick-stream-buffer_VERSION}")
+ endif()
+ 
+-find_package(slick-queue 1.5.0 CONFIG QUIET)
++find_package(slick-queue CONFIG REQUIRED)
+ 
+-if (NOT slick-queue_FOUND)
++if (FALSE)
+     include(FetchContent)
+ 
+     # Disable slick-queue tests and examples, but allow installation

--- a/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
+++ b/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
@@ -26,3 +26,29 @@ index 11cb8e4..0a04799 100644
      include(FetchContent)
  
      # Disable slick-queue tests and examples, but allow installation
+diff --git a/cmake/slick-stream-buffer-multiplexerConfig.cmake.in b/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
+index b9cb86e..8eb750f 100644
+--- a/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
++++ b/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
+@@ -3,8 +3,8 @@
+ # Find dependencies
+ include(CMakeFindDependencyMacro)
+ 
+-find_dependency(slick-stream-buffer 1.0.4 QUIET)
+-if (NOT slick-stream-buffer_FOUND)
++find_dependency(slick-stream-buffer CONFIG)
++if (FALSE)
+     include(FetchContent)
+ 
+     set(BUILD_SLICK_STREAM_BUFFER_TESTS OFF CACHE BOOL "" FORCE)
+@@ -16,8 +16,8 @@ if (NOT slick-stream-buffer_FOUND)
+     FetchContent_MakeAvailable(slick-stream-buffer)
+ endif()
+ 
+-find_dependency(slick-queue 1.5.0 QUIET)
+-if (NOT slick-queue_FOUND)
++find_dependency(slick-queue CONFIG)
++if (FALSE)
+     include(FetchContent)
+ 
+     set(BUILD_SLICK_QUEUE_TESTS OFF CACHE BOOL "" FORCE)

--- a/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
+++ b/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 11cb8e4..0a04799 100644
+index c265436..14867ca 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -10,9 +10,9 @@ set(CMAKE_CXX_STANDARD 20)
  # Options:
  option(BUILD_SLICK_STREAM_BUFFER_MULTIPLEXER_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL})
  
--find_package(slick-stream-buffer 1.0.4 CONFIG QUIET)
+-find_package(slick-stream-buffer 1.0.5 CONFIG QUIET)
 +find_package(slick-stream-buffer CONFIG REQUIRED)
  
 -if (NOT slick-stream-buffer_FOUND)
@@ -27,14 +27,14 @@ index 11cb8e4..0a04799 100644
  
      # Disable slick-queue tests and examples, but allow installation
 diff --git a/cmake/slick-stream-buffer-multiplexerConfig.cmake.in b/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
-index b9cb86e..8eb750f 100644
+index b7f5032..96461bf 100644
 --- a/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
 +++ b/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
 @@ -3,8 +3,8 @@
  # Find dependencies
  include(CMakeFindDependencyMacro)
  
--find_dependency(slick-stream-buffer 1.0.4 QUIET)
+-find_dependency(slick-stream-buffer 1.0.5 CONFIG QUIET)
 -if (NOT slick-stream-buffer_FOUND)
 +find_dependency(slick-stream-buffer CONFIG)
 +if (FALSE)
@@ -45,7 +45,7 @@ index b9cb86e..8eb750f 100644
      FetchContent_MakeAvailable(slick-stream-buffer)
  endif()
  
--find_dependency(slick-queue 1.5.0 QUIET)
+-find_dependency(slick-queue 1.5.0 CONFIG QUIET)
 -if (NOT slick-queue_FOUND)
 +find_dependency(slick-queue CONFIG)
 +if (FALSE)

--- a/ports/slick-stream-buffer-multiplexer/vcpkg.json
+++ b/ports/slick-stream-buffer-multiplexer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-stream-buffer-multiplexer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A C++ lock-free MPMC byte stream buffer multiplexer",
   "homepage": "https://github.com/SlickQuant/slick-stream-buffer-multiplexer",
   "license": "MIT",
@@ -13,7 +13,7 @@
     },
     {
       "name": "slick-stream-buffer",
-      "version>=": "1.0.4"
+      "version>=": "1.0.5"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/slick-stream-buffer-multiplexer/vcpkg.json
+++ b/ports/slick-stream-buffer-multiplexer/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "slick-stream-buffer-multiplexer",
+  "version": "1.0.0",
+  "description": "A C++ lock-free MPMC byte stream buffer multiplexer",
+  "homepage": "https://github.com/SlickQuant/slick-stream-buffer-multiplexer",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "slick-queue",
+      "version>=": "1.5.0"
+    },
+    {
+      "name": "slick-stream-buffer",
+      "version>=": "1.0.4"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9412,6 +9412,10 @@
       "baseline": "1.0.5",
       "port-version": 0
     },
+    "slick-stream-buffer-multiplexer": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "slickquant-hyperliquid-cpp": {
       "baseline": "0.1.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9413,7 +9413,7 @@
       "port-version": 0
     },
     "slick-stream-buffer-multiplexer": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "slickquant-hyperliquid-cpp": {

--- a/versions/s-/slick-stream-buffer-multiplexer.json
+++ b/versions/s-/slick-stream-buffer-multiplexer.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "65e296bc19d6035143d6633f5581a4177f528c5c",
-      "version": "1.0.0",
+      "git-tree": "da0ee9241a039e1d4b844aee4ef10bf4e2f6fae3",
+      "version": "1.0.1",
       "port-version": 0
     }
   ]

--- a/versions/s-/slick-stream-buffer-multiplexer.json
+++ b/versions/s-/slick-stream-buffer-multiplexer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "68e6f3f7e3cb11afcf301a3c6ddc0b9b0bdfc55f",
+      "git-tree": "65e296bc19d6035143d6633f5581a4177f528c5c",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/slick-stream-buffer-multiplexer.json
+++ b/versions/s-/slick-stream-buffer-multiplexer.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "68e6f3f7e3cb11afcf301a3c6ddc0b9b0bdfc55f",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/slick-stream-buffer-multiplexer.json
+++ b/versions/s-/slick-stream-buffer-multiplexer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "da0ee9241a039e1d4b844aee4ef10bf4e2f6fae3",
+      "git-tree": "41a0d64bed8187df8b34f904c58598c072145b54",
       "version": "1.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [x] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="859" height="610" alt="image" src="https://github.com/user-attachments/assets/504ffc7c-e851-4306-88df-188deba231d5" />

