### PR TITLE
[clap-cleveraudio] Update to 1.2.9

### DIFF
--- a/ports/clap-cleveraudio/portfile.cmake
+++ b/ports/clap-cleveraudio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO free-audio/clap
     REF "${VERSION}"
-    SHA512 627ad083e7403a3ba69ca151757997e6ec7e94f9ee6b165c45e57b5ff0033f66b6fbfe99a8daa55574b86239912bf9f4d3f4377d08db986edbdc53c6ab870ccb
+    SHA512 5637edee7e9d63b7c7eafd0a9f25e6ed4e3670412802578ef1749cde4d16d63ec3f776e233a847b747a8db2e23ae4c6c3eeac84fb18d14f93a47cdf9a11e346b
     HEAD_REF main
 )
 

--- a/ports/clap-cleveraudio/vcpkg.json
+++ b/ports/clap-cleveraudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clap-cleveraudio",
-  "version-semver": "1.2.8",
+  "version-semver": "1.2.9",
   "description": "CLAP is an audio plugin ABI which defines a standard for Digital Audio Workstations and audio plugins to work together",
   "homepage": "https://cleveraudio.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1777,7 +1777,7 @@
       "port-version": 0
     },
     "clap-cleveraudio": {
-      "baseline": "1.2.8",
+      "baseline": "1.2.9",
       "port-version": 0
     },
     "clapack": {

--- a/versions/c-/clap-cleveraudio.json
+++ b/versions/c-/clap-cleveraudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fae5fdcc6eb760792c3a6c1fcd7e6d3e9795ec1",
+      "version-semver": "1.2.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "4bdf4b348793aea98bdc9ab02f563325ac5079c1",
       "version-semver": "1.2.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.2.9
