### PR TITLE
[soatable] add new port

### DIFF
--- a/ports/soatable/portfile.cmake
+++ b/ports/soatable/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bbalouki/soatable
+    REF "v${VERSION}"
+    SHA512 0c51a4557e563a8b3216a72a837e50db739743453f71d6c7ff24ab74f8785201da037c8bd30804e53b940f92e1e5cf9500485a5c8bede01dc2442a01b6ea967d
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSOATABLE_BUILD_TESTS=OFF
+        -DSOATABLE_BUILD_EXAMPLES=OFF
+        -DSOATABLE_BUILD_BENCHMARKS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "soatable"
+    CONFIG_PATH "lib/cmake/soatable"
+)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+# An interface library installs no binaries.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/soatable/usage
+++ b/ports/soatable/usage
@@ -1,0 +1,4 @@
+soatable provides CMake targets :
+
+    find_package(soatable CONFIG REQUIRED) 
+    target_link_libraries(main PRIVATE soatable::soatable)

--- a/ports/soatable/vcpkg.json
+++ b/ports/soatable/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "soatable",
+  "version": "0.1.0",
+  "description": "Header-only C++23 sparse Structure-of-Arrays table with generational handles.",
+  "homepage": "https://github.com/bbalouki/soatable",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9488,6 +9488,10 @@
       "baseline": "0.8.1",
       "port-version": 0
     },
+    "soatable": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "sobjectizer": {
       "baseline": "5.8.5.1",
       "port-version": 0

--- a/versions/s-/soatable.json
+++ b/versions/s-/soatable.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a96470932e5cfd9ad0a6e4a1b3681093ea2ee649",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [x ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x ] The license declaration in `vcpkg.json` matches what upstream says.
- [x ] The installed as the "copyright" file matches what upstream says.
- [x ] The source code of the component installed comes from an authoritative source.
- [x ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Exactly one version is added in each modified versions file.
