### PR TITLE
[pybind11] fix issue where Python environment was restricted to versi…

### DIFF
--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "pybind11",
   "version": "3.0.4",
+  "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",
   "license": "BSD-3-Clause",
   "dependencies": [
-    {
-      "name": "python3",
-      "default-features": false
-    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,5 +15,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "python3": {
+      "description": "Use vcpkg's python3 when consuming pybind11",
+      "dependencies": [
+        {
+          "name": "python3",
+          "default-features": false
+        }
+      ]
+    }
+  }
 }

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "pybind11",
   "version": "3.1.0",
+  "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",
   "license": "BSD-3-Clause",
   "dependencies": [
-    {
-      "name": "python3",
-      "default-features": false
-    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,5 +15,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "python3": {
+      "description": "Use vcpkg's python3 when consuming pybind11",
+      "dependencies": [
+        {
+          "name": "python3",
+          "default-features": false
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8142,7 +8142,7 @@
     },
     "pybind11": {
       "baseline": "3.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "pystring": {
       "baseline": "1.2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8170,7 +8170,7 @@
     },
     "pybind11": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pystring": {
       "baseline": "1.2.0",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d59b34bb3860c5302b31eec6da3ead7b35c82b9c",
+      "version": "3.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "4ff2a2116aa09c69db38613943b7332825b77de2",
       "version": "3.0.4",
       "port-version": 0

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,9 +1,19 @@
 {
   "versions": [
     {
+      "git-tree": "9e13d2f3deb63b1bb24a45da818535e47ad75905",
+      "version": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5c87a39d28974df64d8ef3f0483dc965656f1f42",
       "version": "3.1.0",
       "port-version": 0
+    },
+    {
+      "git-tree": "d59b34bb3860c5302b31eec6da3ead7b35c82b9c",
+      "version": "3.0.4",
+      "port-version": 1
     },
     {
       "git-tree": "4ff2a2116aa09c69db38613943b7332825b77de2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
