### PR TITLE
[mongoose] update to 7.22

### DIFF
--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cesanta/mongoose
     REF "${VERSION}"
-    SHA512 ffaa1e1e00dcaa1a2416e7fc38864600b6e25ca3212b096d5fd35c44329bbf89c72e5c356b4a77ae1711a75b99e59d04666a59ce553f123d825a99053c24b8d5
+    SHA512 49ddbb53a1d0588bfef06b6c541479ddc26d5a9e7ded34900f6e9e44023fcf54db7dca8ddf6d8a1cadd8ccf65ec3672dc692973cbbd083847efef19810e8df42
     HEAD_REF master
 )
 

--- a/ports/mongoose/vcpkg.json
+++ b/ports/mongoose/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose",
-  "version": "7.21",
+  "version": "7.22",
   "description": "Embedded web server / embedded networking library",
   "homepage": "https://cesanta.com/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6685,7 +6685,7 @@
       "port-version": 0
     },
     "mongoose": {
-      "baseline": "7.21",
+      "baseline": "7.22",
       "port-version": 0
     },
     "monkeys-audio": {

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f6fbb2e533b914879c953143a78ed525afb9f4b",
+      "version": "7.22",
+      "port-version": 0
+    },
+    {
       "git-tree": "6551aee1b7e24e31f2aa2a1900461bce912aa4c4",
       "version": "7.21",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
