### PR TITLE
[libcap] Update to 2.78

### DIFF
--- a/ports/libcap/portfile.cmake
+++ b/ports/libcap/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${VERSION}.tar.xz"
          "https://www.mirrorservice.org/sites/ftp.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${VERSION}.tar.xz"
     FILENAME "libcap-${VERSION}.tar.xz"
-    SHA512 c783cb43ffb40eb005fb880efe18e72667c743af79d647f67ee3201d5ff1e64446f9c850cced935a04b63a8ee3380bbf28dd91e2dfbcbddb561c8d096da610d0
+    SHA512 a156a8708dd59f13400f701f4e1ddc81f915fe4e7b32f93a328f7d6f030b7a004fb985fa9ac60812dfffeb8ad860d2e1f59895485497350250efd9378682626b
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libcap/vcpkg.json
+++ b/ports/libcap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcap",
-  "version": "2.77",
+  "version": "2.78",
   "description": "A library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.",
   "homepage": "https://sites.google.com/site/fullycapable/",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4821,7 +4821,7 @@
       "port-version": 4
     },
     "libcap": {
-      "baseline": "2.77",
+      "baseline": "2.78",
       "port-version": 0
     },
     "libcbor": {

--- a/versions/l-/libcap.json
+++ b/versions/l-/libcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7325b051f19e1cfb1afdd745a55291086b5e436b",
+      "version": "2.78",
+      "port-version": 0
+    },
+    {
       "git-tree": "f0ad3332cef684d5db40df87da067adc339cfe1f",
       "version": "2.77",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
