### PR TITLE
[dcmtk] allow wasm build

### DIFF
--- a/ports/dcmtk/emscripten-ofwhere.diff
+++ b/ports/dcmtk/emscripten-ofwhere.diff
@@ -1,0 +1,16 @@
+--- a/ofstd/libsrc/ofwhere.c
++++ b/ofstd/libsrc/ofwhere.c
+@@ -33,5 +33,5 @@
+
+-#if defined(__linux__) || defined(__CYGWIN__)
++#if defined(__linux__) || defined(__CYGWIN__) || defined(__EMSCRIPTEN__)
+ #undef _DEFAULT_SOURCE
+ #define _DEFAULT_SOURCE
+ #elif defined(__APPLE__)
+@@ -166,5 +166,5 @@
+ }
+
+-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
++#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE) || defined(__EMSCRIPTEN__)
+
+ #include <stdio.h>

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -11,7 +11,9 @@ vcpkg_from_github(
         disable-test-setup.diff
         pkgconfig-lib-order.diff
         msvc.diff
+        emscripten-ofwhere.diff
 )
+
 file(REMOVE
     "${SOURCE_PATH}/CMake/FindICONV.cmake"
     "${SOURCE_PATH}/CMake/FindJPEG.cmake"

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dcmtk",
   "version": "3.7.0",
+  "port-version": 1,
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2458,7 +2458,7 @@
     },
     "dcmtk": {
       "baseline": "3.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ddtdanilo-lmdb-wrapper": {
       "baseline": "1.0.1",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd083279adef30a6018c8a82e09009c4bf64e214",
+      "version": "3.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "288bd880194f8ef326245cace498d59017b5a2ec",
       "version": "3.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.~~
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.