### PR TITLE
[plasma-wayland-protocols] Update to 1.21.0

### DIFF
--- a/ports/plasma-wayland-protocols/portfile.cmake
+++ b/ports/plasma-wayland-protocols/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/plasma-wayland-protocols
     REF "v${VERSION}"
-    SHA512 bd5c5de9980ce1af5e330adbb360a4389f1f40f85431407e2fa46eb113f527d48e1fe932f42c5a28b3e8e5e8b3499a6193d3b0e5711f9a95880e15d889c8cbfb
+    SHA512 4d660d3b5beac22e988e4c1e6573ac35d09ac1d27d87d7726002faa81f01cdcfc76c7b2098fd96377e423e1bc958335612e434dd194aed9f3ae0f4f442847e35
     HEAD_REF master
 )
 
@@ -16,13 +16,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME PlasmaWaylandProtocols CONFIG_PATH lib/cmake/PlasmaWaylandProtocols)
+vcpkg_cmake_config_fixup(PACKAGE_NAME PlasmaWaylandProtocols CONFIG_PATH share/cmake/PlasmaWaylandProtocols)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
 vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/plasma-wayland-protocols/vcpkg.json
+++ b/ports/plasma-wayland-protocols/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "plasma-wayland-protocols",
-  "version": "1.19.0",
+  "version": "1.21.0",
   "description": "The non-standard Wayland protocols use by KDE Plasma",
   "homepage": "https://invent.kde.org/libraries/plasma-wayland-protocols",
-  "supports": "linux",
   "dependencies": [
     "ecm",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7817,7 +7817,7 @@
       "port-version": 4
     },
     "plasma-wayland-protocols": {
-      "baseline": "1.19.0",
+      "baseline": "1.21.0",
       "port-version": 0
     },
     "platform-folders": {

--- a/versions/p-/plasma-wayland-protocols.json
+++ b/versions/p-/plasma-wayland-protocols.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa20a5ad7c0314ea759b4919af01d37f62c64d7b",
+      "version": "1.21.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "70aed4dafc77c5173b135ee99a0e0837673683af",
       "version": "1.19.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.