### PR TITLE
[icu] force absolute path on install script.

### DIFF
--- a/ports/icu/fix-install-sh-relative-path.patch
+++ b/ports/icu/fix-install-sh-relative-path.patch
@@ -1,0 +1,13 @@
+diff --git a/source/icudefs.mk.in b/source/icudefs.mk.in
+--- a/source/icudefs.mk.in
++++ b/source/icudefs.mk.in
+@@ -100,8 +100,8 @@
+ # Installation programs
+
+ MKINSTALLDIRS = $(SHELL) $(top_srcdir)/mkinstalldirs
+
+-INSTALL = @INSTALL@
++INSTALL = $(top_srcdir)/install-sh -c
+ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_DATA = @INSTALL_DATA@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         disable-static-prefix.patch # https://gitlab.kitware.com/cmake/cmake/-/issues/16617; also mingw.
+        fix-install-sh-relative-path.patch
         fix_bsd_and_solaris.patch
         fix_parallel_build_on_windows.patch
         fix-python-path-with-spaces.patch
@@ -18,8 +19,6 @@ vcpkg_extract_source_archive(SOURCE_PATH
         subdirs.patch
         vcpkg-cross-data.patch
 )
-
-vcpkg_replace_string("${SOURCE_PATH}/source/icudefs.mk.in" "INSTALL = @INSTALL@" "INSTALL = \$(top_srcdir)/install-sh -c")
 
 vcpkg_find_acquire_program(PYTHON3)
 set(ENV{PYTHON} "${PYTHON3}")

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -19,6 +19,8 @@ vcpkg_extract_source_archive(SOURCE_PATH
         vcpkg-cross-data.patch
 )
 
+vcpkg_replace_string("${SOURCE_PATH}/source/icudefs.mk.in" "INSTALL = @INSTALL@" "INSTALL = \$(top_srcdir)/install-sh -c")
+
 vcpkg_find_acquire_program(PYTHON3)
 set(ENV{PYTHON} "${PYTHON3}")
 

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "78.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3926,7 +3926,7 @@
     },
     "icu": {
       "baseline": "78.3",
-      "port-version": 1
+      "port-version": 2
     },
     "ideep": {
       "baseline": "2026-03-31",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "15bf22129d7b57bdb32f59d9e3ca96b959abb522",
+      "git-tree": "f7d7be1f6027b4f30fcb1be15119c7e65ac1c2b6",
       "version": "78.3",
       "port-version": 2
     },

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15bf22129d7b57bdb32f59d9e3ca96b959abb522",
+      "version": "78.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "931a42f3b3b911ba73dbbaead4c1e0037a158efd",
       "version": "78.3",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #51839
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

## Additional context

### User environment:

```pwsh
> fastfetch -l none -s "OS:Kernel:Shell:WM:Terminal:CPU:Memory:Swap"
OS: Windows 11 Pro Insider Preview (26H2) x86_64
Kernel: WIN32_NT 10.0.26300.8758
Shell: PowerShell 7.7.0
WM: Desktop Window Manager 10.0.26100.8687
Terminal: Windows Terminal Preview 1.25.1322.0
CPU: 12th Gen Intel(R) Core(TM) i7-12850HX (16+8) @ 4.80 GHz
Memory: 17.10 GiB / 31.69 GiB (54%)
Swap: 174.04 MiB / 13.50 GiB (1%)
```

### Build output
- Test on `x64-windows` and `x64-windows-static` only.

