### PR TITLE
[typecast-ai] update to 1.2.5

### DIFF
--- a/ports/typecast-ai/portfile.cmake
+++ b/ports/typecast-ai/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO neosapience/typecast-sdk
     REF "v${VERSION}"
-    SHA512 9fafc2b2270de52aaec72d6514aa12a7e21119db59b75e684a35f39bafd746d1e09e78d6a25fc9633abbf82e95b62efcaa0a8100aa49e3231c77de31baf12061
+    SHA512 3d7db6b63fd0ea90ee740108d98c19243c9b8f0accd1a959dfcc7e2121c2e8da38549927cd046b788ce377a130e18ab024c22b670f0bcfdde8f7adb1e689f133
     HEAD_REF main
 )
 

--- a/ports/typecast-ai/vcpkg.json
+++ b/ports/typecast-ai/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "typecast-ai",
-  "version": "1.2.2",
+  "version": "1.2.5",
   "description": "Text-to-Speech API client library for Typecast AI. Pure C with optional C++ wrapper.",
   "homepage": "https://github.com/neosapience/typecast-sdk",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10401,7 +10401,7 @@
       "port-version": 0
     },
     "typecast-ai": {
-      "baseline": "1.2.2",
+      "baseline": "1.2.5",
       "port-version": 0
     },
     "uchardet": {

--- a/versions/t-/typecast-ai.json
+++ b/versions/t-/typecast-ai.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46ba24010e4789d71f6bc6d6bf259cd0908f81d9",
+      "version": "1.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae0087dac821ed34f8e31a250f2cbf371c1c3426",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/neosapience/typecast-sdk/releases/tag/v1.2.5
