### PR TITLE
[intrusive-shared-ptr] Update to 1.13

### DIFF
--- a/ports/intrusive-shared-ptr/portfile.cmake
+++ b/ports/intrusive-shared-ptr/portfile.cmake
@@ -4,16 +4,16 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gershnik/intrusive_shared_ptr
     REF "v${VERSION}"
-    SHA512 ba4a3e88368219893ff03e803ba8f03c4bf61e7bd5ff1e5b50fdfa67cc8756719f5ba4ac77a9dd7fe7a5db03c33a51bfb74b7c6bb8100376a0e7c8c22a8690f1
+    SHA512 0a80f6c21c54e8b263a7929334ef1df97d5dfb4f70d08a8b080ff82a99b0965f7414ac5381d12575d18db0f94cb06e946644da2a50aa3aaf26a2de34d33fa322
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS "-DBUILD_TESTING=OFF"
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/isptr PACKAGE_NAME isptr)
+vcpkg_cmake_config_fixup(PACKAGE_NAME isptr)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/intrusive-shared-ptr/usage
+++ b/ports/intrusive-shared-ptr/usage
@@ -2,3 +2,9 @@ intrusive-shared-ptr provides CMake targets:
 
   find_package(isptr CONFIG REQUIRED)
   target_link_libraries(main PRIVATE isptr::isptr)
+
+To use a C++ module instead of headers, intrusive-shared-ptr
+provides a function that adds the module to your target:
+
+  find_package(isptr CONFIG REQUIRED)
+  isptr_add_module(main PRIVATE)

--- a/ports/intrusive-shared-ptr/vcpkg.json
+++ b/ports/intrusive-shared-ptr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "intrusive-shared-ptr",
-  "version": "1.12",
+  "version": "1.13",
   "description": "Intrusive reference counting smart pointer, highly configurable reference counted base class and various adapters. Also known as libisptr.",
   "homepage": "https://github.com/gershnik/intrusive_shared_ptr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4065,7 +4065,7 @@
       "port-version": 7
     },
     "intrusive-shared-ptr": {
-      "baseline": "1.12",
+      "baseline": "1.13",
       "port-version": 0
     },
     "intx": {

--- a/versions/i-/intrusive-shared-ptr.json
+++ b/versions/i-/intrusive-shared-ptr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54f03f032c038119e3f8b533c58fb5dbe57812cb",
+      "version": "1.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "0d7bbacfff53a6c842d76baae3790d77b61dc849",
       "version": "1.12",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

Note that upstream now installs CMake and pkgconfig files in <prefix>/share instead of <prefix>/lib, hence the portfile changes.