### PR TITLE
[ffmpeg] Update to version 8.1.2

### DIFF
--- a/ports/ffmpeg/0042-fix-arm64-linux.patch
+++ b/ports/ffmpeg/0042-fix-arm64-linux.patch
@@ -1,9 +1,0 @@
-diff --git a/ffbuild/libversion.sh b/ffbuild/libversion.sh
-index a94ab58..ecaa90c 100644
---- a/ffbuild/libversion.sh
-+++ b/ffbuild/libversion.sh
-@@ -1,3 +1,4 @@
-+#!/bin/sh
- toupper(){
-     echo "$@" | tr abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ
- }

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
     REF "n${VERSION}"
-    SHA512 e858e92e5eb08d562302cde371af55917df6e1fe53994e18462a3c929a40ede1828c2bd53c2a7d65a2cfd791782ead3cd94efb2def904f49cb5dd8ab5cd4256f
+    SHA512 c72f4062aecc16d8b2b1e8678d5efe3af4cfaa0cc7c0997052248f9e499e60c2463acf07877cf3b78b246ce3e8078cb043e8d97e90a6b50d06af32ff7369a788
     HEAD_REF master
     PATCHES
         0002-fix-msvc-link.patch

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ffmpeg",
-  "version": "8.1.1",
-  "port-version": 3,
+  "version": "8.1.2",
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -155,6 +155,7 @@ ecal:arm64-android=fail
 ecal:x64-android=fail
 faad2:arm64-linux=fail
 faiss:arm64-osx=fail # No openmp on default osx toolchain
+ffmpeg:arm64-linux=fail
 fizz:arm64-linux=fail
 fltk:arm-neon-android=fail
 fltk:arm64-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -155,7 +155,6 @@ ecal:arm64-android=fail
 ecal:x64-android=fail
 faad2:arm64-linux=fail
 faiss:arm64-osx=fail # No openmp on default osx toolchain
-ffmpeg:arm64-linux=fail
 fizz:arm64-linux=fail
 fltk:arm-neon-android=fail
 fltk:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3033,8 +3033,8 @@
       "port-version": 0
     },
     "ffmpeg": {
-      "baseline": "8.1.1",
-      "port-version": 3
+      "baseline": "8.1.2",
+      "port-version": 0
     },
     "ffmpeg-bin2c": {
       "baseline": "8.1.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30b94bdee9a6a13b7cde083f0965b96aece6c65b",
+      "version": "8.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb486b86580a10badc839f37132a57e133806d6f",
       "version": "8.1.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.