### PR TITLE
Allow bad whitespace in patches.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@ ports/** -linguist-detectable
 
 # Declare files that will always have LF line endings on checkout.
 scripts/ci.baseline.txt text eol=lf
+
+# Stored patch files may legitimately contain whitespace that represents the
+# patched content rather than the patch file itself.
+*.diff -whitespace
+*.patch -whitespace


### PR DESCRIPTION
We've seen copilot-cli sometimes try to use `git diff --check` and then complain that there is trialing whitespace in patch files. However, patches are *supposed* to have trailing whitespace; for example the "column" that has the +/- on it has a trailing space for blank lines in context.

It's unfortunate that powershell damaged patches that should be LF but are CRLF are so common but as there are legitimate cases for both trailing whitespace and CRLFs we have to shut off checking for it here.
