### PR TITLE
[nanobind] update to 2.13.0

### DIFF
--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind
     REF "v${VERSION}"
-    SHA512 a187f0efae1833b2caeaff41074a3d8fbd866ee1874aac088ffd5daf026aeaa6a73a8943b682bd39ef59b755e36b73a221eaf71343a28351dce0c8f284debdd9
+    SHA512 8ab384572d8142b29fdccab2e3693e576cee4cbd6c8d8ac54b3426e45dba6618beb4ccb3e413d41fc405d09935da1fd65f75ef46cf6f78156c2273052fe3e22a
     HEAD_REF master
 )
 

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobind",
-  "version-semver": "2.12.0",
+  "version-semver": "2.13.0",
   "description": "Tiny and efficient C++/Python bindings",
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -807,7 +807,6 @@ mygui[tools]:arm64-osx=feature-fails # Linker errors undefined symbols. See http
 mysql-connector-cpp:arm64-linux=fail
 nana:arm64-linux=fail
 nana:x64-linux=fail
-nanobind:arm64-linux=cascade
 nanogui:arm64-linux=cascade
 nativefiledialog-extended:arm64-linux=cascade
 neko-network[nlog]:arm64-linux=feature-fails

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6905,7 +6905,7 @@
       "port-version": 0
     },
     "nanobind": {
-      "baseline": "2.12.0",
+      "baseline": "2.13.0",
       "port-version": 0
     },
     "nanodbc": {

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae65341dd32843a466be26e7888d77b23c519cdc",
+      "version-semver": "2.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ac000b3e018ad810aa032f836f4d804377847f31",
       "version-semver": "2.12.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/wjakob/nanobind/releases/tag/v2.13.0

