### PR TITLE
[kwallet] New port

### DIFF
--- a/ports/kwallet/portfile.cmake
+++ b/ports/kwallet/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kwallet
+    REF "v${VERSION}"
+    SHA512 d871776227b126fa191e850959472ab0de9f186ee1d7d48560b20b2021d8d55c25d214a418fdfe72e8be2c6426c1526a54958d5906d56db32e253dea2d76a21c
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_KWALLETD=OFF
+        -DBUILD_KSECRETD=OFF
+        -DBUILD_KWALLET_QUERY=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_KF6DocTools=ON
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_KF6DocTools
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME kf6wallet CONFIG_PATH lib/cmake/KF6Wallet)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kwallet/vcpkg.json
+++ b/ports/kwallet/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "kwallet",
+  "version": "6.25.0",
+  "description": "Safe desktop-wide storage for passwords",
+  "homepage": "https://invent.kde.org/frameworks/kwallet",
+  "documentation": "https://api.kde.org/kwallet-index.html",
+  "dependencies": [
+    "ecm",
+    "kconfig",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4628,6 +4628,10 @@
       "baseline": "2019-08-06",
       "port-version": 3
     },
+    "kwallet": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kwidgetsaddons": {
       "baseline": "6.25.0",
       "port-version": 0

--- a/versions/k-/kwallet.json
+++ b/versions/k-/kwallet.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "181cc79b2a1175614058f56958391e9a946dc807",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kwallet/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
