### PR TITLE
[arrow] fix compile errors under gcc-17: missing std::ostringstream i…

### DIFF
--- a/ports/arrow/0008-ostringstring.patch
+++ b/ports/arrow/0008-ostringstring.patch
@@ -1,0 +1,10 @@
+--- a/cpp/src/arrow/util/string_util.h
++++ b/cpp/src/arrow/util/string_util.h
+@@ -17,6 +17,7 @@
+ 
+ #pragma once
+ 
++#include <iosfwd>
+ #include <memory>
+ #include <ostream>
+ #include <string>

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive(
         0004-android-datetime.patch
         0005-cmake-msvcruntime.patch
         0007-use-vcpkg-mimalloc.patch
+        0008-ostringstring.patch
 )
 
 # Check cpp/cmake_modules/DefineOptions.cmake for option dependencies -

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrow",
   "version": "24.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72f4c8f5f7cb8893da5bdca7db90314e25493b16",
+      "version": "24.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5f340d325574ccf47ee4ce62b96a19a817c2aaeb",
       "version": "24.0.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -294,7 +294,7 @@
     },
     "arrow": {
       "baseline": "24.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "arrow-adbc": {
       "baseline": "23",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
