### PR TITLE
[libiconv] Build on macOS

### DIFF
--- a/ports/libiconv/0005-Fix-install-reloc-memeq.patch
+++ b/ports/libiconv/0005-Fix-install-reloc-memeq.patch
@@ -1,0 +1,20 @@
+diff --git a/build-aux/install-reloc b/build-aux/install-reloc
+index 0e550ff..bb01254 100755
+--- a/build-aux/install-reloc
++++ b/build-aux/install-reloc
+@@ -282,6 +282,7 @@ func_verbose $compile_command \
+                "$srcdir"/relocwrapper.c \
+                "$srcdir"/progname.c \
+                "$srcdir"/progreloc.c \
++               "$srcdir"/memeq.c \
+                "$srcdir"/areadlink.c \
+                "$srcdir"/careadlinkat.c \
+                "$srcdir"/allocator.c \
+@@ -308,6 +309,7 @@ func_verbose $compile_command \
+   # compilers on Solaris, HP-UX.
+   rm -f relocwrapper.o \
+         progname.o \
++        memeq.o \
+         progreloc.o \
+         areadlink.o \
+         careadlinkat.o \

--- a/ports/libiconv/portfile.cmake
+++ b/ports/libiconv/portfile.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED X_VCPKG_BUILD_GNU_LIBICONV)
     set(X_VCPKG_BUILD_GNU_LIBICONV 0)
-    if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_BSD)
+    if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_BSD OR VCPKG_TARGET_IS_APPLE)
         set(X_VCPKG_BUILD_GNU_LIBICONV 1)
     elseif(VCPKG_TARGET_IS_ANDROID)
         vcpkg_cmake_get_vars(cmake_vars_file)
@@ -33,6 +33,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         0002-Config-for-MSVC.patch
         0003-Add-export.patch
         0004-ModuleFileName.patch
+        0005-Fix-install-reloc-memeq.patch
 )
 
 vcpkg_list(SET OPTIONS)

--- a/ports/libiconv/vcpkg.json
+++ b/ports/libiconv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libiconv",
   "version": "1.19",
+  "port-version": 1,
   "description": [
     "iconv() text conversion.",
     "This port installs GNU libiconv if the system C runtime doesn't provide a suitable iconv() implementation."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5170,7 +5170,7 @@
     },
     "libiconv": {
       "baseline": "1.19",
-      "port-version": 0
+      "port-version": 1
     },
     "libics": {
       "baseline": "1.7.0",

--- a/versions/l-/libiconv.json
+++ b/versions/l-/libiconv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "765d6bbf2f33bae717c0675251a4c5fbc070d9f5",
+      "version": "1.19",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb4c96e3d66cfba5f75a09bc1c34fa628a822ca4",
       "version": "1.19",
       "port-version": 0


### PR DESCRIPTION
Made with Google Antigravity

Use GNU libiconv instead of the Xcode shipped libiconv due to issues with the Xcode shipped libiconv.

Related #52232

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
