### PR TITLE
[zimpl] Update to 3.7.1

### DIFF
--- a/ports/zimpl/libm.diff
+++ b/ports/zimpl/libm.diff
@@ -1,8 +1,8 @@
-diff --git a/zimpl/CMakeLists.txt b/zimpl/CMakeLists.txt
-index 7cf9d85..07fa187 100644
---- a/zimpl/CMakeLists.txt
-+++ b/zimpl/CMakeLists.txt
-@@ -151,6 +151,8 @@ include(CheckSymbolExists)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4631864..d5f6756 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -158,6 +158,8 @@ include(CheckSymbolExists)
  find_library(libm m)
  if(NOT libm)
    set(libm "")

--- a/ports/zimpl/msvc.diff
+++ b/ports/zimpl/msvc.diff
@@ -1,17 +1,17 @@
-diff --git a/zimpl/CMakeLists.txt b/zimpl/CMakeLists.txt
-index 7cf9d85..85d33a7 100644
---- a/zimpl/CMakeLists.txt
-+++ b/zimpl/CMakeLists.txt
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4631864..080285c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -4,7 +4,7 @@ project(ZIMPL
-     VERSION 3.6.1
+     VERSION 3.7.1
      LANGUAGES C)
  
 -if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 +if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT WIN32)
      # if changing these flags, also update GCCWARN/GXXWARN in make/make.project
-     set(ADD_C_FLAGS -Wall -Wextra -Wno-unknown-pragmas -Wpointer-arith -Wcast-align -Wwrite-strings -Winline -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wmissing-noreturn -Wmissing-declarations -fno-omit-frame-pointer)
- 
-@@ -112,7 +112,6 @@ if(MSVC)
+     if((CMAKE_C_COMPILER_ID MATCHES "GNU") OR (CMAKE_C_COMPILER_ID MATCHES "Clang"))
+         set(ADD_C_FLAGS -Wall -Wextra -Wno-unknown-pragmas -Wpointer-arith -Wcast-align -Wwrite-strings -Winline -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wmissing-noreturn -Wmissing-declarations -fno-omit-frame-pointer)
+@@ -117,7 +117,6 @@ if(MSVC)
      )
  
      foreach(variable ${variables})
@@ -19,24 +19,20 @@ index 7cf9d85..85d33a7 100644
         # message("${variable} = ${${variable}}")
      endforeach()
  endif()
-@@ -128,9 +127,11 @@ if(ZLIB_FOUND)
-     include_directories(${ZLIB_INCLUDE_DIRS})
- else()
-     add_definitions(-DWITHOUT_ZLIB)
-+endif()
+@@ -137,7 +136,8 @@ endif()
  
--    # look for pcre if ZLIB could not be found
+ if(MSVC)
+     # look for pcre if Windows
 -    find_package(PCRE)
-+if(WIN32)
 +    find_package(PCRE NAMES pcre2 REQUIRED)
 +    set(PCRE_LIBRARIES "$<TARGET_NAME:PCRE2::POSIX>")
      if(PCRE_FOUND)
          add_definitions(-DWITH_PCRE)
          add_definitions(-DPCRE2_STATIC)
-diff --git a/zimpl/zimpl-config.cmake.in b/zimpl/zimpl-config.cmake.in
+diff --git a/zimpl-config.cmake.in b/zimpl-config.cmake.in
 index b653f0c..946f6f2 100644
---- a/zimpl/zimpl-config.cmake.in
-+++ b/zimpl/zimpl-config.cmake.in
+--- a/zimpl-config.cmake.in
++++ b/zimpl-config.cmake.in
 @@ -1,3 +1,8 @@
 +if(WIN32)
 +  include(CMakeFindDependencyMacro)

--- a/ports/zimpl/portfile.cmake
+++ b/ports/zimpl/portfile.cmake
@@ -1,15 +1,11 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-# The latest version of ZIMPL is included in the SCIP Optimization Suite.
-set(scipoptsuite_version 9.1.0)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://scipopt.org/download/release/scipoptsuite-${scipoptsuite_version}.tgz"
-    SHA512 03c1c49dd5e4dbc5bfd4f07305937079773f6912c87b0ba86166fc02996928e8d23332137a944f16f2488a88dc12a4a2c6ebde216eb4532135ed282a182bfdaf
-    FILENAME "scipoptsuite-${scipoptsuite_version}.tgz"
-)
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO scipopt/zimpl
+    REF "v${VERSION}"
+    SHA512 a94eba1ec9d7947d30c948599092100f5f1d6be509967f947154141a7718e054e398860fbfba34bb2e0dd129f58fd168d1087023ffe3215f7d498e829e38afc9
+    HEAD_REF master
     PATCHES
         libm.diff
         msvc.diff
@@ -19,7 +15,7 @@ vcpkg_find_acquire_program(BISON)
 vcpkg_find_acquire_program(FLEX)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/zimpl"
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBREW=false
         "-DBISON_EXECUTABLE=${BISON}"
@@ -35,6 +31,9 @@ vcpkg_copy_tools(TOOL_NAMES zimpl AUTO_CLEAN)
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/zimpl/zimpl-config.cmake" "../../../include" "../../include")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/zimpl/mmlparse2.h" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/zimpl/" "")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/zimpl/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zimpl/vcpkg.json
+++ b/ports/zimpl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zimpl",
-  "version": "3.6.1",
-  "port-version": 1,
+  "version": "3.7.1",
   "description": "Zuse Institut Mathematical Programming Language",
   "homepage": "https://zimpl.zib.de/",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11301,8 +11301,8 @@
       "port-version": 0
     },
     "zimpl": {
-      "baseline": "3.6.1",
-      "port-version": 1
+      "baseline": "3.7.1",
+      "port-version": 0
     },
     "zint": {
       "baseline": "2.16.0",

--- a/versions/z-/zimpl.json
+++ b/versions/z-/zimpl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb071ea48fb25658648f1024a2bea8e56f6f264b",
+      "version": "3.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "251a64990cc1a6fdf6c33ad7036cc29daa9c7988",
       "version": "3.6.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

@dg0yt As you added this port in #35053: Was there a specific reason to use the Suite archive instead downloading it from GitHub repo?

