### PR TITLE
[libshout] Add windows support

### DIFF
--- a/ports/libshout/0001-fix-windows-compat-header.patch
+++ b/ports/libshout/0001-fix-windows-compat-header.patch
@@ -1,0 +1,20 @@
+diff --git a/net/sock.h b/net/sock.h
+--- a/net/sock.h
++++ b/net/sock.h
+@@ -35,8 +35,14 @@
+ 
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+-#elif _WIN32
+-#include <compat.h>
++#elif defined(_WIN32)
++#include <io.h>
++#include <direct.h>
++#ifndef _SSIZE_T_DEFINED
++#define _SSIZE_T_DEFINED
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
+ #endif
+ 
+ #ifdef HAVE_SYS_UIO_H

--- a/ports/libshout/0002-fix-strings-h-windows.patch
+++ b/ports/libshout/0002-fix-strings-h-windows.patch
@@ -1,0 +1,16 @@
+diff --git a/httpp/encoding.c b/httpp/encoding.c
+--- a/httpp/encoding.c
++++ b/httpp/encoding.c
+@@ -27,7 +27,12 @@
+ #endif
+ 
+ #include <sys/types.h>
++#ifndef _WIN32
+ #include <strings.h>
++#else
++#define strcasecmp _stricmp
++#define strncasecmp _strnicmp
++#endif
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>

--- a/ports/libshout/0003-fix-ssize_t-windows.patch
+++ b/ports/libshout/0003-fix-ssize_t-windows.patch
@@ -1,0 +1,17 @@
+diff --git a/httpp/encoding.h b/httpp/encoding.h
+--- a/httpp/encoding.h
++++ b/httpp/encoding.h
+@@ -26,6 +26,13 @@
+ #define __ENCODING_H
+ 
+ #include <sys/types.h>
++#ifdef _WIN32
++#ifndef _SSIZE_T_DEFINED
++#define _SSIZE_T_DEFINED
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
++#endif
+ 
+ /* known encodings */
+ #define HTTPP_ENCODING_IDENTITY "identity" /* RFC2616 */

