### PR TITLE
[consteig] Update to 1.2.0

### DIFF
--- a/ports/consteig/portfile.cmake
+++ b/ports/consteig/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MitchellThompkins/consteig
     REF "${VERSION}"
-    SHA512 5ac9458afcdf3e4dd9827eadfc84e0328b60bf9f075ec743d7517ad2205bd7d9a11b0b154ca5be1d1e61273700743379c1118be6ca5b50cbb6c9c3f41224dc97
+    SHA512 8cb4d324eb11b1dd873e60ca47ddcc082fdfffa08723387fc47abd93f7eb14cb27eb148d66be7a59588f4ee55c4aac585752ffcb9c0f95fac6f42cb8a11e1a92
     HEAD_REF main
 )
 

--- a/ports/consteig/vcpkg.json
+++ b/ports/consteig/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "consteig",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Header-only C++17 constexpr library for compile-time eigenvalue and eigenvector computation",
   "homepage": "https://github.com/MitchellThompkins/consteig",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1973,7 +1973,7 @@
       "port-version": 0
     },
     "consteig": {
-      "baseline": "1.1.2",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "constexpr": {

--- a/versions/c-/consteig.json
+++ b/versions/c-/consteig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d9c3eb25d372bed993cb38996dfdefa45795aed",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b29fecf7062a3ba5700d9a866880900f0e57c4d3",
       "version": "1.1.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.2.0
