### PR TITLE
[svt-av1] Update to 4.1.0

### DIFF
--- a/ports/svt-av1/no-force-llvm.diff
+++ b/ports/svt-av1/no-force-llvm.diff
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 57100575..65b5b775 100644
+index c0c9767..93ec320 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -200,7 +200,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY})
- set(REQUIRES_PRIVATE "")
+@@ -192,7 +192,7 @@ set(PC_LIBS_PRIVATE)
+ set(PC_REQUIRES_PRIVATE)
  
  #Clang support, required to build static with LTO
 -if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND UNIX AND NOT APPLE)

--- a/ports/svt-av1/portfile.cmake
+++ b/ports/svt-av1/portfile.cmake
@@ -57,4 +57,4 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md" "${SOURCE_PATH}/PATENTS.md")

--- a/ports/svt-av1/portfile.cmake
+++ b/ports/svt-av1/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AOMediaCodec/SVT-AV1
     REF "v${VERSION}"
-    SHA512 4301e923965e3bff30a0fd2f74ae023d19260f91c2361d48ea7bc1718f501dcca73fa17cb8795b23392ca1bfbe1f4d55edcbb5ce06a2fa9e41da36c5166f527d
+    SHA512 89064696277b3e92e95945e4415bc86490c60c968680dc21253beb4b4caf39d5fa46838aa83759c6e9b31b759abb76c581fb40ebdf08d53d63aaf05a264fc9c9
     PATCHES
         no-force-llvm.diff
         no-inline-yy_unpacklo_epi128.diff
@@ -47,6 +47,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME SVT-AV1 CONFIG_PATH lib/cmake/SVT-AV1)
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/svt-av1/unvendor-fastfeat.diff
+++ b/ports/svt-av1/unvendor-fastfeat.diff
@@ -1,19 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 57100575..47a9e709 100644
+index c0c9767..93ec320 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -721,6 +721,5 @@ if(BUILD_TESTING)
+@@ -719,4 +719,3 @@ if(BUILD_TESTING)
      add_subdirectory(third_party/googletest)
  endif()
  
 -add_subdirectory(third_party/fastfeat)
