### PR TITLE
[minizip-ng] Add zlib-ng feature for zlib compression

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -20,18 +20,28 @@ vcpkg_check_features(
         openssl MZ_OPENSSL
         bzip2   MZ_BZIP2
         lzma    MZ_LZMA
-        zlib    MZ_ZLIB
         zstd    MZ_ZSTD
 )
+
+# Select the zlib flavor explicitly. minizip-ng's "auto" mode searches for
+# zlib-ng first and then falls back to zlib; pinning MZ_ZLIB_FLAVOR ensures we
+# build against whichever library the selected feature pulled in.
+if("zlib-ng" IN_LIST FEATURES)
+    set(ZLIB_OPTIONS -DMZ_ZLIB=ON -DMZ_ZLIB_FLAVOR=zlib-ng)
+elseif("zlib" IN_LIST FEATURES)
+    set(ZLIB_OPTIONS -DMZ_ZLIB=ON -DMZ_ZLIB_FLAVOR=zlib)
+else()
+    set(ZLIB_OPTIONS -DMZ_ZLIB=OFF)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        ${ZLIB_OPTIONS}
         -DMZ_FETCH_LIBS=OFF
         -DMZ_LIB_SUFFIX=-ng
         -DMZ_ICONV=OFF
-        -DCMAKE_DISABLE_FIND_PACKAGE_ZLIBNG=ON # minizip-ng 4.0.10 searches for zlib-ng first before zlib - we provide zlib
 )
 
 vcpkg_cmake_install()

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "minizip-ng",
   "version": "4.1.0",
+  "port-version": 1,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",
@@ -62,6 +63,12 @@
       "description": "Enables ZLIB compression",
       "dependencies": [
         "zlib"
+      ]
+    },
+    "zlib-ng": {
+      "description": "Enables ZLIB compression using zlib-ng instead of zlib",
+      "dependencies": [
+        "zlib-ng"
       ]
     },
     "zstd": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6638,7 +6638,7 @@
     },
     "minizip-ng": {
       "baseline": "4.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "mio": {
       "baseline": "2023-03-03",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69e49d80fc74b7c98aa51d97869d43d6fae8be91",
+      "version": "4.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b6677369c4d8c677604963a4f97f075db0d18948",
       "version": "4.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #52615.

minizip-ng (a project under the zlib-ng umbrella) can build its zlib compression against either the original zlib or zlib-ng, selected via the upstream MZ_ZLIB_FLAVOR option. Previously the port hard-depended on zlib and explicitly disabled zlib-ng detection.

This PR adds a `zlib-ng` feature that pulls in the zlib-ng port and selects the zlib-ng flavor, while pinning the existing `zlib` feature to the zlib flavor. Pinning the flavor explicitly also lets us drop the CMAKE_DISABLE_FIND_PACKAGE_ZLIBNG workaround.

Built and verified on x64-linux: the default (zlib) build links against zlib, and the new zlib-ng feature links against zlib-ng. Both configurations build successfully.