### PR TITLE
[wayland-protocols] Update to 1.49

### DIFF
--- a/ports/wayland-protocols/cross-build.diff
+++ b/ports/wayland-protocols/cross-build.diff
@@ -1,34 +1,37 @@
 diff --git a/meson.build b/meson.build
-index 414e759..4577953 100644
+index 25d42ce..60a8354 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,6 +1,6 @@
  project('wayland-protocols',
- 	version: '1.48',
+ 	version: '1.49',
 -	meson_version: '>= 0.58.0',
 +	meson_version: '>= 0.62.0',
  	license: 'MIT/Expat',
  )
  
-@@ -8,12 +8,7 @@ wayland_protocols_version = meson.project_version()
+@@ -8,15 +8,7 @@ wayland_protocols_version = meson.project_version()
  
  fs = import('fs')
  
 -dep_scanner = dependency('wayland-scanner',
--    version: get_option('tests') ? '>=1.23.0' : '>=1.20.0',
+-    version: get_option('tests') ? '>=1.25.0' : '>=1.22.90',
+-    required: get_option('tests'),
 -    native: true,
 -    fallback: 'wayland'
 -)
--prog_scanner = find_program(dep_scanner.get_variable(pkgconfig: 'wayland_scanner', internal: 'wayland_scanner'))
+-if dep_scanner.found()
+-	prog_scanner = find_program(dep_scanner.get_variable(pkgconfig: 'wayland_scanner', internal: 'wayland_scanner'))
+-endif
 +prog_scanner = find_program('wayland_scanner')
  
  stable_protocols = {
- 	'linux-dmabuf': ['v1'],
-@@ -157,7 +152,7 @@ endforeach
+ 	'linux-dmabuf': {'v1': []},
+@@ -178,7 +170,7 @@ endforeach
  
  include_dirs = []
  headers = []
--if dep_scanner.version().version_compare('>=1.22.90')
+-if dep_scanner.found()
 +if true
  	subdir('include/wayland-protocols')
  	include_dirs = ['include']

--- a/ports/wayland-protocols/portfile.cmake
+++ b/ports/wayland-protocols/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wayland/wayland-protocols
     REF "${VERSION}"
-    SHA512 f259a42d95cacfa66fbd080aa807af7d4aece3ce32f4cff791f9d550131a2427af4e8d80117dfbd2588d1f003fdd92b23219e6307c163d8ade05093a551cf95a
+    SHA512 f1095a667305dce9490b7fc2dddd263e50d90f505c7b2a281ff3a9f77f211589ec45c5124c07805f9d577484c80bf13f71b2dff6e0ae677fbb1bffdde60aec48
     HEAD_REF main
     PATCHES
         cross-build.diff

--- a/ports/wayland-protocols/vcpkg.json
+++ b/ports/wayland-protocols/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wayland-protocols",
-  "version": "1.48",
-  "port-version": 1,
+  "version": "1.49",
   "description": "wayland-protocols contains Wayland protocols that add functionality not available in the Wayland core protocol.",
   "homepage": "https://wayland.freedesktop.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10877,8 +10877,8 @@
       "port-version": 0
     },
     "wayland-protocols": {
-      "baseline": "1.48",
-      "port-version": 1
+      "baseline": "1.49",
+      "port-version": 0
     },
     "wcslib": {
       "baseline": "8.5",

--- a/versions/w-/wayland-protocols.json
+++ b/versions/w-/wayland-protocols.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b65ca5bb85a8eed3faa7bfa6041edc9cab70439",
+      "version": "1.49",
+      "port-version": 0
+    },
+    {
       "git-tree": "92ed80e3b0273c98f498f3b7597459bbc5c3bee1",
       "version": "1.48",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

As the CI doesn't build anything here, tested it locally in a VM with a custom triplet

@AenBleidd In case you want try it, feel free ;-)