### PR TITLE
[fuzztest] add fuzztest port

### DIFF
--- a/ports/fuzztest/fuzztest-config.cmake.in
+++ b/ports/fuzztest/fuzztest-config.cmake.in
@@ -1,0 +1,30 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(absl CONFIG)
+find_dependency(re2 CONFIG)
+find_dependency(GTest CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/fuzztest-targets.cmake")
+
+if(TARGET fuzztest::fuzztest_fuzztest)
+  add_library(fuzztest::fuzztest ALIAS fuzztest::fuzztest_fuzztest)
+endif()
+if(TARGET fuzztest::fuzztest_fuzztest_core)
+  add_library(fuzztest::fuzztest_core ALIAS fuzztest::fuzztest_fuzztest_core)
+endif()
+if(TARGET fuzztest::fuzztest_fuzztest_gtest_main)
+  add_library(fuzztest::fuzztest_gtest_main ALIAS fuzztest::fuzztest_fuzztest_gtest_main)
+endif()
+if(TARGET fuzztest::fuzztest_init_fuzztest)
+  add_library(fuzztest::init_fuzztest ALIAS fuzztest::fuzztest_init_fuzztest)
+endif()
+if(TARGET fuzztest::fuzztest_domain)
+  add_library(fuzztest::domain ALIAS fuzztest::fuzztest_domain)
+endif()
+if(TARGET fuzztest::fuzztest_domain_core)
+  add_library(fuzztest::domain_core ALIAS fuzztest::fuzztest_domain_core)
+endif()
+
+check_required_components(fuzztest)

--- a/ports/fuzztest/patches/vcpkg.patch
+++ b/ports/fuzztest/patches/vcpkg.patch
@@ -1,0 +1,299 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f9f71df..4058fba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,10 +56,11 @@ include(cmake/CompatibilityModeLinkLibFuzzer.cmake)
+ if (FUZZTEST_BUILD_TESTING)
+   enable_testing()
+ 
+-  set(protobuf_PROTOC_EXE "${protobuf_BINARY_DIR}/protoc")
+-  include(${protobuf_SOURCE_DIR}/cmake/protobuf-generate.cmake)
++  include(protobuf-generate)
+ endif ()
+ 
++include_directories("${CMAKE_CURRENT_SOURCE_DIR}/third_party")
++
+ add_subdirectory(common)
+ add_subdirectory(fuzztest)
+ add_subdirectory(fuzztest/grammars)
+@@ -74,3 +75,128 @@ if (FUZZTEST_BUILD_TESTING)
+   add_subdirectory(e2e_tests)
+   add_subdirectory(e2e_tests/testdata)
+ endif ()
++
++include(GNUInstallDirs)
++
++install(DIRECTORY fuzztest common centipede
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++        FILES_MATCHING
++        PATTERN "*.h"
++        PATTERN "*.inc"
++        PATTERN "*_test.cc" EXCLUDE
++        PATTERN "testdata" EXCLUDE
++        PATTERN "testing" EXCLUDE
++        PATTERN "puzzles" EXCLUDE
++        PATTERN "doc" EXCLUDE
++)
++
++install(DIRECTORY grammar_codegen
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++        FILES_MATCHING
++        PATTERN "*.h"
++        PATTERN "*_test.cc" EXCLUDE
++)
++
++set(FUZZTEST_PUBLIC_TARGETS
++
++  fuzztest_bazel
++  fuzztest_blob_file
++  fuzztest_crashing_input_filename
++  fuzztest_defs
++  fuzztest_hash
++  fuzztest_common_logging
++  fuzztest_remote_file
++  fuzztest_sha1
++  fuzztest_status_macros
++  fuzztest_temp_dir
++
++  fuzztest_any
++  fuzztest_compatibility_mode
++  fuzztest_configuration
++  fuzztest_corpus_database
++  fuzztest_coverage
++  fuzztest_escaping
++  fuzztest_fixture_driver
++  fuzztest_flag_name
++  fuzztest_googletest_adaptor
++  fuzztest_io
++  fuzztest_logging
++  fuzztest_meta
++  fuzztest_printer
++  fuzztest_register_fuzzing_mocks
++  fuzztest_registration
++  fuzztest_registry
++  fuzztest_runtime
++  fuzztest_sanitizer_interface
++  fuzztest_seed_seq
++  fuzztest_serialization
++  fuzztest_status
++  fuzztest_subprocess
++  fuzztest_table_of_recent_compares
++  fuzztest_type_support
++
++  fuzztest_absl_helpers
++  fuzztest_core_domains_impl
++  fuzztest_domains_impl
++  fuzztest_in_grammar_impl
++  fuzztest_in_regexp_impl
++  fuzztest_protobuf_domain_impl
++  fuzztest_regexp_dfa
++  fuzztest_utf
++
++  fuzztest_domain
++  fuzztest_domain_core
++  fuzztest_fuzzing_bit_gen
++  fuzztest_fuzztest
++  fuzztest_fuzztest_core
++  fuzztest_fuzztest_gtest_main
++  fuzztest_fuzztest_macros
++  fuzztest_googletest_fixture_adapter
++  fuzztest_init_fuzztest
++  fuzztest_llvm_fuzzer_main
++  fuzztest_llvm_fuzzer_wrapper
++)
++
++foreach(target ${FUZZTEST_PUBLIC_TARGETS})
++  if(TARGET ${target})
++    install(TARGETS ${target}
++            EXPORT fuzztest-targets
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    )
++  endif()
++endforeach()
++
++if(TARGET grammar_domain_code_generator)
++  install(TARGETS grammar_domain_code_generator
++          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++  )
++endif()
++
++install(EXPORT fuzztest-targets
++        FILE fuzztest-targets.cmake
++        NAMESPACE fuzztest::
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/fuzztest"
++)
++
++include(CMakePackageConfigHelpers)
++
++configure_package_config_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/fuzztest-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/fuzztest-config.cmake"
++  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/fuzztest"
++)
++
++write_basic_package_version_file(
++  "${CMAKE_CURRENT_BINARY_DIR}/fuzztest-config-version.cmake"
++  VERSION "2026-02-19"
++  COMPATIBILITY SameMajorVersion
++)
++
++install(FILES
++  "${CMAKE_CURRENT_BINARY_DIR}/fuzztest-config.cmake"
++  "${CMAKE_CURRENT_BINARY_DIR}/fuzztest-config-version.cmake"
++  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/fuzztest"
++)
+diff --git a/cmake/BuildDependencies.cmake b/cmake/BuildDependencies.cmake
+index 25696b8..c12ee26 100644
+--- a/cmake/BuildDependencies.cmake
++++ b/cmake/BuildDependencies.cmake
+@@ -14,107 +14,18 @@
+ 
+ cmake_minimum_required(VERSION 3.19)
+ 
+-include(FetchContent)
++find_package(absl CONFIG REQUIRED)
++find_package(re2 CONFIG REQUIRED)
++find_package(GTest CONFIG REQUIRED)
+ 
+-set(absl_URL https://github.com/abseil/abseil-cpp.git)
+-set(absl_TAG 20260107.1)
++find_package(antlr4-runtime CONFIG REQUIRED)
+ 
+-set(re2_URL https://github.com/google/re2.git)
+-set(re2_TAG 2025-11-05)
+-
+-set(gtest_URL https://github.com/google/googletest.git)
+-set(gtest_TAG v1.17.0)
+-
+-# From https://www.antlr.org/download.html
+-set(antlr_cpp_URL https://www.antlr.org/download/antlr4-cpp-runtime-4.13.2-source.zip)
+-set(antlr_cpp_MD5 bac8aef215ffd7b23a1dde2fcfe3c842)
+-
+-set(proto_URL https://github.com/protocolbuffers/protobuf.git)
+-set(proto_TAG v33.5)
+-
+-set(nlohmann_json_URL https://github.com/nlohmann/json.git)
+-set(nlohmann_json_TAG v3.12.0)
+-
+-set(flatbuffers_URL https://github.com/google/flatbuffers.git)
+-set(flatbuffers_TAG v25.12.19)
+-
+-if(POLICY CMP0135)
+-	cmake_policy(SET CMP0135 NEW)
+-	set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
++if(FUZZTEST_BUILD_FLATBUFFERS)
++  find_package(flatbuffers CONFIG REQUIRED)
+ endif()
+ 
+-FetchContent_Declare(
+-  abseil-cpp
+-  GIT_REPOSITORY ${absl_URL}
+-  GIT_TAG        ${absl_TAG}
+-)
+-
+-FetchContent_Declare(
+-  re2
+-  GIT_REPOSITORY ${re2_URL}
+-  GIT_TAG        ${re2_TAG}
+-)
+-
+-FetchContent_Declare(
+-  googletest
+-  GIT_REPOSITORY ${gtest_URL}
+-  GIT_TAG        ${gtest_TAG}
+-)
+-
+-FetchContent_Declare(
+-  antlr_cpp
+-  URL      ${antlr_cpp_URL}
+-  URL_HASH MD5=${antlr_cpp_MD5}
+-)
+-
+-if (FUZZTEST_BUILD_FLATBUFFERS)
+-  FetchContent_Declare(
+-    flatbuffers
+-    GIT_REPOSITORY ${flatbuffers_URL}
+-    GIT_TAG        ${flatbuffers_TAG}
+-  )
++if(FUZZTEST_BUILD_TESTING)
++  find_package(protobuf CONFIG REQUIRED)
++  find_package(nlohmann_json CONFIG REQUIRED)
+ endif()
+ 
+-if (FUZZTEST_BUILD_TESTING)
+-
+-  FetchContent_Declare(
+-    protobuf
+-    GIT_REPOSITORY ${proto_URL}
+-    GIT_TAG        ${proto_TAG}
+-  )
+-
+-  FetchContent_Declare(
+-    nlohmann_json
+-    GIT_REPOSITORY ${nlohmann_json_URL}
+-    GIT_TAG        ${nlohmann_json_TAG}
+-  )
+-
+-endif ()
+-
+-set(ABSL_PROPAGATE_CXX_STD ON)
+-set(ABSL_ENABLE_INSTALL ON)
+-FetchContent_MakeAvailable(abseil-cpp)
+-
+-set(RE2_BUILD_TESTING OFF)
+-FetchContent_MakeAvailable(re2)
+-
+-set(GTEST_HAS_ABSL ON)
+-FetchContent_MakeAvailable(googletest)
+-
+-FetchContent_MakeAvailable(antlr_cpp)
+-
+-if (FUZZTEST_BUILD_TESTING)
+-
+-  set(protobuf_BUILD_TESTS OFF)
+-  set(protobuf_INSTALL OFF)
+-  FetchContent_MakeAvailable(protobuf)
+-
+-  FetchContent_MakeAvailable(nlohmann_json)
+-
+-endif ()
+-
+-if (FUZZTEST_BUILD_FLATBUFFERS)
+-  set(FLATBUFFERS_BUILD_TESTS OFF)
+-  set(FLATBUFFERS_BUILD_INSTALL OFF)
+-  FetchContent_MakeAvailable(flatbuffers)
+-endif()
+diff --git a/fuzztest/internal/CMakeLists.txt b/fuzztest/internal/CMakeLists.txt
+index 1a674bc..93220b6 100644
+--- a/fuzztest/internal/CMakeLists.txt
++++ b/fuzztest/internal/CMakeLists.txt
+@@ -535,9 +535,11 @@ if (FUZZTEST_BUILD_FLATBUFFERS)
+       --bfbs-gen-embed --gen-name-strings
+     TESTONLY
+   )
+-  add_dependencies(fuzztest_test_flatbuffers_headers
+-    fuzztest_GENERATE_test_flatbuffers_headers
+-  )
++  if(BUILD_TESTING AND FUZZTEST_BUILD_TESTING)
++    add_dependencies(fuzztest_test_flatbuffers_headers
++      fuzztest_GENERATE_test_flatbuffers_headers
++    )
++  endif()
+ endif()
+ 
+ fuzztest_cc_library(
+diff --git a/grammar_codegen/generated_antlr_parser/CMakeLists.txt b/grammar_codegen/generated_antlr_parser/CMakeLists.txt
+index 736c6ef..13bc5e0 100644
+--- a/grammar_codegen/generated_antlr_parser/CMakeLists.txt
++++ b/grammar_codegen/generated_antlr_parser/CMakeLists.txt
+@@ -16,6 +16,5 @@ target_link_libraries(
+ target_include_directories(
+   generated_antlr_parser
+   PUBLIC
+-  ${antlr_cpp_SOURCE_DIR}/runtime/src
+   ${CMAKE_CURRENT_SOURCE_DIR}
+ )
+\ No newline at end of file

--- a/ports/fuzztest/portfile.cmake
+++ b/ports/fuzztest/portfile.cmake
@@ -1,0 +1,76 @@
+# MSVC is not supported by the upstream project.
+if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    message(FATAL_ERROR "FuzzTest requires Clang or GCC. MSVC is not supported.")
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/fuzztest
+    REF "${VERSION}"
+    SHA512 dcfd1596286ee1bdaba654d6b291d048718610b10de5aca09982fd6297f9233826aad81f9ae06a56a5cdeaf67d540c2b4a3145a31a42009772466bc997d321eb
+    HEAD_REF main
+    PATCHES
+        patches/vcpkg.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/fuzztest-config.cmake.in"
+    DESTINATION "${SOURCE_PATH}/cmake")
+
+set(RE2_REF "927f5d53caf8111721e734cf24724686bb745f55")
+vcpkg_download_distfile(RE2_ARCHIVE
+    URLS "https://github.com/google/re2/archive/${RE2_REF}.tar.gz"
+    FILENAME "re2-${RE2_REF}.tar.gz"
+    SHA512 35103a46a6350084f2d09ccfcf4322dac7364c61fbdad8bfcbd41b39990f83a260d2a8cd5ca019a3f24b71faf1588c7dabf07c3dddae5268bcc5b9502b87658a
+)
+
+set(RE2_EXTRACT_DIR "${CURRENT_BUILDTREES_DIR}/re2-vendor")
+file(REMOVE_RECURSE "${RE2_EXTRACT_DIR}")
+file(ARCHIVE_EXTRACT INPUT "${RE2_ARCHIVE}" DESTINATION "${RE2_EXTRACT_DIR}")
+
+file(GLOB RE2_SRC_DIR "${RE2_EXTRACT_DIR}/re2-*")
+file(MAKE_DIRECTORY "${SOURCE_PATH}/third_party/re2"
+    "${SOURCE_PATH}/third_party/util")
+file(COPY "${RE2_SRC_DIR}/re2/prog.h"
+    "${RE2_SRC_DIR}/re2/regexp.h"
+    "${RE2_SRC_DIR}/re2/pod_array.h"
+    "${RE2_SRC_DIR}/re2/sparse_array.h"
+    "${RE2_SRC_DIR}/re2/sparse_set.h"
+    DESTINATION "${SOURCE_PATH}/third_party/re2")
+file(COPY "${RE2_SRC_DIR}/util/utf.h"
+    DESTINATION "${SOURCE_PATH}/third_party/util")
+
+set(FUZZTEST_FEATURE_OPTIONS "")
+if("flatbuffers" IN_LIST FEATURES)
+    list(APPEND FUZZTEST_FEATURE_OPTIONS "-DFUZZTEST_BUILD_FLATBUFFERS=ON")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=17
+        -DFUZZTEST_BUILD_TESTING=OFF
+        -DFUZZTEST_FUZZING_MODE=OFF
+        ${FUZZTEST_FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_tools(TOOL_NAMES grammar_domain_code_generator AUTO_CLEAN)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/fuzztest")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/include/centipede/dso_example"
+    "${CURRENT_PACKAGES_DIR}/include/centipede/tools"
+    "${CURRENT_PACKAGES_DIR}/include/fuzztest/grammars"
+)
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/fuzztest/usage
+++ b/ports/fuzztest/usage
@@ -1,0 +1,4 @@
+The package fuzztest provides CMake targets:
+
+    find_package(fuzztest CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fuzztest::fuzztest fuzztest::fuzztest_gtest_main)

--- a/ports/fuzztest/vcpkg.json
+++ b/ports/fuzztest/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "fuzztest",
+  "version-date": "2026-02-19",
+  "description": [
+    "FuzzTest is a C++ testing framework for writing and executing fuzz tests,",
+    "which are property-based tests executed using coverage-guided fuzzing under the hood."
+  ],
+  "homepage": "https://github.com/google/fuzztest",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "abseil",
+    "antlr4",
+    "gtest",
+    "re2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "flatbuffers": {
+      "description": "Enable FlatBuffers domain support",
+      "dependencies": [
+        "flatbuffers"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3272,6 +3272,10 @@
       "baseline": "0.2.0",
       "port-version": 0
     },
+    "fuzztest": {
+      "baseline": "2026-02-19",
+      "port-version": 0
+    },
     "fuzzylite": {
       "baseline": "6.0",
       "port-version": 6

--- a/versions/f-/fuzztest.json
+++ b/versions/f-/fuzztest.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fc45d5993675cb45a29978822172bc262431de8b",
+      "version-date": "2026-02-19",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.



## integration summary

this port adds FuzzTest Google's property-based fuzz testing framework.

three patches are applied. 

the first replaces all FetchContent calls in BuildDependencies.cmake with find_package, since vcpkg provides dependencies.  
it also adds install rules and CMake package config generation to CMakeLists.txt, which upstream lacks.  

the second adds include(protobuf-generate) instead of the hardcoded FetchContent paths. the third fixes the generated_antlr_parser target to link against antlr4_shared or antlr4_static depending on which target the vcpkg antlr4 port provides and removes a reference to antlr_cpp_SOURCE_DIR that only exists in FetchContent builds.

msvc is not supported because the upstream project explicitly guards against it.  
the fuzzing engine uses Clang specific compiler instrumentation (fsanitize-coverage), some builtin features and POSIX APIs  Even in non fuzzing mode, the compiler check in [CMakeLists.txt, ln 31](https://github.com/google/fuzztest/blob/6d428b093eb95758ec27c92026b7590b51cbaad0/CMakeLists.txt) rejects anything that is not GCC or Clang.

fuzzTest uses two internal re2 headers, re2/prog.h and re2/regexp.h. See https://github.com/google/re2/blob/main/re2/prog.h and the warning in https://github.com/google/re2/blob/main/re2/regexp.h lines 8-14 which states this is a low level interface that may change in backwards incompatible ways.  
the vcpkg re2 port installs only public headers because re2's [CMakeLists.txt, line 138](https://github.com/google/re2/blob/972a15cedd008d846f1a39b2e88ce48d7f166cbd/CMakeLists.txt) sets `RE2_HEADERS` to just filtered_re2.h, re2.h, set.h and stringpiece.h.  
these internal headers are deliberately excluded.

since modifying the re2 port to install private headers would expose unstable api to all re2 consumers, we vendor the exact versions needed.  
the port downloads the re2 source archive at commit 927f5d53caf8111721e734cf24724686bb745f55, which is the same commit used by the vcpkg re2 port, verified by SHA512 from the re2 portfile.

six header files are extracted to a third_party directory and added to the include path. No re2 compilation occurs, the re2 library dependency remains via find_package. 

**note**: if this vendoring approach is not acceptable, the alternative is to patch the re2 port's RE2_HEADERS list.

## Tests

i have performed tests for the following and verified that everything functions correctly on these platforms; i also wrote a test program:

1. gcc 15 and 14 on ubuntu
2. llvm 21 with vs 2026

since i do not have access to a mac environment or other compiler environments, I was unable to test this port on other platforms.
