### PR TITLE
[nng] Update to 1.12.0

### DIFF
--- a/ports/nng/portfile.cmake
+++ b/ports/nng/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanomsg/nng
     REF "v${VERSION}"
-    SHA512 cceedb16ecc3849f49b76a2ebfee4ba46a6d22b429aa9a5a94354c92aa643c5dcffd325f854ecba8ebe341c514f8288576a7be392f3a03a69152873fdd277fe3
+    SHA512 15f659805ea8a66a6dc4273a0f28ab1593ef82038ef0870207b1b5ab8c621df15d27253f1fd9c87e5a705f3198ef5eebe9ecaa0e2479af8bc5bb847fcebf2d06
     HEAD_REF master
 )
 

--- a/ports/nng/vcpkg.json
+++ b/ports/nng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nng",
-  "version": "1.11",
+  "version": "1.12.0",
   "description": "nanomsg-next-gen, lightweight messaging library",
   "homepage": "https://nng.nanomsg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7093,7 +7093,7 @@
       "port-version": 3
     },
     "nng": {
-      "baseline": "1.11",
+      "baseline": "1.12.0",
       "port-version": 0
     },
     "nngpp": {

--- a/versions/n-/nng.json
+++ b/versions/n-/nng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a079433e30e117f146ad5d436e18c4c4a44122d",
+      "version": "1.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0920bc1109fd6952a4f361bffe8bc16209dd788",
       "version": "1.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.12.0
