### PR TITLE
[slick-stream-buffer] Update to 1.0.5

### DIFF
--- a/ports/slick-stream-buffer/portfile.cmake
+++ b/ports/slick-stream-buffer/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-stream-buffer
     REF "v${VERSION}"
-    SHA512 73f49896f355e92eb2e1583befdfb6a8f3b9f64e6b8acd3aa6c83ad324cabfe5193b5f973d4c4d19d6feaa814e7fbc78db3caee6b665ec5b80bfc29b6042560f
+    SHA512 89a381c9e8a848400291a2c27b266c09a35a158ac4194d7af25fb5a333f3bcb044277117685ff00afbc733a10c6d76ab7eeb23d60ef4a818516086fe2f6487ab
     HEAD_REF main
 )
 

--- a/ports/slick-stream-buffer/vcpkg.json
+++ b/ports/slick-stream-buffer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-stream-buffer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A C++ lock-free SPMC byte stream buffer",
   "homepage": "https://github.com/SlickQuant/slick-stream-buffer",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9409,7 +9409,7 @@
       "port-version": 0
     },
     "slick-stream-buffer": {
-      "baseline": "1.0.4",
+      "baseline": "1.0.5",
       "port-version": 0
     },
     "slickquant-hyperliquid-cpp": {

--- a/versions/s-/slick-stream-buffer.json
+++ b/versions/s-/slick-stream-buffer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f09ecd2c6fd1cbcd5ed43adc3cf2e2c6538428f4",
+      "version": "1.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "aaf5f2473fd919296f1b5511e65e3c5ff1d3884d",
       "version": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
