### PR TITLE
[libzim] Update to 9.8.0

### DIFF
--- a/ports/libzim/cross-builds.diff
+++ b/ports/libzim/cross-builds.diff
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index c75d103..ad5e856 100644
+index add8aa0..1f085d5 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,9 +1,9 @@
  project('libzim', ['c', 'cpp'],
-   version : '9.7.0',
+   version : '9.8.0',
    license : 'GPL2',
 -  default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 +  default_options : ['c_std=c11', 'cpp_std=c++17'])
@@ -14,7 +14,7 @@ index c75d103..ad5e856 100644
    add_project_arguments('-D_LARGEFILE64_SOURCE=1', '-D_FILE_OFFSET_BITS=64', language: 'cpp')
  endif
  
-@@ -67,7 +67,7 @@ else
+@@ -73,7 +73,7 @@ else
  endif
  
  compiler = meson.get_compiler('cpp')

--- a/ports/libzim/dllexport.diff
+++ b/ports/libzim/dllexport.diff
@@ -1,8 +1,8 @@
 diff --git a/include/zim/zim.h b/include/zim/zim.h
-index 80e8596..631cfab 100644
+index d68d4e3..1238029 100644
 --- a/include/zim/zim.h
 +++ b/include/zim/zim.h
-@@ -35,8 +35,10 @@
+@@ -36,8 +36,10 @@
  
  #include <zim/zim_config.h>
  

--- a/ports/libzim/portfile.cmake
+++ b/ports/libzim/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openzim/libzim
     REF "${VERSION}"
-    SHA512 3f635eaf4363bf12b92f12a4d089883f10bb8cfe4c572876ab410d88273f8a44455ce93ef74bcb0836051ea3dd51d39f25f703d6c01d6599cce0a8801bc09fba
+    SHA512 dbddee0a7beadc041df416e3ecc2c0dba4afacfb4a5245dd02b4466d582979d9eeb8e027e095bf719f856c95563653e6d6d3b2fae59315d997f3740eac4b392c
     HEAD_REF main
     PATCHES
         cross-builds.diff

--- a/ports/libzim/subdirs.diff
+++ b/ports/libzim/subdirs.diff
@@ -1,16 +1,16 @@
 diff --git a/meson.build b/meson.build
-index d946c49..eded01d 100644
+index 1f085d5..f360501 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -90,6 +90,7 @@ subdir('include')
- subdir('scripts')
- subdir('static')
+@@ -102,6 +102,7 @@ subdir('static')
  subdir('src')
+ # The example project demonstrates writer usage
+ # so only include it if the writer is also present
 +if false
- if get_option('examples')
+ if get_option('examples') and not get_option('without_writer')
    subdir('examples')
  endif
-@@ -97,6 +98,7 @@ subdir('test')
+@@ -111,6 +112,7 @@ endif
  if get_option('doc')
    subdir('docs')
  endif

--- a/ports/libzim/vcpkg.json
+++ b/ports/libzim/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libzim",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "The Libzim is the reference implementation for the ZIM file format. It's a software library to read and write ZIM files on many systems and architectures. More information about the ZIM format and the openZIM project at https://openzim.org/.",
   "homepage": "https://github.com/openzim/libzim",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6089,7 +6089,7 @@
       "port-version": 0
     },
     "libzim": {
-      "baseline": "9.7.0",
+      "baseline": "9.8.0",
       "port-version": 0
     },
     "libzip": {

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4fb173be1f4237bd0e191d56bf017232a39801cb",
+      "git-tree": "2e92226ca26dc4a480d7adb958ae003be8eb440e",
       "version": "9.8.0",
       "port-version": 0
     },

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4fb173be1f4237bd0e191d56bf017232a39801cb",
+      "version": "9.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "28d90812c3709d2a019e23316cf4d55b92494701",
       "version": "9.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 9.8.0
