### PR TITLE
[faiss] Add required OpenMP dependency

### DIFF
--- a/ports/faiss/portfile.cmake
+++ b/ports/faiss/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_cmake_configure(
         -DFAISS_ENABLE_MKL=OFF
         -DFAISS_ENABLE_PYTHON=OFF  # Requires SWIG
         -DBUILD_TESTING=OFF
+        --trace-expand
 )
 
 vcpkg_cmake_install()

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "faiss",
   "version": "1.14.3",
+  "port-version": 1,
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://faiss.ai/",
   "license": "MIT",

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2026/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
-    SHA512 1d1dbe7d084ddebc7a80b33dc655e3a707cdbd6141b7eb03fcb4bf809eae8892237e85eb983f8b360bb5fde7e26290e15eb945766c90006a0d565cc382e3e03f
+    SHA512 355a8db490ec2a68c2801644e56178a26416c355792586a6c1c904de116e26f8602bc344e7172181c9d92c4c9e696319243e16405460fad87b23ee997a3ef9da
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.53.2",
-  "port-version": 1,
+  "version": "3.53.3",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2922,7 +2922,7 @@
     },
     "faiss": {
       "baseline": "1.14.3",
-      "port-version": 0
+      "port-version": 1
     },
     "fakeit": {
       "baseline": "2.5.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9669,8 +9669,8 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.53.2",
-      "port-version": 1
+      "baseline": "3.53.3",
+      "port-version": 0
     },
     "sqlitecpp": {
       "baseline": "3.3.3",

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c926e18e45ec1b45746420c755ff9b419d387b9e",
+      "version": "1.14.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "81d13e5dd7057f8a35422430953ead558deac421",
       "version": "1.14.3",
       "port-version": 0

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e25652685566012d0818e1883d31276e413f7845",
+      "version": "3.53.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ccab6992dbd68ec1b0ebcb0bb13d92af37c7beb",
       "version": "3.53.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The CI failed in #52616, due to
```
CMake Error at /Users/vcpkg/Data/work/1/s/downloads/tools/cmake-4.3.3-osx/cmake-4.3.3-macos-universal/CMake.app/Contents/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES)
Call Stack (most recent call first):
  /Users/vcpkg/Data/work/1/s/downloads/tools/cmake-4.3.3-osx/cmake-4.3.3-macos-universal/CMake.app/Contents/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:654 (_FPHSA_FAILURE_MESSAGE)
  /Users/vcpkg/Data/work/1/s/downloads/tools/cmake-4.3.3-osx/cmake-4.3.3-macos-universal/CMake.app/Contents/share/cmake-4.3/Modules/FindOpenMP.cmake:734 (find_package_handle_standard_args)
  /Users/vcpkg/Data/work/1/s/scripts/buildsystems/vcpkg.cmake:939 (_find_package)
  faiss/CMakeLists.txt:696 (find_package)
```

Draft to verify the issue first with a forces rebuild due to changed port-version.