```pwsh
> vcpkg install icu:x64-windows-static --recurse --binarysource=clear
Computing installation plan...
The following packages will be built and installed:
    icu:x64-windows-static@78.3#2
Detecting compiler hash for triplet x64-windows-static...
Compiler found: C:/Program Files/Microsoft Visual Studio/18/Insiders/VC/Tools/MSVC/14.51.36231/bin/Hostx64/x64/cl.exe
Installing 1/1 icu:x64-windows-static@78.3#2...
icu:x64-windows-static@78.3#2 package ABI: 87adb63f818d567cd56cc5c4fb25517479b59b8cdff71b7685de173e10ee17a6
Building icu:x64-windows-static@78.3#2...
-- Using cached icu4c-78.3-sources.tgz
-- Cleaning sources at C:/Users/<username>/scoop/apps/vcpkg/current/buildtrees/icu/src/icu4c-78-34dc699e15.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source C:/Users/<username>/scoop/apps/vcpkg/current/downloads/icu4c-78.3-sources.tgz
-- Applying patch disable-static-prefix.patch
-- Applying patch fix_bsd_and_solaris.patch
-- Applying patch fix_parallel_build_on_windows.patch
-- Applying patch fix-python-path-with-spaces.patch
-- Applying patch mh-darwin.patch
-- Applying patch mh-mingw.patch
-- Applying patch mh-msys-msvc.patch
-- Applying patch subdirs.patch
-- Applying patch vcpkg-cross-data.patch
-- Using source at C:/Users/<username>/scoop/apps/vcpkg/current/buildtrees/icu/src/icu4c-78-34dc699e15.clean
-- Getting CMake variables for x64-windows-static
-- Loading CMake variables from C:/Users/<username>/scoop/apps/vcpkg/current/buildtrees/icu/cmake-get-vars_C_CXX-x64-windows-static.cmake.log
-- Using cached msys2-autoconf-wrapper-20250528-1-any.pkg.tar.zst
-- Using cached msys2-automake-wrapper-20250528-1-any.pkg.tar.zst
-- Using cached msys2-autoconf-archive-2024.10.16-1-any.pkg.tar.zst
-- Using cached msys2-binutils-2.45.1-1-x86_64.pkg.tar.zst
-- Using cached msys2-libtool-2.5.4-4-x86_64.pkg.tar.zst
-- Using cached msys2-make-4.4.1-2-x86_64.pkg.tar.zst
-- Using cached msys2-which-2.23-4-x86_64.pkg.tar.zst
-- Using cached msys2-bash-5.3.009-1-x86_64.pkg.tar.zst
-- Using cached msys2-coreutils-8.32-5-x86_64.pkg.tar.zst
-- Using cached msys2-file-5.46-2-x86_64.pkg.tar.zst
-- Using cached msys2-gawk-5.3.2-1-x86_64.pkg.tar.zst
-- Using cached msys2-grep-1~3.0-7-x86_64.pkg.tar.zst
-- Using cached msys2-gzip-1.14-1-x86_64.pkg.tar.zst
-- Using cached msys2-diffutils-3.12-1-x86_64.pkg.tar.zst
-- Using cached msys2-pkgconf-2.5.1-1-x86_64.pkg.tar.zst
-- Using cached msys2-sed-4.9-1-x86_64.pkg.tar.zst
-- Using cached msys2-msys2-runtime-3.6.5-1-x86_64.pkg.tar.zst
-- Using cached msys2-autoconf2.72-2.72-3-any.pkg.tar.zst
-- Using cached msys2-automake1.16-1.16.5-1-any.pkg.tar.zst
-- Using cached msys2-automake1.17-1.17-1-any.pkg.tar.zst
-- Using cached msys2-automake1.18-1.18.1-1-any.pkg.tar.zst
-- Using cached msys2-libiconv-1.18-1-x86_64.pkg.tar.zst
-- Using cached msys2-libintl-0.22.5-1-x86_64.pkg.tar.zst
-- Using cached msys2-zlib-1.3.1-1-x86_64.pkg.tar.zst
-- Using cached msys2-findutils-4.10.0-2-x86_64.pkg.tar.zst
-- Using cached msys2-tar-1.35-3-x86_64.pkg.tar.zst
-- Using cached msys2-gmp-6.3.0-2-x86_64.pkg.tar.zst
-- Using cached msys2-gcc-libs-15.2.0-1-x86_64.pkg.tar.zst
-- Using cached msys2-libbz2-1.0.8-4-x86_64.pkg.tar.zst
-- Using cached msys2-liblzma-5.8.2-1-x86_64.pkg.tar.zst
-- Using cached msys2-libzstd-1.5.7-1-x86_64.pkg.tar.zst
-- Using cached msys2-libreadline-8.3.003-1-x86_64.pkg.tar.zst
-- Using cached msys2-mpfr-4.2.2-1-x86_64.pkg.tar.zst
-- Using cached msys2-libpcre-8.45-5-x86_64.pkg.tar.zst
-- Using cached msys2-m4-1.4.19-2-x86_64.pkg.tar.zst
-- Using cached msys2-perl-5.40.3-1-x86_64.pkg.tar.zst
-- Using cached msys2-ncurses-6.5.20240831-2-x86_64.pkg.tar.zst
-- Using cached msys2-libxcrypt-4.5.2-1-x86_64.pkg.tar.zst
-- Using msys root at C:/Users/<username>/scoop/apps/vcpkg/current/downloads/tools/msys2/19f68f647e350a23
-- Configuring x64-windows-static-dbg
-- Configuring x64-windows-static-rel
-- Using cached msys2-autoconf-wrapper-20250528-1-any.pkg.tar.zst
-- Using cached msys2-automake-wrapper-20250528-1-any.pkg.tar.zst
-- Using cached msys2-autoconf-archive-2024.10.16-1-any.pkg.tar.zst
-- Using cached msys2-binutils-2.45.1-1-x86_64.pkg.tar.zst
-- Using cached msys2-libtool-2.5.4-4-x86_64.pkg.tar.zst
-- Using cached msys2-make-4.4.1-2-x86_64.pkg.tar.zst
-- Using cached msys2-which-2.23-4-x86_64.pkg.tar.zst
-- Using cached msys2-bash-5.3.009-1-x86_64.pkg.tar.zst
-- Using cached msys2-coreutils-8.32-5-x86_64.pkg.tar.zst
-- Using cached msys2-file-5.46-2-x86_64.pkg.tar.zst
-- Using cached msys2-gawk-5.3.2-1-x86_64.pkg.tar.zst
-- Using cached msys2-grep-1~3.0-7-x86_64.pkg.tar.zst
-- Using cached msys2-gzip-1.14-1-x86_64.pkg.tar.zst
-- Using cached msys2-diffutils-3.12-1-x86_64.pkg.tar.zst
-- Using cached msys2-pkgconf-2.5.1-1-x86_64.pkg.tar.zst
-- Using cached msys2-sed-4.9-1-x86_64.pkg.tar.zst
-- Using cached msys2-msys2-runtime-3.6.5-1-x86_64.pkg.tar.zst
-- Using cached msys2-autoconf2.72-2.72-3-any.pkg.tar.zst
-- Using cached msys2-automake1.16-1.16.5-1-any.pkg.tar.zst
-- Using cached msys2-automake1.17-1.17-1-any.pkg.tar.zst
-- Using cached msys2-automake1.18-1.18.1-1-any.pkg.tar.zst
-- Using cached msys2-libiconv-1.18-1-x86_64.pkg.tar.zst
-- Using cached msys2-libintl-0.22.5-1-x86_64.pkg.tar.zst
-- Using cached msys2-zlib-1.3.1-1-x86_64.pkg.tar.zst
-- Using cached msys2-findutils-4.10.0-2-x86_64.pkg.tar.zst
-- Using cached msys2-tar-1.35-3-x86_64.pkg.tar.zst
-- Using cached msys2-gmp-6.3.0-2-x86_64.pkg.tar.zst
-- Using cached msys2-gcc-libs-15.2.0-1-x86_64.pkg.tar.zst
-- Using cached msys2-libbz2-1.0.8-4-x86_64.pkg.tar.zst
-- Using cached msys2-liblzma-5.8.2-1-x86_64.pkg.tar.zst
-- Using cached msys2-libzstd-1.5.7-1-x86_64.pkg.tar.zst
-- Using cached msys2-libreadline-8.3.003-1-x86_64.pkg.tar.zst
-- Using cached msys2-mpfr-4.2.2-1-x86_64.pkg.tar.zst
-- Using cached msys2-libpcre-8.45-5-x86_64.pkg.tar.zst
-- Using cached msys2-m4-1.4.19-2-x86_64.pkg.tar.zst
-- Using cached msys2-perl-5.40.3-1-x86_64.pkg.tar.zst
-- Using cached msys2-ncurses-6.5.20240831-2-x86_64.pkg.tar.zst
-- Using cached msys2-libxcrypt-4.5.2-1-x86_64.pkg.tar.zst
-- Using msys root at C:/Users/<username>/scoop/apps/vcpkg/current/downloads/tools/msys2/19f68f647e350a23
-- Building/Installing x64-windows-static-dbg
-- Making target 'all' for x64-windows-static-dbg
-- Making target 'install' for x64-windows-static-dbg
-- Building/Installing x64-windows-static-rel
-- Making target 'all' for x64-windows-static-rel
-- Making target 'install' for x64-windows-static-rel
-- Installing: C:/Users/<username>/scoop/apps/vcpkg/current/packages/icu_x64-windows-static/tools/icu/config/icucross.inc
-- Installing: C:/Users/<username>/scoop/apps/vcpkg/current/packages/icu_x64-windows-static/tools/icu/config/icucross.mk
-- Fixing pkgconfig file: C:/Users/<username>/scoop/apps/vcpkg/current/packages/icu_x64-windows-static/lib/pkgconfig/icu-uc.pc
-- Fixing pkgconfig file: C:/Users/<username>/scoop/apps/vcpkg/current/packages/icu_x64-windows-static/debug/lib/pkgconfig/icu-uc.pc
-- Installing: C:/Users/<username>/scoop/apps/vcpkg/current/packages/icu_x64-windows-static/share/icu/copyright
-- Performing post-build validation
Elapsed time to handle icu:x64-windows-static: 7.6 min
Total install time: 7.6 min
Installed contents are licensed to you by owners. Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Packages installed in this vcpkg installation declare the following licenses:
ICU
icu provides pkg-config modules:

  # International Components for Unicode: Common and Data libraries
  icu-uc

All requested installations completed successfully in: 7.6 min
```
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
