### PR TITLE
[libassert] add wasm support

### DIFF
--- a/ports/libassert/emscripten-platform.diff
+++ b/ports/libassert/emscripten-platform.diff
@@ -1,0 +1,12 @@
+diff --git a/src/common.hpp b/src/common.hpp
+--- a/src/common.hpp
++++ b/src/common.hpp
+@@ -48,7 +48,7 @@
+ #if defined(_WIN32)
+  #undef IS_WINDOWS
+  #define IS_WINDOWS 1
+-#elif defined(__linux)
++#elif defined(__linux) || defined(__EMSCRIPTEN__)
+  #undef IS_LINUX
+  #define IS_LINUX 1
+ #elif defined(__APPLE__)

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 877f7ddac1b3ffa77d6c30b9aa4c6bf2a32bd3089b5348b75b4f52ef474cf6ee1f754bab5f0396e3ee3df83f9a438a5154c0fefce683c479b2f3a8adaef3c0a7
     HEAD_REF main
     PATCHES
-        emscripten-platform.diff # treat emscripten as a linux-like platform; inert on other targets
+        emscripten-platform.diff
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)

--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 877f7ddac1b3ffa77d6c30b9aa4c6bf2a32bd3089b5348b75b4f52ef474cf6ee1f754bab5f0396e3ee3df83f9a438a5154c0fefce683c479b2f3a8adaef3c0a7
     HEAD_REF main
+    PATCHES
+        emscripten-platform.diff # treat emscripten as a linux-like platform; inert on other targets
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)

--- a/ports/libassert/vcpkg.json
+++ b/ports/libassert/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libassert",
   "version": "2.2.1",
+  "port-version": 1,
   "description": "The most over-engineered C++ assertion library",
   "homepage": "https://github.com/jeremy-rifkin/libassert",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4774,7 +4774,7 @@
     },
     "libassert": {
       "baseline": "2.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libassuan": {
       "baseline": "3.0.2",

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e962c3c0ed2eed14469272bc237fd8f64be6281",
+      "git-tree": "3075f9e8094dde8d0353e700bff505cea81495c6",
       "version": "2.2.1",
       "port-version": 1
     },

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e962c3c0ed2eed14469272bc237fd8f64be6281",
+      "version": "2.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "4ab5a1843ee05a1535282abfb68f84edb62265d6",
       "version": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.