### PR TITLE
[nanoprintf] Update to 0.6.1

### DIFF
--- a/ports/nanoprintf/portfile.cmake
+++ b/ports/nanoprintf/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO charlesnicholson/nanoprintf
     REF "v${VERSION}"
-    SHA512 adcfa75a283d181785dd969f100909f57d1b45c8ccc8325e6d9b5f6b59ce7aabab01c9ff78b91bd93ffa079eb9926200452ffabffff6b297c81b1af5d3586214
+    SHA512 725109f10e41b2c7a3dd0b03cc0f71028246ca1e9a85e7bf6737baaaacbf47655e0d2a659b2fe2bac9166ba3118c7cb7473fdcfc8f3b8027df355ffd8f0775af
     HEAD_REF master
 )
 

--- a/ports/nanoprintf/vcpkg.json
+++ b/ports/nanoprintf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoprintf",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A tiny embeddable printf replacement written in C99",
   "homepage": "https://github.com/charlesnicholson/nanoprintf"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6933,7 +6933,7 @@
       "port-version": 0
     },
     "nanoprintf": {
-      "baseline": "0.6.0",
+      "baseline": "0.6.1",
       "port-version": 0
     },
     "nanorange": {

--- a/versions/n-/nanoprintf.json
+++ b/versions/n-/nanoprintf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6dd5a929bf50c79292821b13173224adaf6630ea",
+      "version": "0.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c78e5e3b8a78e477588a3707d53f614227252606",
       "version": "0.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 0.6.1