--- a/ports/libshout/0004-fix-void-ptr-arithmetic-windows.patch
+++ b/ports/libshout/0004-fix-void-ptr-arithmetic-windows.patch
@@ -1,0 +1,62 @@
+diff --git a/httpp/encoding.c b/httpp/encoding.c
+--- a/httpp/encoding.c
++++ b/httpp/encoding.c
+@@ -48,16 +48,16 @@ struct httpp_encoding_tag {
+     httpp_meta_t *meta_read;
+     httpp_meta_t *meta_write;
+ 
+-    void *buf_read_raw; /* input buffer */
++    char *buf_read_raw; /* input buffer */
+     size_t buf_read_raw_offset, buf_read_raw_len;
+ 
+-    void *buf_read_decoded; /* decoded stuff */
++    char *buf_read_decoded; /* decoded stuff */
+     size_t buf_read_decoded_offset, buf_read_decoded_len;
+ 
+-    void *buf_write_raw; /* input buffer */
++    char *buf_write_raw; /* input buffer */
+     size_t buf_write_raw_offset, buf_write_raw_len;
+ 
+-    void *buf_write_encoded; /* encoded output */
++    char *buf_write_encoded; /* encoded output */
+     size_t buf_write_encoded_offset, buf_write_encoded_len;
+ 
+     /* backend specific stuff */
+@@ -73,9 +73,9 @@ static ssize_t __enc_chunked_read(httpp_encoding_t *self, void *buf, size_t len,
+ static ssize_t __enc_chunked_write(httpp_encoding_t *self, const void *buf, size_t len, ssize_t (*cb)(void*, const void*, size_t), void *userdata);
+ 
+ /* function to move some data out of our buffers */
+-ssize_t __copy_buffer(void *dst, void **src, size_t *boffset, size_t *blen, size_t len)
++ssize_t __copy_buffer(void *dst, char **src, size_t *boffset, size_t *blen, size_t len)
+ {
+-    void *p;
++    char *p;
+     size_t have_len;
+     size_t todo;
+ 
+@@ -260,7 +260,7 @@ ssize_t           httpp_encoding_read(httpp_encoding_t *self, void *buf, size_t
+ 
+     if (ret > 0) {
+         done += ret;
+-        buf  += ret;
++        buf  = (char*)buf + ret;
+         len  -= ret;
+     }
+ 
+@@ -271,14 +271,14 @@ ssize_t           httpp_encoding_read(httpp_encoding_t *self, void *buf, size_t
+         return -1;
+ 
+     done += ret;
+-    buf  += ret;
++    buf  = (char*)buf + ret;
+     len  -= ret;
+ 
+     if (len) {
+         ret = __copy_buffer(buf, &(self->buf_read_decoded), &(self->buf_read_decoded_offset), &(self->buf_read_decoded_len), len);
+         if (ret > 0) {
+             done += ret;
+-            buf  += ret;
++            buf  = (char*)buf + ret;
+             len  -= ret;
+         }
+     }

--- a/ports/libshout/0005-Verify-port-number-length.patch
+++ b/ports/libshout/0005-Verify-port-number-length.patch
@@ -1,0 +1,45 @@
+diff --git a/net/sock.c b/net/sock.c
+--- a/net/sock.c
++++ b/net/sock.c
+@@ -608,7 +608,9 @@ sock_t sock_connect_non_blocking (const char *hostname, unsigned port)
+     hints.ai_family = AF_UNSPEC;
+     hints.ai_socktype = SOCK_STREAM;
+ 
+-    snprintf (service, sizeof (service), "%u", port);
++    int len = snprintf (service, sizeof (service), "%u", port);
++    if (len < 1 || len >= sizeof (service))
++    	return SOCK_ERROR;
+ 
+     if (getaddrinfo (hostname, service, &hints, &head))
+         return SOCK_ERROR;
+@@ -649,7 +651,9 @@ sock_t sock_connect_wto_bind (const char *hostname, int port, const char *bnd, i
+     memset (&hints, 0, sizeof (hints));
+     hints.ai_family = AF_UNSPEC;
+     hints.ai_socktype = SOCK_STREAM;
+-    snprintf (service, sizeof (service), "%u", port);
++    int len = snprintf (service, sizeof (service), "%u", port);
++    if (len < 1 || len >= sizeof (service))
++    	return SOCK_ERROR;
+ 
+     if (getaddrinfo (hostname, service, &hints, &head))
+         return SOCK_ERROR;
+@@ -720,7 +724,7 @@ sock_t sock_get_server_socket (int port, const char *sinterface)
+ {
+     struct sockaddr_storage sa;
+     struct addrinfo hints, *res, *ai;
+-    char service [10];
++    char service [12];
+     int sock;
+ 
+     if (port < 0)
+@ -728,7 +732,9 @@ sock_t sock_get_server_socket (int port, const char *sinterface)
+     hints.ai_family = AF_UNSPEC;
+     hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG | AI_NUMERICSERV | AI_NUMERICHOST;
+     hints.ai_socktype = SOCK_STREAM;
+-    snprintf (service, sizeof (service), "%d", port);
++    int len = snprintf (service, sizeof (service), "%d", port);
++    if (len < 1 || len >= sizeof (service))
++    	return SOCK_ERROR;
+ 
+     if (getaddrinfo (sinterface, service, &hints, &res))
+         return SOCK_ERROR;

--- a/ports/libshout/0006-Handle-unhandled-enum-values-in-switch-statements.patch
+++ b/ports/libshout/0006-Handle-unhandled-enum-values-in-switch-statements.patch
@@ -1,0 +1,29 @@
+diff --git a/src/connection.c b/src/connection.c
+--- a/src/connection.c
++++ b/src/connection.c
+@@ -208,10 +208,13 @@ static shout_connection_return_state_t shout_connection_iter__socket(shout_conne
+                 return SHOUT_RS_ERROR;
+             }
+         break;
++        case SHOUT_SOCKSTATE_TLS_VERIFIED:
++            return SHOUT_RS_DONE;
+ #else
+         case SHOUT_SOCKSTATE_CONNECTED:
+         case SHOUT_SOCKSTATE_TLS_CONNECTING:
+         case SHOUT_SOCKSTATE_TLS_CONNECTED:
++        case SHOUT_SOCKSTATE_TLS_VERIFIED:
+             shout_connection_set_error(con, SHOUTERR_UNSUPPORTED);
+             return SHOUT_RS_ERROR;
+         break;
+@@ -443,6 +446,8 @@ static shout_connection_return_state_t shout_connection_iter__protocol(shout_con
+         case SHOUT_RS_TIMEOUT:
+             shout_connection_set_error(con, SHOUTERR_RETRY);
+         break;
++        case SHOUT_RS_DONE:
++        	return SHOUT_RS_DONE;
+     }
+ 
+     return ret;
+-- 
+2.25.1
+

--- a/ports/libshout/0007-fix-libshout-void-ptr-arithmetic-windows.patch
+++ b/ports/libshout/0007-fix-libshout-void-ptr-arithmetic-windows.patch
@@ -1,0 +1,12 @@
+diff --git a/src/format_webm.c b/src/format_webm.c
+--- a/src/format_webm.c
++++ b/src/format_webm.c
+@@ -437,7 +437,7 @@ static size_t copy_possible(const void *src_base,
+ 
+     if (target_space < to_copy) to_copy = target_space;
+ 
+-    memcpy(target_base + *target_position, src_base + *src_position, to_copy);
++    memcpy((char *)target_base + *target_position, (const char *)src_base + *src_position, to_copy);
+ 
+     *src_position += to_copy;
+     *target_position += to_copy;

--- a/ports/libshout/0008-fix-libshout-ssize_t-windows.patch
+++ b/ports/libshout/0008-fix-libshout-ssize_t-windows.patch
@@ -1,0 +1,18 @@
+diff --git a/include/shout/shout.h.in b/include/shout/shout.h.in
+--- a/include/shout/shout.h.in
++++ b/include/shout/shout.h.in
+@@ -23,8 +23,12 @@
+ #define __LIBSHOUT_SHOUT_H__
+ 
+ #include <sys/types.h>
+-#if defined(WIN32) && !defined(__MINGW64__) && !defined(__MINGW32__)
+-#include <os.h>
++#if defined(_WIN32) && !defined(__MINGW64__) && !defined(__MINGW32__)
++#ifndef _SSIZE_T_DEFINED
++#define _SSIZE_T_DEFINED
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
+ #endif
+ 
+ #include <stdarg.h>

--- a/ports/libshout/0009-fix-sys-paths-windows.patch
+++ b/ports/libshout/0009-fix-sys-paths-windows.patch
@@ -1,0 +1,19 @@
+diff --git a/src/connection.c b/src/connection.c
+--- a/src/connection.c
++++ b/src/connection.c
+@@ -27,6 +27,7 @@
+ #   include <inttypes.h>
+ #endif
+ 
++#ifndef _WIN32    
+ #ifdef HAVE_SYS_SELECT_H
+ #   include <sys/select.h>
+ #else
+@@ -34,6 +35,7 @@
+ #   include <sys/types.h>
+ #   include <unistd.h>
+ #endif
++#endif
+ 
+ #include <shout/shout.h>
+ #include "shout_private.h"

--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -5,6 +5,11 @@ vcpkg_from_gitlab(
     REF "v${VERSION}"
     HEAD_REF master
     SHA512 04dbb567f36269506becc3a50eb5fa263cbc308764c3fc1e59c3ab4833ef944479d0d35af33941214ff86899c40253a0ded095e5e217035848ce2694496720b5
+    PATCHES
+        0006-Handle-unhandled-enum-values-in-switch-statements.patch
+        0007-fix-libshout-void-ptr-arithmetic-windows.patch
+        0008-fix-libshout-ssize_t-windows.patch
+        0009-fix-sys-paths-windows.patch
 )
 
 vcpkg_from_gitlab(
@@ -14,6 +19,12 @@ vcpkg_from_gitlab(
     REF 5de3e8b3b063002d8a9f52122e97f721e1742531
     HEAD_REF master
     SHA512 f064e2b2dd686c7647ba4c5afb9ca7e85b2015643d7a185cc319f47461aacc765e7f9b3e9576e09a73a8af0724a54fafdd7c064756d3c6e97329bb5f77806933
+    PATCHES
+        0001-fix-windows-compat-header.patch
+        0002-fix-strings-h-windows.patch
+        0003-fix-ssize_t-windows.patch
+        0004-fix-void-ptr-arithmetic-windows.patch
+        0005-Verify-port-number-length.patch
 )
 
 vcpkg_from_gitlab(
@@ -28,20 +39,51 @@ vcpkg_from_gitlab(
 file(COPY ${SOURCE_PATH_COMMON}/ DESTINATION ${SOURCE_PATH}/src/common)
 file(COPY ${SOURCE_PATH_M4}/ DESTINATION ${SOURCE_PATH}/m4)
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS")
+    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS")
+endif()
+
 set(FEATURE_OPTIONS "")
 if(NOT "speex" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS "--disable-speex")
+endif()
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    list(APPEND FEATURE_OPTIONS "--disable-examples")    
+    list(APPEND FEATURE_OPTIONS "--disable-tools")
+    list(APPEND FEATURE_OPTIONS "LIBS=-lws2_32 \$LIBS")
 endif()
 
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
+    COPY_SOURCE
     OPTIONS
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_make_install()
+# autoconf bakes CFLAGS=-O into the generated Makefile for MSVC, which overrides the
+# environment CFLAGS set by vcpkg.
+set(make_options_debug "")
+set(make_options_release "")
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+     list(APPEND make_options_debug "CFLAGS=\"$CFLAGS\"" "CXXFLAGS=\"$CXXFLAGS\"")
+     list(APPEND make_options_release "CFLAGS=\"$CFLAGS\"" "CXXFLAGS=\"$CXXFLAGS\"")
+endif()
+
+vcpkg_make_install(
+    OPTIONS_DEBUG ${make_options_debug}
+    OPTIONS_RELEASE ${make_options_release}
+)
 vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/shout.pc" "-lshout" "-llibshout")
+    if(NOT VCPKG_BUILD_TYPE)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/shout.pc" "-lshout" "-llibshout")
+    endif()
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/libshout/vcpkg.json
+++ b/ports/libshout/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libshout",
   "version": "2.4.6",
+  "port-version": 1,
   "description": "A library for communicating with and sending data to an Icecast server.",
   "homepage": "https://gitlab.xiph.org/xiph/icecast-libshout",
   "license": "LGPL-2.0-or-later",
-  "supports": "!windows",
   "dependencies": [
     "libogg",
     "libtheora",
@@ -14,6 +14,10 @@
     {
       "name": "vcpkg-make",
       "host": true
+    },
+    {
+      "name": "winsock2",
+      "platform": "windows"
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5646,7 +5646,7 @@
     },
     "libshout": {
       "baseline": "2.4.6",
-      "port-version": 0
+      "port-version": 1
     },
     "libsigcpp": {
       "baseline": "3.8.1",

--- a/versions/l-/libshout.json
+++ b/versions/l-/libshout.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2fce6eb47b9fa77c32a9e53390df39656e02d391",
+      "version": "2.4.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "755d43d4bb02bfea8f528a9f3db52bd2a610d15e",
       "version": "2.4.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This PR adds Windows/MSVC support for libshout, by applying patches that are derived from patches contributed long time ago to upstream libshout - these contributions were unfortunately ignored by the upstream maintainers:
https://gitlab.xiph.org/xiph/icecast-libshout/-/work_items?show=eyJpaWQiOiIyMzIzIiwiZnVsbF9wYXRoIjoieGlwaC9pY2VjYXN0LWxpYnNob3V0IiwiaWQiOjE3Njk2fQ%3D%3D
https://gitlab.xiph.org/xiph/icecast-libshout/-/work_items?show=eyJpaWQiOiIyMzM0IiwiZnVsbF9wYXRoIjoieGlwaC9pY2VjYXN0LWxpYnNob3V0IiwiaWQiOjE3ODIxfQ%3D%3D
This PR contains improved implementations, but basically they do the same thing as the patches in the upstream contributions.