### PR TITLE
[comms] Update to 5.5.2

### DIFF
--- a/ports/comms/portfile.cmake
+++ b/ports/comms/portfile.cmake
@@ -1,11 +1,12 @@
-#header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commschamp/comms
     REF "v${VERSION}"
-    SHA512 9ed5d9040acc440e0a07fc8ffb4fac3bc6f9b1bc70f6eda99af1bec37192762b7f67d16148529399db4114920c210764e933e7c40f34864c36cca2e54dc64a0f
+    SHA512 832228872ab688c7a87f1c89844e490ac1ab36e4be06f61d9ff9182912da79ec84d6b3e63bba0547310c6639a568a0419f036e4a81098f445165e27c1563fc0d
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -18,8 +19,5 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME LibComms CONFIG_PATH lib/LibComms/cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/comms/usage
+++ b/ports/comms/usage
@@ -1,4 +1,0 @@
-The package comms provides CMake targets:
-
-    find_package(LibComms CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE cc::comms)

--- a/ports/comms/vcpkg.json
+++ b/ports/comms/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "comms",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "COMMS is the C++(11) headers only, platform independent library, which makes the implementation of a communication protocol to be an easy and relatively quick process.",
   "homepage": "https://commschamp.github.io/",
   "documentation": "https://github.com/commschamp/comms",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1937,7 +1937,7 @@
       "port-version": 0
     },
     "comms": {
-      "baseline": "5.5.1",
+      "baseline": "5.5.2",
       "port-version": 0
     },
     "comms-ublox": {

--- a/versions/c-/comms.json
+++ b/versions/c-/comms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd2d7b327085bc8ef8d28baa3cb8e1b668f0f70c",
+      "version": "5.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "559b9aedc6f93ce390d09947e6f9d7699265d00e",
       "version": "5.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
