### PR TITLE
[sentry-native] update to 0.15.1

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 e87aef3757dbf1aae7b67758bd47280d515330fda6497b23f226bc7e2c6139d78e867048427110439c7fb0e6cc36e95a027d4e6acd492adf53c4c774e144fdf2
+    SHA512 0edf9f12cd13071fc42112b3812b47a77abe1722f1247bd61692bacddb42b95ce836d77609fd468e604b1c34701b20c1bb3fd1b88c57b192f4508200a3469792
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9209,7 +9209,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.15.0",
+      "baseline": "0.15.1",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf06ade7573d9f94518db115016f04f642682c15",
+      "version": "0.15.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "73cc88f045eb88d7a589e3a31f8794acdd1fa1f2",
       "version": "0.15.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
