### PR TITLE
[flashaccept] Add new port

### DIFF
--- a/ports/flashaccept/portfile.cmake
+++ b/ports/flashaccept/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO thealonlevi/flashaccept
+    REF "v${VERSION}"
+    SHA512 048a0dfdaf97657c7572820d48da6cb3d62edd22d9826e3e81974fd4bb662c614c357f6591592209dff6dfdc6c47927106d075361a02be28fdf98804f48afc15
+    HEAD_REF main
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" FA_SHARED)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static"  FA_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFLASHACCEPT_BUILD_EXAMPLES=OFF
+        -DFLASHACCEPT_BUILD_SHARED=${FA_SHARED}
+        -DFLASHACCEPT_BUILD_STATIC=${FA_STATIC}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME flashaccept CONFIG_PATH lib/cmake/flashaccept)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/flashaccept/usage
+++ b/ports/flashaccept/usage
@@ -1,0 +1,8 @@
+flashaccept provides CMake targets:
+
+    find_package(flashaccept CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE flashaccept::flashaccept)
+
+and a pkg-config module:
+
+    pkg-config --cflags --libs flashaccept

--- a/ports/flashaccept/vcpkg.json
+++ b/ports/flashaccept/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "flashaccept",
+  "version": "1.0.1",
+  "description": "Fast io_uring TCP accept engine for Linux (multishot accept, registered/direct descriptors, MSG_MORE reply+FIN fusion).",
+  "homepage": "https://github.com/thealonlevi/flashaccept",
+  "license": "MIT",
+  "supports": "linux",
+  "dependencies": [
+    "liburing",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3088,6 +3088,10 @@
       "baseline": "2.4",
       "port-version": 1
     },
+    "flashaccept": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "flashlight-cpu": {
       "baseline": "0.3",
       "port-version": 5

--- a/versions/f-/flashaccept.json
+++ b/versions/f-/flashaccept.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d46290a837b7fdb97a2c17e23b2d677d32f22710",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds **flashaccept** 1.0.1 — a fast io_uring TCP accept engine for Linux.

It accepts short-lived TCP connections for ~3× fewer CPU instructions than a goroutine-per-connection server and ~2.2× fewer than vanilla io_uring (multishot accept, registered/direct descriptors, per-worker connection freelist, MSG_MORE reply+FIN fusion, batched submit/harvest).

- Upstream: https://github.com/thealonlevi/flashaccept
- License: MIT
- **Linux-only** (built on io_uring) — declared via `"supports": "linux"`.
- Depends on `liburing`.
- Installs an exported CMake config (`find_package(flashaccept CONFIG)` → `flashaccept::flashaccept`) plus a pkg-config module.

### Validation
- [x] `./vcpkg install flashaccept` succeeds (x64-linux), post-build validation passes.
- [x] Honors per-triplet linkage (static/shared) — no stray libraries left behind.
- [x] A downstream `find_package(flashaccept CONFIG REQUIRED)` consumer links and runs.
- [x] `./vcpkg x-add-version flashaccept` run; version database updated.
- [x] `./vcpkg format-manifest` clean.

### Notes
Linux-only, so I haven't tested non-Linux triplets (the port advertises `"supports": "linux"`).
