### PR TITLE
[ace] Upgrade to ACE 8.0.6 and TAO 4.0.6

### DIFF
--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -8,20 +8,22 @@ if("tao" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE%2BTAO-src-${VERSION}.tar.gz"
         FILENAME "ACE-TAO-src-${VERSION}.tar.gz"
-        SHA512 cf582fc5cb5e1df33ade341c73f841d84048b804a354a5095ef2eb44bc32e3edcb42e9335bcabff3363582552ce8e4c64d96625b2ec20cf6e5b346320b3f422c
+        SHA512 955fa4de8df23fb0b91c3d7b3d6a23c2e16b15d16305efda874688bfa1cd3c9f6f7997d2cc19585daab1781bba7daca397179453d652edfc06b513f6028518c6
     )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 137b0310b5b134939446e53ebe4a1af151b4bf272b85327733e4a6142ec5b424d78c61dee90dfb1f645d707ba19935a850250a82156973b0da2de121da148b6a
+        SHA512 eb7ac914438136cf98a3952bdd1d43543729019812b13509a6d805465f9016ec866dc6f07aed0a489555d3ac54c1ebe931ffd74a0687e29086bc5b063ab25cbc
     )
 endif()
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        zlib.patch
 )
 
 set(ACE_ROOT "${SOURCE_PATH}")
@@ -128,6 +130,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
   vcpkg_msbuild_install(
     SOURCE_PATH "${SOURCE_PATH}"
     PROJECT_SUBPATH "${PROJECT_SUBPATH}"
+    OPTIONS "/p:UseMultiToolTask=false" # tao_idl uses static temp file buffers; parallel custom builds cause mkstemp name collisions on Windows
   )
 
   # ACE itself does not define an install target, so it is not clear which

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ace",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/ports/ace/zlib.patch
+++ b/ports/ace/zlib.patch
@@ -1,0 +1,24 @@
+diff --git a/MPC/config/zlib.mpb b/MPC/config/zlib.mpb
+index 731935a..af8ee02 100644
+--- a/MPC/config/zlib.mpb
++++ b/MPC/config/zlib.mpb
+@@ -14,9 +14,16 @@ feature(zlib) {
+   macros   += ZLIB
+ 
+   specific(prop:windows) {
+-    Debug::lit_libs += zlibd
+-    Release::lit_libs += zlib
++    Debug::lit_libs += zd
++    Release::lit_libs += z
+   } else {
+-    lit_libs += z
++    Debug::lit_libs += zd
++    Release::lit_libs += z
++  }
++  specific(prop:static) {
++    Debug::lit_libs += zsd
++    Debug::lit_libs -= zd
++    Release::lit_libs += zs
++    Release::lit_libs -= z
+   }
+ }

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e3ab66fd54d2cb0695689595627cf0af27fea0f",
+      "version": "8.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ed0e66d8367b7b26695923ba6e903190be5505a",
       "version": "8.0.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -29,7 +29,7 @@
       "port-version": 1
     },
     "ace": {
-      "baseline": "8.0.5",
+      "baseline": "8.0.6",
       "port-version": 0
     },
     "acl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

As there was no response in #51655 since a month, restored a old branch of me and updates to include @dg0yt comment. If I understand #51235 correctly, Unix has now also `zd` for the debug zlib library?

The strange syntax `zlib.mpb` was the only one I found that seemed to work. Unfortunately, it didn't worked to write the Debug/Release values directly without the dummy "if" statement. An empty `specific` didn't work either. According to AI, `specific(prop:windows, !prop:windows)` should also work, but this also doesn't really look any better.