### PR TITLE
[cspice] add fallback download URL

### DIFF
--- a/ports/cspice/portfile.cmake
+++ b/ports/cspice/portfile.cmake
@@ -24,10 +24,15 @@ else()
     endif()
 endif()
 
-set(URL "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N00${VERSION}/C/${SUBPATH}")
 get_filename_component(ext "${SUBPATH}" EXT)
 string(SUBSTRING "${SHA512}" 0 6 subsha)
-vcpkg_download_distfile(ARCHIVE URLS "${URL}" FILENAME "cspice-${subsha}${ext}" SHA512 "${SHA512}")
+vcpkg_download_distfile(ARCHIVE
+    URLS
+        "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N00${VERSION}/C/${SUBPATH}"
+        "https://naif.jpl.nasa.gov/pub/naif/toolkit/C/${SUBPATH}"
+    FILENAME "cspice-${subsha}${ext}"
+    SHA512 "${SHA512}"
+)
 
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/cspice/vcpkg.json
+++ b/ports/cspice/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cspice",
   "version": "67",
-  "port-version": 4,
+  "port-version": 5,
   "description": "NASA C SPICE toolkit",
   "homepage": "https://naif.jpl.nasa.gov/naif/toolkit_C.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2230,7 +2230,7 @@
     },
     "cspice": {
       "baseline": "67",
-      "port-version": 4
+      "port-version": 5
     },
     "ctbench": {
       "baseline": "1.3.4",

--- a/versions/c-/cspice.json
+++ b/versions/c-/cspice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac2b2534a36aab4ba9a4b0cdddd02724cbff0248",
+      "version": "67",
+      "port-version": 5
+    },
+    {
       "git-tree": "fed2cab83c9bc034a31b97b047a3dcea35a762ff",
       "version": "67",
       "port-version": 4


### PR DESCRIPTION
Fixes #52682

Adds the un-versioned NAIF toolkit path as a fallback mirror for the download. Both URLs currently serve byte-identical files (verified: SHA512 `5457f2...da98` matches on both). The versioned `misc/toolkit_N00${VERSION}` path stays first since `pub/naif/toolkit/` always tracks the latest release; the SHA512 check rejects the mirror once a newer toolkit is published, so version pinning is preserved.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.