### PR TITLE
[workflow] update to 1.0.1

### DIFF
--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sogou/workflow
     REF "v${VERSION}"
-    SHA512 ed38ce31c39d5f51497379f4184c7890d30b1e683973cd363f7921e628cf1d731bbbbe77f8cece1195cea2199e64d503ea4ed2bfb350d09fc22c862abd497577
+    SHA512 a2befaa1042ff6a37f03869972ac7408dc8527a8f381a5fd3262e06ff3d766b14d9ecccab822278fd69f8236e8d74b68248f985ab2a85da941b28e8bbbd6dffd
     HEAD_REF master
     PATCHES
         cmake.diff

--- a/ports/workflow/vcpkg.json
+++ b/ports/workflow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "C++ Parallel Computing and Asynchronous Networking Engine",
   "homepage": "https://github.com/sogou/workflow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11009,7 +11009,7 @@
       "port-version": 3
     },
     "workflow": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "workflow-win": {

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b9cea8616275995f9abbe730b46624f573c9c1f",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1cef31dac1e04135b5ea3b54fcd3cfe974c3a193",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/sogou/workflow/releases/tag/v1.0.1
