### PR TITLE
[rtc-benchmarksuite] Update to 1.0.5

### DIFF
--- a/ports/rtc-benchmarksuite/portfile.cmake
+++ b/ports/rtc-benchmarksuite/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO realtimechris/benchmarksuite
     REF "v${VERSION}"    
-    SHA512 5f10d9c9b57d1e6e8826516ed6fd04af78360731cda378e379ea7d1a8ce651c00558d19722e80129539498a55ecadf13ac7e75b13cedeaee3174805eba026955
+    SHA512 d63a9b42e6d917d6da5775009a632a9a4e79b5e01cdf267aa383e27096a59739f9004d7e8f15ae5e02b286ba07523732f5b86d4cc3b12ec06ba7ebb3b35febcc
     HEAD_REF main
 )
 

--- a/ports/rtc-benchmarksuite/vcpkg.json
+++ b/ports/rtc-benchmarksuite/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rtc-benchmarksuite",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A header-only C++ benchmarking library with cross-platform hardware performance counter integration, providing precise measurements of cycles, instructions, branches, cache behavior, and throughput with minimal overhead.",
   "homepage": "https://github.com/realtimechris/benchmarksuite",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8969,7 +8969,7 @@
       "port-version": 1
     },
     "rtc-benchmarksuite": {
-      "baseline": "1.0.4",
+      "baseline": "1.0.5",
       "port-version": 0
     },
     "rtlsdr": {

--- a/versions/r-/rtc-benchmarksuite.json
+++ b/versions/r-/rtc-benchmarksuite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f96fd09eb00fe17ee8efdf781aa402e3eeb7dfd2",
+      "version": "1.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "412ab86bc1eda796b9b3ea868f61b20ba05fcb30",
       "version": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.0.5
