### PR TITLE
[tinyexr] Update to 3.1.0

### DIFF
--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyexr
     REF "v${VERSION}"
-    SHA512 736388fada2dd83ca78e6fa1110ff7142be626dfb2225096cd207caf092e952c63f7537af4074b1926681d5df40ab23bafda77fca0a88b5ba8986a75e3d72dfe
+    SHA512 b158487518db27dde6865ebb11cbd210a1e5feb77b9ead77e66cf314cb893a55326040cc92198ec51ed7fc861d7f1b676459e6440e7d3d0263aa1e88cde7dc25
     HEAD_REF master
     PATCHES
         fixtargets.patch

--- a/ports/tinyexr/vcpkg.json
+++ b/ports/tinyexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyexr",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Library to load and save OpenEXR(.exr) images",
   "homepage": "https://github.com/syoyo/tinyexr",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10173,7 +10173,7 @@
       "port-version": 2
     },
     "tinyexr": {
-      "baseline": "3.0.0",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "tinyfiledialogs": {

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0f10855fd85c7f002b68657472547adf2607abb",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5edc094f2f230f582dea0bdcf3ecab4bcd98a1eb",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

https://github.com/syoyo/tinyexr/releases/tag/v3.1.0