### PR TITLE
[kservice] New port

### DIFF
--- a/ports/kservice/portfile.cmake
+++ b/ports/kservice/portfile.cmake
@@ -1,0 +1,57 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kservice
+    REF "v${VERSION}"
+    SHA512 b054284a132969b5e064ef5ed55111c72169be13d2e6ede6924e9ef60095beb2227ba5214bad70a519127258cee7b41438c0586945539cd9edccae56a081f546
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+if(VCPKG_TARGET_IS_OSX)
+    # On Darwin platform, the bundled version of 'bison' may be too old (< 3.0).
+    vcpkg_find_acquire_program(BISON)
+    execute_process(
+        COMMAND ${BISON} --version
+        OUTPUT_VARIABLE BISON_OUTPUT
+    )
+    string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" BISON_VERSION "${BISON_OUTPUT}")
+    set(BISON_MAJOR ${CMAKE_MATCH_1})
+    set(BISON_MINOR ${CMAKE_MATCH_2})
+    message(STATUS "Using bison: ${BISON_MAJOR}.${BISON_MINOR}.${CMAKE_MATCH_3}")
+    if(NOT (BISON_MAJOR GREATER_EQUAL 3 AND BISON_MINOR GREATER_EQUAL 0))
+        message(WARNING "${PORT} requires bison version greater than one provided by macOS, please use \`brew install bison\` to install a newer bison.")
+    endif()
+endif()
+
+vcpkg_find_acquire_program(BISON)
+vcpkg_find_acquire_program(FLEX)
+
+get_filename_component(FLEX_DIR "${FLEX}" DIRECTORY)
+get_filename_component(BISON_DIR "${BISON}" DIRECTORY)
+
+vcpkg_add_to_path(PREPEND "${FLEX_DIR}")
+vcpkg_add_to_path(PREPEND "${BISON_DIR}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_KF6DocTools=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME kf6service CONFIG_PATH lib/cmake/KF6Service)
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(
+    TOOL_NAMES kbuildsycoca6
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kservice/vcpkg.json
+++ b/ports/kservice/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "kservice",
+  "version": "6.25.0",
+  "description": "Plugin framework for desktop services",
+  "homepage": "https://invent.kde.org/frameworks/kservice",
+  "documentation": "https://api.kde.org/kservice-index.html",
+  "dependencies": [
+    "ecm",
+    "kconfig",
+    "kcoreaddons",
+    "ki18n",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4608,6 +4608,10 @@
       "baseline": "1.22.2",
       "port-version": 1
     },
+    "kservice": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "ktx": {
       "baseline": "4.4.2",
       "port-version": 0

--- a/versions/k-/kservice.json
+++ b/versions/k-/kservice.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "145fe11890f1b48e3436f483f4dbed8165f1226e",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kservice/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
