### PR TITLE
[typecast-ai] update to 1.2.6

### DIFF
--- a/ports/typecast-ai/portfile.cmake
+++ b/ports/typecast-ai/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO neosapience/typecast-sdk
-    REF "v${VERSION}"
-    SHA512 9fafc2b2270de52aaec72d6514aa12a7e21119db59b75e684a35f39bafd746d1e09e78d6a25fc9633abbf82e95b62efcaa0a8100aa49e3231c77de31baf12061
+    REF "typecast-c/v${VERSION}"
+    SHA512 290fcb33d398286d404bdffeea5c970d9cb8ef34840b98b3db1f98e31fe24eb071553b6ad2e90b8848673adbc1db3880719d1846532b1d8f6fe5181183bb3b5a
     HEAD_REF main
+    PATCHES
+        use-vcpkg-cjson.patch
 )
 
 # The C SDK is in the typecast-c subdirectory

--- a/ports/typecast-ai/use-vcpkg-cjson.patch
+++ b/ports/typecast-ai/use-vcpkg-cjson.patch
@@ -1,0 +1,66 @@
+--- a/typecast-c/CMakeLists.txt
++++ b/typecast-c/CMakeLists.txt
+@@ -44,16 +44,15 @@
+ 
+ # Find CURL
+ find_package(CURL REQUIRED)
++find_package(cJSON CONFIG REQUIRED)
+ 
+ # Source files
+ set(TYPECAST_SOURCES
+     src/typecast.c
+-    src/cJSON.c
+ )
+ 
+ set(TYPECAST_HEADERS
+     include/typecast.h
+-    src/cJSON.h
+ )
+ 
+ # Shared library
+@@ -63,10 +62,8 @@
+         PUBLIC
+             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+             $<INSTALL_INTERFACE:include>
+-        PRIVATE
+-            ${CMAKE_CURRENT_SOURCE_DIR}/src
+     )
+-    target_link_libraries(typecast PRIVATE CURL::libcurl)
++    target_link_libraries(typecast PRIVATE CURL::libcurl cjson)
+     target_compile_definitions(typecast PRIVATE TYPECAST_BUILDING_DLL)
+     
+     # Set library version
+@@ -91,10 +88,8 @@
+         PUBLIC
+             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+             $<INSTALL_INTERFACE:include>
+-        PRIVATE
+-            ${CMAKE_CURRENT_SOURCE_DIR}/src
+     )
+-    target_link_libraries(typecast_static PRIVATE CURL::libcurl)
++    target_link_libraries(typecast_static PRIVATE CURL::libcurl cjson)
+     target_compile_definitions(typecast_static PUBLIC TYPECAST_STATIC)
+     
+     set_target_properties(typecast_static PROPERTIES
+--- a/typecast-c/src/typecast.c
++++ b/typecast-c/src/typecast.c
+@@ -29,7 +29,7 @@
+ #include <curl/curl.h>
+ 
+ #include "typecast.h"
+-#include "cJSON.h"
++#include <cjson/cJSON.h>
+ 
+ /* ============================================
+  * Internal Structures
+--- a/typecast-c/cmake/typecastConfig.cmake.in
++++ b/typecast-c/cmake/typecastConfig.cmake.in
+@@ -1,4 +1,8 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(CURL REQUIRED)
++find_dependency(cJSON CONFIG REQUIRED)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/typecastTargets.cmake")
+ check_required_components(typecast)

--- a/ports/typecast-ai/vcpkg.json
+++ b/ports/typecast-ai/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "typecast-ai",
-  "version": "1.2.2",
+  "version": "1.2.6",
   "description": "Text-to-Speech API client library for Typecast AI. Pure C with optional C++ wrapper.",
   "homepage": "https://github.com/neosapience/typecast-sdk",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
+    "cjson",
     {
       "name": "curl",
       "default-features": false

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10405,7 +10405,7 @@
       "port-version": 0
     },
     "typecast-ai": {
-      "baseline": "1.2.2",
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "uchardet": {

--- a/versions/t-/typecast-ai.json
+++ b/versions/t-/typecast-ai.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbf9fc815a102920b5ad1a38bad35f6b5ced5d29",
+      "version": "1.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae0087dac821ed34f8e31a250f2cbf371c1c3426",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
Updates typecast-ai to 1.2.6.

This uses the SDK-specific `typecast-c/v1.2.6` tag and patches the CMake build to consume vcpkg's `cjson` port instead of the bundled cJSON source. This addresses the review feedback on #52516 while moving to the latest released Typecast C SDK version.

Validation:
- ./vcpkg format-manifest ports/typecast-ai/vcpkg.json
- ./vcpkg x-add-version typecast-ai --overwrite-version
- ./vcpkg install typecast-ai --triplet arm64-osx