### PR TITLE
[libmount] update to 2.42.2

### DIFF
--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH "^([0-9]+\\.[0-9]+)" VERSION_SHORT "${VERSION}")
 vcpkg_download_distfile(ARCHIVE
     URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION_SHORT}/util-linux-${VERSION}.tar.xz"
     FILENAME "util-linux-${VERSION}.tar.xz"
-    SHA512 3d299f0e05a4c982a04dbcbaaeff1222152feedf51c56c5dbdeb75999c68269d652a994f5cdf4c1ee42bb7b28475dd0792192c299fd9bc3b45198c5b153dad00
+    SHA512 7415add0be2930654e322830808dde03ff6d511bd357f0679e6b6287a13ca79fe58ce4ac05edef86b76fb381b3a36ca2da9d3c31b5dc0a1d889c203156a57277
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmount",
-  "version": "2.41.3",
-  "port-version": 1,
+  "version": "2.42.2",
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5333,8 +5333,8 @@
       "port-version": 0
     },
     "libmount": {
-      "baseline": "2.41.3",
-      "port-version": 1
+      "baseline": "2.42.2",
+      "port-version": 0
     },
     "libmpeg2": {
       "baseline": "0.5.1",

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "974982c2c85556fbbff201d22ad8b88d5eee0547",
+      "version": "2.42.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "57fea6e580958cd9cd7a0834aa38a03e6a22f930",
       "version": "2.41.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