- 
- install(DIRECTORY ${PROJECT_SOURCE_DIR}/Source/API/ DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/svt-av1" FILES_MATCHING PATTERN "*.h")
 diff --git a/Source/Lib/CMakeLists.txt b/Source/Lib/CMakeLists.txt
-index 03ffe4e2..43325e91 100644
+index 6a2c57d..6c12992 100644
 --- a/Source/Lib/CMakeLists.txt
 +++ b/Source/Lib/CMakeLists.txt
-@@ -47,7 +47,7 @@ endif()
+@@ -24,7 +24,7 @@ endif()
  include_directories(${PROJECT_SOURCE_DIR}/Source/API/
      ${PROJECT_SOURCE_DIR}/Source/Lib/Codec/
      ${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/
@@ -22,7 +20,7 @@ index 03ffe4e2..43325e91 100644
  
  add_library(SvtAv1Enc)
  # Required for cmake to be able to tell Xcode how to link all of the object files
-@@ -98,7 +98,6 @@ endif()
+@@ -75,7 +75,6 @@ endif()
  
  # Encoder Lib Source Files
  target_sources(SvtAv1Enc PRIVATE
@@ -30,7 +28,7 @@ index 03ffe4e2..43325e91 100644
      $<TARGET_OBJECTS:GLOBALS>
      $<TARGET_OBJECTS:CODEC>
      $<TARGET_OBJECTS:C_DEFAULT>)
-@@ -133,6 +132,14 @@ if(common_lib_source)
+@@ -110,6 +109,14 @@ if(common_lib_source)
      target_sources(SvtAv1Enc PRIVATE ${common_lib_source})
  endif()
  
@@ -42,11 +40,11 @@ index 03ffe4e2..43325e91 100644
 +list(APPEND PLATFORM_LIBS ${FASTFEAT})
 +set(LIBS_PRIVATE "${LIBS_PRIVATE} -lfastfeat")
 +
- set_target_properties(SvtAv1Enc PROPERTIES VERSION ${ENC_VERSION})
- set_target_properties(SvtAv1Enc PROPERTIES SOVERSION ${ENC_VERSION_MAJOR})
- set_target_properties(SvtAv1Enc PROPERTIES C_VISIBILITY_PRESET hidden)
+ if(BUILD_SHARED_LIBS)
+     set(SVT_AV1_TARGET SVT-AV1-shared)
+ else()
 diff --git a/Source/Lib/Codec/CMakeLists.txt b/Source/Lib/Codec/CMakeLists.txt
-index d3e95e4f..63b32eda 100644
+index 26b0562..2f72464 100644
 --- a/Source/Lib/Codec/CMakeLists.txt
 +++ b/Source/Lib/Codec/CMakeLists.txt
 @@ -39,7 +39,7 @@ include_directories(${PROJECT_SOURCE_DIR}/Source/API/
@@ -75,30 +73,30 @@ index d3e95e4f..63b32eda 100644
  endif ()
  
  set(all_files
-@@ -292,3 +292,4 @@ set(all_files
+@@ -298,3 +298,4 @@ set(all_files
          )
  
  add_library(CODEC OBJECT ${all_files})
 +target_include_directories(CODEC PRIVATE "${FASTFEAT_INCLUDE_DIR}")
 diff --git a/Source/Lib/Codec/corner_detect.c b/Source/Lib/Codec/corner_detect.c
-index 793919be..ca7e8537 100644
+index 3060670..2b93b1f 100644
 --- a/Source/Lib/Codec/corner_detect.c
 +++ b/Source/Lib/Codec/corner_detect.c
-@@ -18,7 +18,7 @@
- #define FAST_BARRIER 18
- int svt_av1_fast_corner_detect(unsigned char *buf, int width, int height, int stride, int *points, int max_points) {
+@@ -19,7 +19,7 @@
+ 
+ int svt_av1_fast_corner_detect(unsigned char* buf, int width, int height, int stride, int* points, int max_points) {
      int       num_points;
--    xy *const frm_corners_xy = svt_aom_fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
-+    xy *const frm_corners_xy = fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
+-    xy* const frm_corners_xy = svt_aom_fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
++    xy* const frm_corners_xy = fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
      num_points               = (num_points <= max_points ? num_points : max_points);
      if (num_points > 0 && frm_corners_xy) {
          svt_memcpy(points, frm_corners_xy, sizeof(*frm_corners_xy) * num_points);
 diff --git a/Source/Lib/Globals/CMakeLists.txt b/Source/Lib/Globals/CMakeLists.txt
-index 47e20736..0d8e99e1 100644
+index 5d1c2da..854cace 100644
 --- a/Source/Lib/Globals/CMakeLists.txt
 +++ b/Source/Lib/Globals/CMakeLists.txt
 @@ -15,7 +15,6 @@
- include_directories(../../../API
+ include_directories(${PROJECT_SOURCE_DIR}/Source/Lib/API
          ${PROJECT_BINARY_DIR}/Source/Lib/Codec/
          ${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/
 -        ${PROJECT_SOURCE_DIR}/third_party/fastfeat/

--- a/ports/svt-av1/unvendor-fastfeat.diff
+++ b/ports/svt-av1/unvendor-fastfeat.diff
@@ -38,7 +38,7 @@ index 6a2c57d..6c12992 100644
 +    NO_DEFAULT_PATH
 +)
 +list(APPEND PLATFORM_LIBS ${FASTFEAT})
-+set(LIBS_PRIVATE "${LIBS_PRIVATE} -lfastfeat")
++list(APPEND PC_LIBS_PRIVATE -lfastfeat)
 +
  if(BUILD_SHARED_LIBS)
      set(SVT_AV1_TARGET SVT-AV1-shared)

--- a/ports/svt-av1/vcpkg.json
+++ b/ports/svt-av1/vcpkg.json
@@ -3,7 +3,7 @@
   "version-semver": "4.1.0",
   "description": "AV1 software video encoder library",
   "homepage": "https://gitlab.com/AOMediaCodec/SVT-AV1",
-  "license": "BSD-3-Clause",
+  "license": null,
   "supports": "!x86 & !arm32 & !uwp",
   "dependencies": [
     "fastfeat",

--- a/ports/svt-av1/vcpkg.json
+++ b/ports/svt-av1/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "svt-av1",
-  "version-semver": "3.1.2",
-  "port-version": 1,
+  "version-semver": "4.1.0",
   "description": "AV1 software video encoder library",
   "homepage": "https://gitlab.com/AOMediaCodec/SVT-AV1",
   "license": "BSD-3-Clause",
@@ -10,6 +9,10 @@
     "fastfeat",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9941,8 +9941,8 @@
       "port-version": 0
     },
     "svt-av1": {
-      "baseline": "3.1.2",
-      "port-version": 1
+      "baseline": "4.1.0",
+      "port-version": 0
     },
     "swaggercpp": {
       "baseline": "0.3.0",

--- a/versions/s-/svt-av1.json
+++ b/versions/s-/svt-av1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f259e74d05b554436afdd3922e3a16f12286c74d",
+      "version-semver": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1a94cc62d7d93d05b2c5033681b592342021672f",
       "version-semver": "3.1.2",
       "port-version": 1

--- a/versions/s-/svt-av1.json
+++ b/versions/s-/svt-av1.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f259e74d05b554436afdd3922e3a16f12286c74d",
+      "git-tree": "88aac1c185cbd28491692301cf3f250fb6b16b12",
       "version-semver": "4.1.0",
       "port-version": 0
     },

--- a/versions/s-/svt-av1.json
+++ b/versions/s-/svt-av1.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "88aac1c185cbd28491692301cf3f250fb6b16b12",
+      "git-tree": "8063109a97a1dc4aa0428a56a721de6e0f894406",
       "version-semver": "4.1.0",
       "port-version": 0
     },


### PR DESCRIPTION
Updates `svt-av1` from 3.1.2 to 4.1.0 (latest stable release).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

### Notes

- `no-force-llvm.diff` and `unvendor-fastfeat.diff` were regenerated to apply against the 4.1.0 source (upstream line/whitespace shifts only; patch intent unchanged). `no-inline-yy_unpacklo_epi128.diff` and `no-safestringlib.diff` still apply unchanged.
- v4.x now exports a CMake package configuration; added a `vcpkg-cmake-config` host dependency and `vcpkg_cmake_config_fixup(PACKAGE_NAME SVT-AV1 CONFIG_PATH lib/cmake/SVT-AV1)` so the config files are relocated to `share/svt-av1` and post-build validation passes.
- Verified locally with `./vcpkg install svt-av1` on `arm64-osx`: configures, builds, installs, and passes post-build validation with no warnings.