### PR TITLE
[pipewire] update to 1.6.7

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pipewire/pipewire
     REF "${VERSION}"
-    SHA512 e8c1e620f09e2405de432797afb66a39aeb258b9a9f26b4e7aea541498c7690600a1788c863f2df9ba38dc44f0740a6908b7ad347d808511ecef7f9424f5b08d
+    SHA512 d13d9dd7f2f58ebced793a1fbe97101b3a476ae3f459a5bfcf6adc015b7cbd559e19f46933ec37acd55e26393cd4fed078b55f1d92e6b95defc7031b50a1e5ba
     HEAD_REF master
 )
 

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pipewire",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7797,7 +7797,7 @@
       "port-version": 2
     },
     "pipewire": {
-      "baseline": "1.6.6",
+      "baseline": "1.6.7",
       "port-version": 0
     },
     "pistache": {

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "847d53be4f1e4a05f0e26143844bbafec460db04",
+      "version": "1.6.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "af809f3dbbc99f50bcdad87365c5fd23535eb0f4",
       "version": "1.6.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/PipeWire/pipewire/releases/tag/1.6.7
