### PR TITLE
Fix ffmpeg and rocksdb CI regressions

### DIFF
--- a/ports/ffmpeg/0051-create-resource-output-directories.patch
+++ b/ports/ffmpeg/0051-create-resource-output-directories.patch
@@ -1,0 +1,13 @@
+diff --git a/ffbuild/common.mak b/ffbuild/common.mak
+index 8217831..ac9bc75 100644
+--- a/ffbuild/common.mak
++++ b/ffbuild/common.mak
+@@ -126,7 +126,7 @@ $(BIN2CEXE): ffbuild/bin2c_host.o
+ 	$(HOSTLD) $(HOSTLDFLAGS) $(HOSTLD_O) $^ $(HOSTEXTRALIBS)
+ 
+ RUN_BIN2C = $(BIN2C) $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<) $@ $(subst .,_,$(basename $(notdir $@)))
+-RUN_GZIP  = $(M)gzip -nc9 $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<) >$@
++RUN_GZIP  = $(M)mkdir -p $(@D) && gzip -nc9 $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<) >$@
+ RUN_MINIFY = $(M)sed 's!/\\*.*\\*/!!g' $< | tr '\n' ' ' | tr -s ' ' | sed 's/^ //; s/ $$//' > $@
+ %.gz: TAG = GZIP
+ %.min: TAG = MINIFY

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_from_github(
         0048-backport-23039.patch
         0049-fix-twolame-pkgconfig.patch
         0050-fix-test-ld-absolute-lib-paths.patch
+        0051-create-resource-output-directories.patch
 )
 
 if(SOURCE_PATH MATCHES " ")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "8.1.2",
+  "port-version": 1,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/ports/rocksdb/0001-fix-dependencies.patch
+++ b/ports/rocksdb/0001-fix-dependencies.patch
@@ -98,7 +98,7 @@ diff --git a/cmake/RocksDBConfig.cmake.in b/cmake/RocksDBConfig.cmake.in
 index 0bd14be11..ccc69ba72 100644
 --- a/cmake/RocksDBConfig.cmake.in
 +++ b/cmake/RocksDBConfig.cmake.in
-@@ -33,19 +33,24 @@ if(@WITH_BZ2@)
+@@ -33,19 +33,27 @@ if(@WITH_BZ2@)
  endif()
  
  if(@WITH_LZ4@)
@@ -121,9 +121,12 @@ index 0bd14be11..ccc69ba72 100644
 +  find_dependency(TBB CONFIG)
 +endif()
 +
-+if(@WITH_LIBURING@)
-+  find_dependency(PkgConfig)
-+  pkg_check_modules(liburing REQUIRED IMPORTED_TARGET GLOBAL liburing>=2.0)
++if(@WITH_LIBURING@ AND NOT TARGET PkgConfig::liburing)
++  find_library(liburing_LIBRARY_RELEASE NAMES uring REQUIRED)
++  add_library(PkgConfig::liburing UNKNOWN IMPORTED)
++  set_target_properties(PkgConfig::liburing PROPERTIES
++    IMPORTED_LOCATION "${liburing_LIBRARY_RELEASE}"
++  )
  endif()
  
  find_dependency(Threads)

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rocksdb",
   "version": "11.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3034,7 +3034,7 @@
     },
     "ffmpeg": {
       "baseline": "8.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "ffmpeg-bin2c": {
       "baseline": "8.1.1",
@@ -8914,7 +8914,7 @@
     },
     "rocksdb": {
       "baseline": "11.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "rp-ntuples": {
       "baseline": "0.1.4",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e09dc5630fbb3c4eb8c6b08105d5e76c63bdb76",
+      "version": "8.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "30b94bdee9a6a13b7cde083f0965b96aece6c65b",
       "version": "8.1.2",
       "port-version": 0

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afaf24b5a681e31d46fa6c3981217da0fd0b1fa5",
+      "version": "11.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "e4163c835824288a256d114ab8d31853ebb8d565",
       "version": "11.1.1",
       "port-version": 1


### PR DESCRIPTION
Build: https://dev.azure.com/vcpkg/public/_build/results?buildId=133407

GPT 5.5 fixed regression lines:

- 2026-06-18T13:01:22.0567194Z REGRESSION: ffmpeg:x64-android failed with BUILD_FAILED. If expected, add ffmpeg:x64-android=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.
- 2026-06-18T13:01:22.0567551Z REGRESSION: vcpkg-ci-ffmpeg:x64-android cascaded, but it is required to pass. (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
- 2026-06-18T13:01:22.0567885Z REGRESSION: vcpkg-ci-freerdp:x64-android cascaded, but it is required to pass. (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
- 2026-06-18T13:01:22.0568210Z REGRESSION: vcpkg-ci-opencv:x64-android cascaded, but it is required to pass. (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
- 2026-06-18T15:37:40.2027562Z REGRESSION: vcpkg-ci-rocksdb:arm64-linux failed with BUILD_FAILED. If expected, add vcpkg-ci-rocksdb:arm64-linux=fail to /vcpkg/scripts/azure-pipelines/../ci.baseline.txt.

The ffmpeg failure was caused by the build trying to write fftools/resources/graph.html.gz before fftools/resources existed. Patch ffbuild/common.mak so RUN_GZIP creates the output directory before redirecting gzip output. This should also unblock the vcpkg-ci-ffmpeg, vcpkg-ci-freerdp, and vcpkg-ci-opencv cascades on x64-android.

The vcpkg-ci-rocksdb arm64-linux failure was caused by the installed RocksDBConfig.cmake calling FindPkgConfig and attempting to execute the target-side /mnt/vcpkg-ci/installed/arm64-linux/tools/pkgconf/pkgconf on the x64-linux host. Patch the exported config to provide the expected PkgConfig::liburing imported target from the installed uring library instead of running pkgconf at consumer configure time.