### PR TITLE
[cpptrace] add wasm support

### DIFF
--- a/ports/cpptrace/emscripten-platform.diff
+++ b/ports/cpptrace/emscripten-platform.diff
@@ -1,0 +1,12 @@
+diff --git a/src/platform/platform.hpp b/src/platform/platform.hpp
+--- a/src/platform/platform.hpp
++++ b/src/platform/platform.hpp
+@@ -8,7 +8,7 @@
+ #if defined(_WIN32)
+  #undef IS_WINDOWS
+  #define IS_WINDOWS 1
+-#elif defined(__linux)
++#elif defined(__linux) || defined(__EMSCRIPTEN__)
+  #undef IS_LINUX
+  #define IS_LINUX 1
+ #elif defined(__APPLE__)

--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 e88edddbcdd423d49ed3adb02cf70580ee3a56065db4d81ca69d3f9f6d9b64ac27734842ca3b6d8ff45a548c25900a88f979e39d777af422a153e586d26ac5b5
     HEAD_REF main
     PATCHES
-        emscripten-platform.diff # treat emscripten as a linux-like platform; inert on other targets
+        emscripten-platform.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 e88edddbcdd423d49ed3adb02cf70580ee3a56065db4d81ca69d3f9f6d9b64ac27734842ca3b6d8ff45a548c25900a88f979e39d777af422a153e586d26ac5b5
     HEAD_REF main
+    PATCHES
+        emscripten-platform.diff # treat emscripten as a linux-like platform; inert on other targets
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -11,12 +13,24 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         libunwind CPPTRACE_UNWIND_WITH_LIBUNWIND
 )
 
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    # Emscripten exposes no stack-unwinding or symbol back-end, so build a no-op tracer.
+    set(BACKEND_OPTIONS
+        -DCPPTRACE_UNWIND_WITH_NOTHING=ON
+        -DCPPTRACE_GET_SYMBOLS_WITH_NOTHING=ON
+    )
+else()
+    set(BACKEND_OPTIONS
+        -DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON 
-        -DCPPTRACE_USE_EXTERNAL_ZSTD=ON 
+        -DCPPTRACE_USE_EXTERNAL_ZSTD=ON
         -DCPPTRACE_VCPKG=ON
+        ${BACKEND_OPTIONS}
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpptrace",
   "version": "1.0.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
   "homepage": "https://github.com/jeremy-rifkin/cpptrace",
   "license": "MIT",

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "libdwarf",
-      "platform": "!windows | mingw"
+      "platform": "(!windows | mingw) & !emscripten"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "cpptrace": {
       "baseline": "1.0.4",
-      "port-version": 1
+      "port-version": 2
     },
     "cppunit": {
       "baseline": "1.15.1",

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2b56cefacd320cef0b4ea7e4c0bd4408c2410e5",
+      "git-tree": "83534ef55f5d412b27110843bc66de1b7f321d85",
       "version": "1.0.4",
       "port-version": 2
     },

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2b56cefacd320cef0b4ea7e4c0bd4408c2410e5",
+      "version": "1.0.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "ad66212ea6ab61a94e2b5f228577c8453bc120ed",
       "version": "1.0.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.