### PR TITLE
[gtsam] Update to 4.2.2

### DIFF
--- a/ports/gtsam/build-fixes.patch
+++ b/ports/gtsam/build-fixes.patch
@@ -17,21 +17,6 @@ index cc2a7df8f..e11de1815 100644
  # Load exports
  include(${OUR_CMAKE_DIR}/@PACKAGE_NAME@-exports.cmake)
  
-diff --git a/cmake/FindTBB.cmake b/cmake/FindTBB.cmake
-index 0ecd4ca0e..725589a2d 100644
---- a/cmake/FindTBB.cmake
-+++ b/cmake/FindTBB.cmake
-@@ -1,3 +1,4 @@
-+if(0)
- # The MIT License (MIT)
- #
- # Copyright (c) 2015 Justus Calvin
-@@ -321,3 +322,4 @@ if(NOT TBB_FOUND)
-   unset(TBB_DEFAULT_SEARCH_DIR)
- 
- endif()
-+endif()
-\ No newline at end of file
 diff --git a/cmake/HandleMetis.cmake b/cmake/HandleMetis.cmake
 index 5cbec4ff5..10dbb53de 100644
 --- a/cmake/HandleMetis.cmake
@@ -59,9 +44,18 @@ index 5cbec4ff5..10dbb53de 100644
  else()
    # Bundled version:
 diff --git a/cmake/HandleTBB.cmake b/cmake/HandleTBB.cmake
-index fb944ba5b..393aeb345 100644
+index fb944ba5b..3a3600c2c 100644
 --- a/cmake/HandleTBB.cmake
 +++ b/cmake/HandleTBB.cmake
+@@ -1,7 +1,7 @@
+ ###############################################################################
+ if (GTSAM_WITH_TBB)
+     # Find TBB
+-    find_package(TBB 4.4 COMPONENTS tbb tbbmalloc)
++    find_package(TBB 4.4 CONFIG COMPONENTS tbb tbbmalloc)
+ 
+     # Set up variables if we're using TBB
+     if(TBB_FOUND)
 @@ -14,7 +14,7 @@ if (GTSAM_WITH_TBB)
          endif()
          # all definitions and link requisites will go via imported targets:

--- a/ports/gtsam/portfile.cmake
+++ b/ports/gtsam/portfile.cmake
@@ -1,13 +1,18 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO borglab/gtsam
-    REF ${VERSION}
-    SHA512 c0e5de8d86ea8241b49449bd291999ec0d6530bc9943b213e7c650b0ab29894ab53636bd1a0ed82d9d9d148dfc399ebff28e108b060d2d2176b584823bd722cd
+    REF "${VERSION}"
+    SHA512 63f77fb725c3466f548425e9f7c2459268034bbbdaca9d091265171da0b23078dbce6ff031d2b97b61e0eb8955b70b271119924754c8ed27bba62b33613cc46b
     HEAD_REF develop
     PATCHES
         build-fixes.patch
         path-fixes.patch
         eigen3-fixes.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tbb   GTSAM_WITH_TBB
 )
 
 vcpkg_cmake_configure(
@@ -23,6 +28,7 @@ vcpkg_cmake_configure(
         -DGTSAM_INSTALL_CPPUNITLITE=OFF
         -DGTSAM_BUILD_TYPE_POSTFIXES=OFF
         -DCMAKE_CXX_STANDARD=14 # Boost-math require C++14
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/gtsam/vcpkg.json
+++ b/ports/gtsam/vcpkg.json
@@ -1,27 +1,22 @@
 {
   "name": "gtsam",
-  "version": "4.2.0",
-  "port-version": 2,
+  "version": "4.2.2",
   "description": "GTSAM is a library of C++ classes that implement smoothing and mapping (SAM) in robotics and vision, using factor graphs and Bayes networks as the underlying computing paradigm rather than sparse matrices.",
   "homepage": "https://github.com/borglab/gtsam",
   "license": "BSD-3-Clause",
   "dependencies": [
     "boost-assign",
-    "boost-bimap",
-    "boost-date-time",
+    "boost-chrono",
     "boost-filesystem",
     "boost-format",
     "boost-graph",
     "boost-math",
     "boost-program-options",
-    "boost-regex",
+    "boost-ptr-container",
     "boost-serialization",
-    "boost-system",
-    "boost-thread",
     "boost-timer",
     "eigen3",
     "metis",
-    "tbb",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -30,5 +25,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tbb": {
+      "description": "Use GTSAM parallelization",
+      "dependencies": [
+        "tbb"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3645,8 +3645,8 @@
       "port-version": 9
     },
     "gtsam": {
-      "baseline": "4.2.0",
-      "port-version": 2
+      "baseline": "4.2.2",
+      "port-version": 0
     },
     "guetzli": {
       "baseline": "2020-09-14",

--- a/versions/g-/gtsam.json
+++ b/versions/g-/gtsam.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b81e116e204d0fe35b92ff3c149ca85feed7125",
+      "version": "4.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a624959f90d8bb11e218a292848fff0a31e177a5",
       "version": "4.2.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Interesting fact: When building this port, you get (with TBB as dependency):
```
CMake Warning at cmake/HandleFinalChecks.cmake:3 (message):
  TBB 4.4 or newer was not found - this is ok, but note that GTSAM
  parallelization will be disabled.  Set GTSAM_WITH_TBB to 'Off' to avoid
  this warning.
```

// EDIT: After Adding `CONFIG`I get now:
```
--  Use Intel TBB                                    : Yes (Version: 2023.0.0)
```

Without adding `CONFIG` and just removing the `if(0)` from previos patch I'm getting:
```
--  Use Intel TBB                                    : TBB not found
```

@BillyONeal As TBB wasn't used before and no one complained: Adding tbb as optional feature?