### PR TITLE
[mailio] update to 0.26

### DIFF
--- a/ports/mailio/portfile.cmake
+++ b/ports/mailio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO karastojko/mailio
     REF "${VERSION}"
-    SHA512 550ab52400e3085d9dfeb1405ad34a5d26c65f9d0a9321933300da78e56e0469d2b79d1dd67559e3bdbf1f73899370d8feb7a9e9996bd309cbf4f8f9fd645605
+    SHA512 5a63eb87fdb2a583aaa1de5f8a02facceacaf4174cdb96faafed992899396921eb3b232359ca49bf40ce2cdb414113cb88bf8a71c69bbc2e74f56dab9e8ee06c
     HEAD_REF master
 )
 

--- a/ports/mailio/vcpkg.json
+++ b/ports/mailio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mailio",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "maintainers": "Tomislav Karastojković <contact@alepho.com>",
   "description": "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols. It is based on the standard C++ 17 and Boost library.",
   "homepage": "https://github.com/karastojko/mailio",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6345,7 +6345,7 @@
       "port-version": 13
     },
     "mailio": {
-      "baseline": "0.25.3",
+      "baseline": "0.26.0",
       "port-version": 0
     },
     "makeid": {

--- a/versions/m-/mailio.json
+++ b/versions/m-/mailio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b33114ec6cfee6dc05340a379757a4bb91789205",
+      "version": "0.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2a66de23f32c8b929aa630d9ebdb15492e0fc344",
       "version": "0.25.3",
       "port-version": 0

--- a/versions/m-/mailio.json
+++ b/versions/m-/mailio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b33114ec6cfee6dc05340a379757a4bb91789205",
+      "git-tree": "cc52b0dc1201289526e7052c35716328b6f6a88a",
       "version": "0.26.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

