### PR TITLE
sdl3-sound 3.2.0: Add port

### DIFF
--- a/ports/sdl3-sound/portfile.cmake
+++ b/ports/sdl3-sound/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO icculus/SDL_sound
+    REF "v${VERSION}"
+    SHA512 2bf27cd895938d5913254d57d147255bad5f48d3f9bc9192742087cd1d3023b2874ac65496964a21fa9514164d20ae51b962a89b34c49eee9890780134dbcb96
+    HEAD_REF main
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDLSOUND_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDLSOUND_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSDLSOUND_BUILD_STATIC=${SDLSOUND_STATIC}
+        -DSDLSOUND_BUILD_SHARED=${SDLSOUND_SHARED}
+        -DSDLSOUND_BUILD_DOCS=OFF
+        -DSDLSOUND_BUILD_TEST=OFF
+        -DSDLSOUND_DECODER_MIDI=ON
+        -DSDLSOUND_INSTALL_CMAKEDIR=share/SDL3_sound
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_sound)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sdl3-sound/usage
+++ b/ports/sdl3-sound/usage
@@ -1,0 +1,9 @@
+sdl3-sound provides CMake targets:
+
+  find_package(SDL3 CONFIG REQUIRED)
+  find_package(SDL3_sound CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE SDL3_sound::SDL3_sound SDL3::SDL3)
+
+sdl3-sound provides pkg-config modules:
+
+  sdl3-sound

--- a/ports/sdl3-sound/vcpkg.json
+++ b/ports/sdl3-sound/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "sdl3-sound",
+  "version": "3.2.0",
+  "description": "An abstract soundfile decoder",
+  "homepage": "https://github.com/icculus/SDL_sound",
+  "license": "Zlib",
+  "dependencies": [
+    "sdl3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9184,6 +9184,10 @@
       "baseline": "3.0.0-preview2",
       "port-version": 0
     },
+    "sdl3-sound": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "sdl3-ttf": {
       "baseline": "3.2.2",
       "port-version": 1

--- a/versions/s-/sdl3-sound.json
+++ b/versions/s-/sdl3-sound.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f3770de733388c80f0f1ccf7b8da9bd458dc7842",
+      "version": "3.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [X] Has a release at least 6 months old or 6 months of demonstrated public development
    - [X] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [X] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [X] The project is amongst the first web search results for "SDL_sound" or "SDL_sound C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [X] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

---

SDL_Sound is a lesser-known SDL library from one of its main authors (icculus). It previously released for SDL1.2 and SDL2 but hadn't been packaged on vcpkg.

The only external dependency currently is SDL3, the other optional ones are Doxygen (disabled with `SDLSOUND_BUILD_DOCS=OFF`) and Perl (`SDLSOUND_INSTALL_MAN` defaults to `OFF`) which are only used to build documentation.

Let me know if there is any issue!

<details>
<summary>Project name search result</summary>
<img width="1018" height="429" alt="image" src="https://github.com/user-attachments/assets/2b2b25e8-368a-4092-a07e-c7bf7f8920cc" />
</details>