### PR TITLE
[xmlsec] Add windows RC info

### DIFF
--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -94,6 +94,24 @@ set(CMAKE_STATIC_LIBRARY_PREFIX "lib")
 add_library(xmlsec1 ${SOURCESXMLSEC})
 add_library(xmlsec1-openssl ${SOURCESXMLSECOPENSSL})
 
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set_property(SOURCE win32/version.rc APPEND PROPERTY COMPILE_DEFINITIONS
+        RC_VERSION_MAJOR=${XMLSEC_VERSION_MAJOR}
+        RC_VERSION_MINOR=${XMLSEC_VERSION_MINOR}
+        RC_VERSION_MICRO=${XMLSEC_VERSION_SUBMINOR}
+    )
+    target_sources(xmlsec1 PRIVATE win32/version.rc)
+    target_compile_definitions(xmlsec1 PRIVATE
+        "RC_FILENAME=\"libxmlsec1.dll\""
+        "RC_DESCRIPTION=\"XML Security Library\""
+    )
+    target_sources(xmlsec1-openssl PRIVATE win32/version.rc)
+    target_compile_definitions(xmlsec1-openssl PRIVATE
+        "RC_FILENAME=\"libxmlsec1-openssl.dll\""
+        "RC_DESCRIPTION=\"XML Security Library - OpenSSL\""
+    )
+endif()
+
 target_include_directories(xmlsec1 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xmlsec",
   "version": "1.3.12",
+  "port-version": 1,
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11150,7 +11150,7 @@
     },
     "xmlsec": {
       "baseline": "1.3.12",
-      "port-version": 0
+      "port-version": 1
     },
     "xnnpack": {
       "baseline": "2024-08-20",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c857a3eaedef5087eace91ba829959771208afb5",
+      "version": "1.3.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "1901799554a6b159d94753b9b0ab2dcc24e70840",
       "version": "1.3.12",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
