### PR TITLE
[alibabacloud-oss-cpp-sdk-v2] Update to 0.1.1

### DIFF
--- a/ports/alibabacloud-oss-cpp-sdk-v2/portfile.cmake
+++ b/ports/alibabacloud-oss-cpp-sdk-v2/portfile.cmake
@@ -2,10 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aliyun/alibabacloud-oss-cpp-sdk-v2
     REF "${VERSION}"
-    SHA512 d5bc33e237dcf5a74327e35c4550e83eb7d8cf1ced7dbe82fc72bb46ea201dd7a069145711dfa4f949e21938178f712cac2e147114e7bd0d3fb307a38824d672
+    SHA512 f3dac1785188a65a90e53c7f152882387e571a502cece1094ce3d26a0edc1e9d6d87b34b16babe6c1e1527940b652629dd024f21c85b4598a3db49a20dc680bd
     HEAD_REF main
-    PATCHES
-        fix-unused-variables.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -16,6 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         openssl     USE_SYSTEM_OPENSSL
         encryption  ENABLE_ENCRYPTION
         rtti        ENABLE_RTTI
+        tinyxml2    USE_SYSTEM_TINYXML2
 )
 
 vcpkg_cmake_configure(
@@ -33,11 +32,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME alibabacloud_oss_v2 CONFIG_PATH lib/cmake/
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(
-    FILE_LIST "${SOURCE_PATH}/LICENSE"
-    COMMENT [[Consult sdk/src/thirdparty/* in the original source tree for authoritative third-party notices.
-
-As of 2026-06-09, vendored code under sdk/src/thirdparty includes:
-- tinyxml2
-- base64]]
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/THIRD_PARTY_NOTICES")

--- a/ports/alibabacloud-oss-cpp-sdk-v2/vcpkg.json
+++ b/ports/alibabacloud-oss-cpp-sdk-v2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-oss-cpp-sdk-v2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Alibaba Cloud OSS SDK for C++ v2",
   "homepage": "https://github.com/aliyun/alibabacloud-oss-cpp-sdk-v2",
   "license": "Apache-2.0 AND Zlib AND BSL-1.0",
@@ -48,6 +48,12 @@
     },
     "rtti": {
       "description": "Build with run-time type information"
+    },
+    "tinyxml2": {
+      "description": "Use system tinyxml2 for XML parsing",
+      "dependencies": [
+        "tinyxml2"
+      ]
     },
     "winhttp": {
       "description": "WinHTTP transport (Windows only)",

--- a/versions/a-/alibabacloud-oss-cpp-sdk-v2.json
+++ b/versions/a-/alibabacloud-oss-cpp-sdk-v2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f9f63587b8603866e06fefe0b4155fce361ed4c",
+      "version": "0.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b889c42b31a594874213157d6b52347298aa4020",
       "version": "0.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,7 +89,7 @@
       "port-version": 0
     },
     "alibabacloud-oss-cpp-sdk-v2": {
-      "baseline": "0.1.0",
+      "baseline": "0.1.1",
       "port-version": 0
     },
     "aliyun-oss-c-sdk": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
