### PR TITLE
[supernovas]: patch for incorrect use of `gmtime_s()`

### DIFF
--- a/ports/supernovas/gmtime_s.patch
+++ b/ports/supernovas/gmtime_s.patch
@@ -1,0 +1,24 @@
+diff --git a/src/c99/iers.c b/src/c99/iers.c
+index dbbae395..b27da1a6 100644
+--- a/src/c99/iers.c
++++ b/src/c99/iers.c
+@@ -64,7 +64,6 @@
+ #  define NTP_UNIX_EPOCH              2208988800LL      ///< [s] NTP timestamp of UNIX epoch (1970 Jan 1)
+ 
+ #ifdef _MSC_VER
+-#  define gmtime_r        gmtime_s                      ///< MSC equivalent
+ #  define strtok_r        strtok_s                      ///< MSVC equivalent
+ #endif
+ 
+@@ -823,7 +822,11 @@ int novas_lookup_leap(time_t t) {
+     struct tm tm = {};
+     char str[40] = {'\0'};
+     unlock_leap();
++#ifdef _MSC_VER
++    gmtime_s(&tm, &t);
++#else
+     gmtime_r(&t, &tm);
++#endif
+     strftime(str, sizeof(str), "%c", &tm);
+     return novas_error(NOVAS_INVALID_LEAP, ERANGE, fn, "Time %s is beyond the leap seconds coverage range", str);
+   }

--- a/ports/supernovas/portfile.cmake
+++ b/ports/supernovas/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 ae74ec6969c2902c53e5f1cc9bf66f41e97a838c7c0c0e6167a3f24050676a22f9ebd67f0b90a11105790b45166e3d1e79a4e9e264ccf68d4fb330785090f409
     HEAD_REF main
-    PATCHES pkgconfig.patch
+    PATCHES pkgconfig.patch gmtime_s.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/supernovas/vcpkg.json
+++ b/ports/supernovas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "supernovas",
   "version": "1.7.1",
+  "port-version": 1,
   "description": "SuperNOVAS C/C++ high-precision astrometry library",
   "homepage": "https://sigmyne.github.io/SuperNOVAS/",
   "documentation": "https://sigmyne.github.io/SuperNOVAS/doc/html/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9926,7 +9926,7 @@
     },
     "supernovas": {
       "baseline": "1.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sushant-wayal-stringhash": {
       "baseline": "1.1.0",

--- a/versions/s-/supernovas.json
+++ b/versions/s-/supernovas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1871128734a57b5da9f3684eeba0895656715872",
+      "version": "1.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6f619d894812ada8b3fd6199e1f71dce48c8bedf",
       "version": "1.7.1",
       "port-version": 0


### PR DESCRIPTION
Patch for upstream [Issue #355](https://github.com/Sigmyne/SuperNOVAS/issues/355).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

