### PR TITLE
[nvidia-cutlass] Update to 4.5.2

### DIFF
--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIA/cutlass
     REF "v${VERSION}"
-    SHA512 9949cb735a1085b8ee7ab350a3cc681f5e93e26e0ac7fdddeb51f467b8fc0ca6cf96b50f2ae27c005ecb2a38c996a59e0575acf0857bd12f8ff1bbc31c5a05ce
+    SHA512 435bd838b1c89a5fec45c95ac45bec78b3dd641f93665b97a2cea3d4a9a82bddb9d7cd4139afe9d749e5c6e7195521f09aff4871981eddfa546d5bf9b2dc23a3
     HEAD_REF main
 )
 

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nvidia-cutlass",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7189,7 +7189,7 @@
       "port-version": 0
     },
     "nvidia-cutlass": {
-      "baseline": "4.5.1",
+      "baseline": "4.5.2",
       "port-version": 0
     },
     "nvrhi": {

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e38e0d74d21d9537fdde4980b53635382bfb866f",
+      "version": "4.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e01bb8cfecb0d9c24c049f4a003550a303125323",
       "version": "4.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.