### PR TITLE
[qtwebengine] Improve node failure diagnostics

### DIFF
--- a/ports/qtwebengine/node-wrapper-diagnostics.diff
+++ b/ports/qtwebengine/node-wrapper-diagnostics.diff
@@ -1,0 +1,24 @@
+diff --git a/src/3rdparty/chromium/third_party/node/node.py b/src/3rdparty/chromium/third_party/node/node.py
+index 3af0f1d9ee..20516742f5 100644
+--- a/src/3rdparty/chromium/third_party/node/node.py
++++ b/src/3rdparty/chromium/third_party/node/node.py
+@@ -32,9 +32,15 @@ def RunNode(cmd_parts, stdout=None):
+   stdout, stderr = process.communicate()
+ 
+   if process.returncode != 0:
+-    # Handle cases where stderr is empty, even though the command failed, for
+-    # example https://github.com/microsoft/TypeScript/issues/615
+-    err = stderr if len(stderr) > 0 else stdout
+-    raise RuntimeError('Command \'%s\' failed\n%s' % (' '.join(cmd), err))
++    details = [
++        'Command \'%s\' failed with exit code %d' %
++            (' '.join(cmd), process.returncode),
++        'Working directory: %s' % os.getcwd(),
++        'stdout:',
++        stdout,
++        'stderr:',
++        stderr,
++    ]
++    raise RuntimeError('\n'.join(details))
+ 
+   return stdout

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -13,6 +13,7 @@ set(${PORT}_PATCHES
       #"pkg-config.diff"
       "rpath.diff"
       "include-dir-order.diff"
+      "node-wrapper-diagnostics.diff"
 )
 
 set(qtwebengine_target "${VCPKG_TARGET_TRIPLET}-${VCPKG_CMAKE_SYSTEM_NAME}")

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.11.1",
+  "port-version": 1,
   "description": "Qt modules for rendering web and PDF content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8570,7 +8570,7 @@
     },
     "qtwebengine": {
       "baseline": "6.11.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwebsockets": {
       "baseline": "6.11.1",

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa9371eee2255a22028bb2706483742f33d95149",
+      "version": "6.11.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dd7f00da04426952df330785997501ae4ede11b3",
       "version": "6.11.1",
       "port-version": 0


### PR DESCRIPTION
GPT 5.5 asked this when I asked it to help figure out why we have intermittent qtwebengine failures in the lab e.g. https://dev.azure.com/vcpkg/public/_build/results?buildId=133835:

> Print the node command exit code, working directory, stdout, and stderr when Chromium's node wrapper fails so intermittent Rollup failures have actionable logs.
