### PR TITLE
[comms-ublox] update to 3.0.7

### DIFF
--- a/ports/comms-ublox/portfile.cmake
+++ b/ports/comms-ublox/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commschamp/cc.ublox.generated
-    REF v1.0
-    SHA512 0c487d9409c2f2818024f6232832762527250c3563a5eb5c639ad49943931ceb24616db2432bcd752d1a84820ec5349522510dcd202508641d3f29aef41ca1e5
+    REF v${VERSION}
+    SHA512 18ce224f1e4ec86e5b19c948f76d6adee3e0d0344218025bef82ae08b2937c863de107161fab38cc8c959c944876c510e9df249a8aa26132e6c099069a2dd713
     HEAD_REF master
 )
 
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME ublox CONFIG_PATH lib/ublox/cmake)
+vcpkg_cmake_config_fixup(PACKAGE_NAME cc_ublox CONFIG_PATH lib/cc_ublox/cmake)
 # currently this is only a header only library. after moving lib/ublox to share this lib path will be empty
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/comms-ublox/vcpkg.json
+++ b/ports/comms-ublox/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "comms-ublox",
-  "version-semver": "1.0.0",
+  "version-semver": "3.0.7",
   "description": "UBLOX (UBX) protocol definition, generated out of cc.ublox.commsdsl",
   "homepage": "https://commschamp.github.io/",
   "documentation": "https://github.com/commschamp/cc.ublox.generated",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1941,7 +1941,7 @@
       "port-version": 0
     },
     "comms-ublox": {
-      "baseline": "1.0.0",
+      "baseline": "3.0.7",
       "port-version": 0
     },
     "commsdsl": {

--- a/versions/c-/comms-ublox.json
+++ b/versions/c-/comms-ublox.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53e43d9a3c6740e33641edcb000457d2962939f6",
+      "version-semver": "3.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "a129592b8ecf08fed15abaeab8b8c229ef16d045",
       "version-semver": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/commschamp/cc.ublox.generated/releases/tag/v3.0.7
