### PR TITLE
[sfcgal] Enable arm64 support

### DIFF
--- a/ports/sfcgal/vcpkg.json
+++ b/ports/sfcgal/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "sfcgal",
   "version": "2.3.0",
+  "port-version": 1,
   "description": "sfcgal is a C++ wrapper library around CGAL with the aim of supporting ISO 191007:2013 and OGC Simple Features for 3D operations.",
   "homepage": "https://gitlab.com/SFCGAL/SFCGAL",
   "license": "LGPL-2.0-or-later",
-  "supports": "(x64 & (windows | osx | linux)) | (arm64 & osx)",
+  "supports": "(x64 | arm64) & (linux | windows | osx)",
   "dependencies": [
     "cgal",
     "eigen3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9246,7 +9246,7 @@
     },
     "sfcgal": {
       "baseline": "2.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sfgui": {
       "baseline": "1.0.0",

--- a/versions/s-/sfcgal.json
+++ b/versions/s-/sfcgal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "168ed6a226cb085c2c13309a89c013e519a99996",
+      "version": "2.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6b9daa3e00139de23b2b5af06c9fb7bb81ca0685",
       "version": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

