### PR TITLE
[box3d] add new port

### DIFF
--- a/ports/box3d/msvc-runtime.diff
+++ b/ports/box3d/msvc-runtime.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6360666..09a3dad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,8 +24,6 @@ message(STATUS "CMake C++ compiler: ${CMAKE_CXX_COMPILER_ID}")
+ message(STATUS "CMake system name: ${CMAKE_SYSTEM_NAME}")
+ message(STATUS "CMake host system processor: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+ 
+-# static link to make leak checking easier (_crtBreakAlloc)
+-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+ 
+ if (MSVC OR APPLE OR UNIX)
+ 	option(BOX3D_SANITIZE "Enable sanitizers for some builds" OFF)

--- a/ports/box3d/portfile.cmake
+++ b/ports/box3d/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO erincatto/box3d
+    REF v${VERSION}
+    SHA512 92eaa76bb0e309d10ae2f408183487e5c55eeff71428ae1a0d1b814d892ac532aca10069414c4b0ef998a754f0bf420a41838c94d70073485f6f9260371aa737
+    HEAD_REF main
+    PATCHES
+        msvc-runtime.diff
+        x86-msvc-popcount.diff
+)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    # Upstream's NEON path uses AArch64-only intrinsics (vdivq_f32, vsqrtq_f32)
+    list(APPEND OPTIONS -DBOX3D_DISABLE_SIMD=ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -DBOX3D_SAMPLES=OFF
+        -DBOX3D_BENCHMARKS=OFF
+        -DBOX3D_DOCS=OFF
+        -DBOX3D_PROFILE=OFF
+        -DBOX3D_VALIDATE=OFF
+        -DBOX3D_UNIT_TESTS=OFF
+        -DBOX3D_COMPILE_WARNING_AS_ERROR=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/box3d)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/box3d/base.h" "defined(BOX3D_DLL)" "1")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/box3d/vcpkg.json
+++ b/ports/box3d/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "box3d",
+  "version-semver": "0.1.0",
+  "description": "A 3D physics engine for games",
+  "homepage": "https://github.com/erincatto/box3d",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/box3d/x86-msvc-popcount.diff
+++ b/ports/box3d/x86-msvc-popcount.diff
@@ -1,0 +1,17 @@
+diff --git a/src/ctz.h b/src/ctz.h
+index 483ce4b..b592afb 100644
+--- a/src/ctz.h
++++ b/src/ctz.h
+@@ -72,7 +72,12 @@ static inline uint32_t b3CTZ64( uint64_t block )
+ 
+ static inline int b3PopCount64( uint64_t block )
+ {
++#ifdef _WIN64
+ 	return (int)__popcnt64( block );
++#else
++	// 32-bit fall back
++	return (int)( __popcnt( (uint32_t)block ) + __popcnt( (uint32_t)( block >> 32 ) ) );
++#endif
+ }
+ 
+ #else

--- a/versions/b-/box3d.json
+++ b/versions/b-/box3d.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a9c129249164e17d4ba0e69ec8c0d7272a3e7040",
+      "version-semver": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1472,6 +1472,10 @@
       "baseline": "3.1.1",
       "port-version": 0
     },
+    "box3d": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "braft": {
       "baseline": "2021-26-04",
       "port-version": 7


### PR DESCRIPTION
Issue #52699

Adds a port for [Box3D](https://github.com/erincatto/box3d), Erin Catto's 3D physics engine, following the same structure as the existing `box2d` port (same upstream author and build conventions). One patch removes upstream's hardcoded `CMAKE_MSVC_RUNTIME_LIBRARY` (static CRT) so vcpkg's CRT linkage selection stays in control.

Verified locally on x64-linux: port installs cleanly (debug + release, post-build validation passes) and a consumer smoke test (`find_package(box3d CONFIG)` -> link `box3d::box3d` -> create/step/destroy a `b3World`) builds and runs.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [x] Some other reason (please explain): the repository is ~2 months old and v0.1.0 was tagged 2026-06-30, so the 6-month criterion is not met yet. Mitigating factors: the author is Erin Catto (Box2D, maintained publicly for 15+ years; `box2d` is already a vcpkg port), Box3D is its official 3D successor documented at https://box2d.org/documentation3d/, the repo has ~1.7k stars, upstream CI, and a tagged release with proper CMake install/export rules. There is also an explicit port request from the community (#52699). If maintainers prefer to wait out the 6-month window, happy to park this PR as draft.
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/box3d/versions (404, project too new)
    - [x] The project is amongst the first web search results for "box3d C++": erincatto/box3d is the top result, followed by its README and the official documentation at box2d.org/documentation3d. The name also mirrors the existing `box2d` port from the same author.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port: the library target uses no `find_package` at all; all upstream options (`BOX3D_SAMPLES`, `BOX3D_BENCHMARKS`, `BOX3D_DOCS`, `BOX3D_PROFILE`, `BOX3D_VALIDATE`, `BOX3D_UNIT_TESTS`) are explicitly set OFF. The vendored `extern/sokol` is only referenced by the disabled samples.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says (semver tag `v0.1.0` -> `version-semver`).
- [x] The license declaration in `vcpkg.json` matches what upstream says (MIT).
- [x] The installed as the "copyright" file matches what upstream says (upstream `LICENSE` via `vcpkg_install_copyright`).
- [x] The source code of the component installed comes from an authoritative source (github.com/erincatto/box3d release tag).
- [x] The generated "usage text" is brief and accurate. No usage file added: the automatically generated usage (`find_package(box3d CONFIG REQUIRED)` + `target_link_libraries(main PRIVATE box3d::box3d)`) was verified correct on a real install.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
