### PR TITLE
[pango] Update to 1.58.0

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(SOURCE_ARCHIVE
         "https://download.gnome.org/sources/pango/${VERSION_MAJOR_MINOR}/pango-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "pango-${VERSION}.tar.xz"
-    SHA512 ccfcec11f0beb0487d9225be227e7f31d03229ed1e0dc3309e2647ed5fa953cf036ad352232429f5604f97d20812074ff145ea622110afa4df3a410ebba4d26a
+    SHA512 5edf537653eee47aba5de53faac8d3906894069902fc4b301fc99daff5da3f35037ca14d75e21769ef0abcafb12a031e3ea8c02cafe967b678c11977f612485f
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${SOURCE_ARCHIVE}"

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pango",
-  "version": "1.57.1",
+  "version": "1.58.0",
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7653,7 +7653,7 @@
       "port-version": 0
     },
     "pango": {
-      "baseline": "1.57.1",
+      "baseline": "1.58.0",
       "port-version": 0
     },
     "pangolin": {

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8e38f73f1aad2bcacda5a7b6da548f97862aa6f",
+      "version": "1.58.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "caa5a9d22c4b45f1c36d14d11a54d4cc7fb93ed6",
       "version": "1.57.1",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
