### PR TITLE
[re2] export low-level headers

### DIFF
--- a/ports/re2/001-expose-low-level-headers.patch
+++ b/ports/re2/001-expose-low-level-headers.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d6ae962..a6ea44d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -140,6 +140,14 @@ set(RE2_HEADERS
+     re2/re2.h
+     re2/set.h
+     re2/stringpiece.h
++
++    # low-level headers that are not part of the public API but are needed for other google libraries that depend on RE2, such as fuzztest.
++    #see: https://github.com/google/fuzztest/blob/b73724d4866c22d9b64c152a2d7ac22c7ca94168/fuzztest/internal/domains/regexp_dfa.cc
++    re2/prog.h
++    re2/regexp.h
++    re2/pod_array.h
++    re2/sparse_array.h
++    re2/sparse_set.h
+     )
+ 
+ add_library(re2 ${RE2_SOURCES})
+@@ -259,6 +267,7 @@ if(RE2_INSTALL)
+           FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR}
+           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/re2
+           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++  install(FILES util/utf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/re2/util)
+   install(EXPORT re2Targets
+           DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2
+           NAMESPACE re2::)

--- a/ports/re2/portfile.cmake
+++ b/ports/re2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 927f5d53caf8111721e734cf24724686bb745f55
     SHA512 35103a46a6350084f2d09ccfcf4322dac7364c61fbdad8bfcbd41b39990f83a260d2a8cd5ca019a3f24b71faf1588c7dabf07c3dddae5268bcc5b9502b87658a
     HEAD_REF master
+    PATCHES
+        001-expose-low-level-headers.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/re2/vcpkg.json
+++ b/ports/re2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "re2",
   "version-date": "2025-11-05",
+  "port-version": 1,
   "description": "RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.",
   "homepage": "https://github.com/google/re2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8710,7 +8710,7 @@
     },
     "re2": {
       "baseline": "2025-11-05",
-      "port-version": 0
+      "port-version": 1
     },
     "reaction": {
       "baseline": "1.0.0",

--- a/versions/r-/re2.json
+++ b/versions/r-/re2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68397d4355de027155ba57df721490384d02990c",
+      "version-date": "2025-11-05",
+      "port-version": 1
+    },
+    {
       "git-tree": "cdb3c6b427f023ec6af6433f0494e2e7ec0f708f",
       "version-date": "2025-11-05",
       "port-version": 0


### PR DESCRIPTION
this change includes a patch for re2's CMakeLists.txt to ensure that low-level re2 headers are copied during installation rather than being skipped.

***

certain headers of re2 are used by other google projects (e.g., fuzztest: https://github.com/google/fuzztest/blob/b73724d4866c22d9b64c152a2d7ac22c7ca94168/fuzztest/internal/domains/regexp_dfa.cc, includes prog.h).

prior to this change, these headers were not included in the install list and thus were not copied to the installed folder, which prevented other google projects using re2 from being ported to vcpkg.


related to: https://github.com/microsoft/vcpkg/pull/52565

***

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
