### PR TITLE
[atkmm] Update to 2.36.4

### DIFF
--- a/ports/atkmm/portfile.cmake
+++ b/ports/atkmm/portfile.cmake
@@ -7,7 +7,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" ATKMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnome.org/pub/GNOME/sources/atkmm/${ATKMM_MAJOR_MINOR}/atkmm-${VERSION}.tar.xz"
     FILENAME "atkmm-${VERSION}.tar.xz"
-    SHA512 2c2513b5c5fd7a5c9392727325c7551c766d4d51b8089fbea7e8043cde97d07c9b1f98a4a693f30835e4366e9236e28e092c2480a78415d77c5cb72e9432344f
+    SHA512 268a16bae365427c13ae5f318c0913782ddfdd705dd577407424f2b08a2454acc9a6435c67abcd1eef3986c7ca0e23936c78179269fd844dde402c69d2c95976
 )
 
 vcpkg_extract_source_archive(
@@ -27,6 +27,8 @@ vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
 file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME readme.txt)
 file(INSTALL "${SOURCE_PATH}/README.win32.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/atkmm/vcpkg.json
+++ b/ports/atkmm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "atkmm",
-  "version": "2.36.3",
+  "version": "2.36.4",
   "description": "atkmm is the official C++ interface for the ATK accessibility toolkit library. It may be used, for instance, by user interfaces implemented with gtkmm.",
   "homepage": "https://www.gtkmm.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/atkmm.json
+++ b/versions/a-/atkmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94f05887e2b5bf9b88fd699a62417cca19eb6c29",
+      "version": "2.36.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b42bc112850ef59493e65d67cf5bbfb40011fac",
       "version": "2.36.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -377,7 +377,7 @@
       "port-version": 11
     },
     "atkmm": {
-      "baseline": "2.36.3",
+      "baseline": "2.36.4",
       "port-version": 0
     },
     "atl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
