### PR TITLE
[OpenSSL, Botan]: Remove JOM, it hangs.

### DIFF
--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -100,7 +100,6 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
         PROJECT_NAME "Makefile"
-        PREFER_JOM
         PRERUN_SHELL_RELEASE
             "${PYTHON3}" "${SOURCE_PATH}/configure.py"
             ${configure_arguments}

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -79,7 +79,6 @@ cmake_path(NATIVE_PATH VCPKG_DETECTED_CMAKE_LINKER NORMALIZE ld)
 # instead.
 vcpkg_build_nmake(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_JOM
     CL_LANGUAGE NONE
     PRERUN_SHELL_RELEASE "${PERL}" Configure
         ${CONFIGURE_OPTIONS} 


### PR DESCRIPTION
We have been seeing many hangs in building OpenSSL.
i.e instead of our vcpkg taking around 40 minutes overall, it times out after 8 hours.
Every case I have looked at is in the middle of building OpenSSL with jom.
(We do not build Botan.)
While the investigation is yet quite shallow (haven't reproed locally and debugged) I strongly suspect a problem in jom.
Ongoing testing in our local cloud CI is occuring with:
  set VCPKG_MAX_CONCURRENCY=1
So far 1-2 runs have succeeded but I'll run 10 or so.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.