### PR TITLE
[chenjunfu2-nbt-cpp] Update to version 2.1.4

### DIFF
--- a/ports/chenjunfu2-nbt-cpp/portfile.cmake
+++ b/ports/chenjunfu2-nbt-cpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO chenjunfu2/NBT_CPP
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 2d54f55f2cc5de6d5633e0a794cc2f4c67da30eea26ab158c37cde7135b63fa1f8b149cff042a3fa2670dec0dfb5f354a28bf55a561310e83bca98709943bb98
+    SHA512 79f040dee1cb5d4cdf20474e8dfa8d79641c45911de46d120d366cd2efa5c77e09d5c4b6f6e629efc5fb6ccd950c82396c217381aeab5d621373300ee75791aa
 )
 
 # install

--- a/ports/chenjunfu2-nbt-cpp/vcpkg.json
+++ b/ports/chenjunfu2-nbt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "chenjunfu2-nbt-cpp",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A header-only C++ library for [NBT(Named Binary Tag)]",
   "homepage": "https://github.com/chenjunfu2/NBT_CPP",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1725,7 +1725,7 @@
       "port-version": 5
     },
     "chenjunfu2-nbt-cpp": {
-      "baseline": "2.1.3",
+      "baseline": "2.1.4",
       "port-version": 0
     },
     "chipmunk": {

--- a/versions/c-/chenjunfu2-nbt-cpp.json
+++ b/versions/c-/chenjunfu2-nbt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5690b05e200c2a0a72bc40cee7b603292c494c31",
+      "version": "2.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2af49564a200ad0112385f426b27ad33778905e1",
       "version": "2.1.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.