### PR TITLE
[libass] Update to 0.17.5

### DIFF
--- a/ports/libass/arm64-windows-asm.patch
+++ b/ports/libass/arm64-windows-asm.patch
@@ -1,8 +1,8 @@
 diff --git a/libass/meson.build b/libass/meson.build
-index 5251c2f..a3429bb 100644
+index 9eda958..cf057b9 100644
 --- a/libass/meson.build
 +++ b/libass/meson.build
-@@ -70,6 +70,28 @@ if enable_asm
+@@ -92,6 +92,28 @@ if enable_asm
  
      if asm_is_nasm
          libass_src += asm_sources
@@ -30,12 +30,12 @@ index 5251c2f..a3429bb 100644
 +        endforeach
      else
          asm_lib = static_library(
-             'libass_asm',
+             'ass_asm',
 diff --git a/meson.build b/meson.build
-index 4b1c24e..b82233e 100644
+index 91a0435..5b4c568 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -207,7 +207,9 @@ endif
+@@ -246,7 +246,9 @@ endif
  enable_asm = false
  # used in libass/meson.build
  asm_is_nasm = false
@@ -45,8 +45,7 @@ index 4b1c24e..b82233e 100644
  
  # ASM architecture variables
  asm_option = get_option('asm')
-@@ -276,6 +278,10 @@ if not asm_option.disabled()
-         enable_asm = true
+@@ -322,6 +324,10 @@ if not asm_option.disabled()
          conf.set('ARCH_AARCH64', 1)
          if host_system == 'darwin'
              asm_args += '-DPREFIX'

--- a/ports/libass/portfile.cmake
+++ b/ports/libass/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libass/libass
     REF ${VERSION}
-    SHA512 08762623dd09e3034699ba9d11b70d1f6cc6b2e3b38aa897b07efef1364e76141df484e70ed27888cf3595b77d072cdb5e8abbbfa560e33ca21f87872e24df8d
+    SHA512 8dfea8ef3043ace28efa8a6ae4d6a443fd19d49ad19a521a642e7ec3a7c6f97284cda16d479e168ce30bd560f7e05a0675c9f3fde872bb92ed650343499a57b1
     HEAD_REF master
     PATCHES
         arm64-windows-asm.patch

--- a/ports/libass/vcpkg.json
+++ b/ports/libass/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libass",
-  "version": "0.17.4",
-  "port-version": 1,
+  "version": "0.17.5",
   "description": "libass is a portable subtitle renderer for the ASS/SSA (Advanced Substation Alpha/Substation Alpha) subtitle format",
   "homepage": "https://github.com/libass/libass",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4769,8 +4769,8 @@
       "port-version": 0
     },
     "libass": {
-      "baseline": "0.17.4",
-      "port-version": 1
+      "baseline": "0.17.5",
+      "port-version": 0
     },
     "libassert": {
       "baseline": "2.2.1",

--- a/versions/l-/libass.json
+++ b/versions/l-/libass.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8e97c53a641b18215840ed8db049b65ee636bb6f",
+      "git-tree": "9d59f6df16e0dc5a99abac4269492a9c28d66823",
       "version": "0.17.5",
       "port-version": 0
     },

--- a/versions/l-/libass.json
+++ b/versions/l-/libass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e97c53a641b18215840ed8db049b65ee636bb6f",
+      "version": "0.17.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd06e48b7d2929fbda6f29a28455fbbd5acc018c",
       "version": "0.17.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.17.5
