### PR TITLE
[depz-sensor-sdk] Add new ports depz-sensor-sdk-c and depz-sensor-sdk-cpp

### DIFF
--- a/ports/depz-sensor-sdk-c/portfile.cmake
+++ b/ports/depz-sensor-sdk-c/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO depz-ai/depz-sensor-sdk
     REF "v${VERSION}"
-    SHA512 33042a6ee43b7ad91e28ebcb6193def164a3602d19713f80bf9392fe0f9dba96824cee3e95d1f8c74449a7564034d76ae7e5ddaea2045d06311b6588bb2f7c88
+    SHA512 a55df8ece752f5288df0fc1c5db09b5caccf4a300e37adbe29a40434252fec7cfea901eb78236f878e838e10b30c1cf766ca1187c0afea574bcb356c998b06d8
     HEAD_REF main
 )
 
@@ -23,8 +23,6 @@ vcpkg_cmake_config_fixup(
 # Static library: no headers belong in the debug tree.
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# The depz-sensor-sdk-c subdirectory ships no standalone LICENSE file; the
-# repository's MIT license text lives in the sibling depz-sensor-sdk-cpp
-# subdirectory and applies to the whole monorepo (it also carries the
+# The depz-sensor-sdk-c package ships its own LICENSE file (MIT, with the
 # BSD-3-Clause note for the shared VL53L8 advanced-DCI codecs used here).
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/packages/depz-sensor-sdk-cpp/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/packages/depz-sensor-sdk-c/LICENSE")

--- a/ports/depz-sensor-sdk-c/portfile.cmake
+++ b/ports/depz-sensor-sdk-c/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO depz-ai/depz-sensor-sdk
+    REF "v${VERSION}"
+    SHA512 33042a6ee43b7ad91e28ebcb6193def164a3602d19713f80bf9392fe0f9dba96824cee3e95d1f8c74449a7564034d76ae7e5ddaea2045d06311b6588bb2f7c88
+    HEAD_REF main
+)
+
+# The C SDK lives in a subdirectory of the monorepo.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/packages/depz-sensor-sdk-c"
+    OPTIONS
+        -DDEPZ_SENSOR_SDK_C_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME depz-sensor-sdk-c
+    CONFIG_PATH lib/cmake/depz-sensor-sdk-c
+)
+
+# Static library: no headers belong in the debug tree.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# The depz-sensor-sdk-c subdirectory ships no standalone LICENSE file; the
+# repository's MIT license text lives in the sibling depz-sensor-sdk-cpp
+# subdirectory and applies to the whole monorepo (it also carries the
+# BSD-3-Clause note for the shared VL53L8 advanced-DCI codecs used here).
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/packages/depz-sensor-sdk-cpp/LICENSE")

--- a/ports/depz-sensor-sdk-c/vcpkg.json
+++ b/ports/depz-sensor-sdk-c/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "depz-sensor-sdk-c",
+  "version": "0.1.0",
+  "description": "Contract-first C11 decode/codec SDK for the DEPZ USB sensor line (SR04, VL53L8CX/CH, BNO086): CRCs, packet framing, USB identity, firmware container parsing, and the per-sensor decode layer.",
+  "homepage": "https://github.com/depz-ai/depz-sensor-sdk",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/depz-sensor-sdk-c/vcpkg.json
+++ b/ports/depz-sensor-sdk-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "depz-sensor-sdk-c",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Contract-first C11 decode/codec SDK for the DEPZ USB sensor line (SR04, VL53L8CX/CH, BNO086): CRCs, packet framing, USB identity, firmware container parsing, and the per-sensor decode layer.",
   "homepage": "https://github.com/depz-ai/depz-sensor-sdk",
   "license": "MIT",

--- a/ports/depz-sensor-sdk-cpp/portfile.cmake
+++ b/ports/depz-sensor-sdk-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO depz-ai/depz-sensor-sdk
     REF "v${VERSION}"
-    SHA512 33042a6ee43b7ad91e28ebcb6193def164a3602d19713f80bf9392fe0f9dba96824cee3e95d1f8c74449a7564034d76ae7e5ddaea2045d06311b6588bb2f7c88
+    SHA512 a55df8ece752f5288df0fc1c5db09b5caccf4a300e37adbe29a40434252fec7cfea901eb78236f878e838e10b30c1cf766ca1187c0afea574bcb356c998b06d8
     HEAD_REF main
 )
 

--- a/ports/depz-sensor-sdk-cpp/portfile.cmake
+++ b/ports/depz-sensor-sdk-cpp/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO depz-ai/depz-sensor-sdk
+    REF "v${VERSION}"
+    SHA512 33042a6ee43b7ad91e28ebcb6193def164a3602d19713f80bf9392fe0f9dba96824cee3e95d1f8c74449a7564034d76ae7e5ddaea2045d06311b6588bb2f7c88
+    HEAD_REF main
+)
+
+# The C++ SDK lives in a subdirectory of the monorepo.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/packages/depz-sensor-sdk-cpp"
+    OPTIONS
+        -DDEPZ_SENSOR_SDK_CPP_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME depz-sensor-sdk-cpp
+    CONFIG_PATH lib/cmake/depz-sensor-sdk-cpp
+)
+
+# Static library: no headers belong in the debug tree.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/packages/depz-sensor-sdk-cpp/LICENSE")

--- a/ports/depz-sensor-sdk-cpp/vcpkg.json
+++ b/ports/depz-sensor-sdk-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "depz-sensor-sdk-cpp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "C++17 decode-layer SDK for the DEPZ USB sensor line: framed-protocol parser and per-sensor wire codecs (SR04, VL53L8CX/CH, BNO086). Pure codecs, no I/O.",
   "homepage": "https://github.com/depz-ai/depz-sensor-sdk",
   "license": "MIT",

--- a/ports/depz-sensor-sdk-cpp/vcpkg.json
+++ b/ports/depz-sensor-sdk-cpp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "depz-sensor-sdk-cpp",
+  "version": "0.1.0",
+  "description": "C++17 decode-layer SDK for the DEPZ USB sensor line: framed-protocol parser and per-sensor wire codecs (SR04, VL53L8CX/CH, BNO086). Pure codecs, no I/O.",
+  "homepage": "https://github.com/depz-ai/depz-sensor-sdk",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2485,11 +2485,11 @@
       "port-version": 0
     },
     "depz-sensor-sdk-c": {
-      "baseline": "0.1.0",
+      "baseline": "0.1.1",
       "port-version": 0
     },
     "depz-sensor-sdk-cpp": {
-      "baseline": "0.1.0",
+      "baseline": "0.1.1",
       "port-version": 0
     },
     "detours": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2484,6 +2484,14 @@
       "baseline": "1.5.0",
       "port-version": 0
     },
+    "depz-sensor-sdk-c": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
+    "depz-sensor-sdk-cpp": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "detours": {
       "baseline": "2025-06-20",
       "port-version": 0

--- a/versions/d-/depz-sensor-sdk-c.json
+++ b/versions/d-/depz-sensor-sdk-c.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "50ad7e055af00a9a4105a4104e8cbdaff34d6332",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/depz-sensor-sdk-c.json
+++ b/versions/d-/depz-sensor-sdk-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41fce21c8525a7b5c68c7432cdaada7f8add4f95",
+      "version": "0.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "50ad7e055af00a9a4105a4104e8cbdaff34d6332",
       "version": "0.1.0",
       "port-version": 0

--- a/versions/d-/depz-sensor-sdk-cpp.json
+++ b/versions/d-/depz-sensor-sdk-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9e331dc7b620b877e7d414a165d396d61ade67e1",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/depz-sensor-sdk-cpp.json
+++ b/versions/d-/depz-sensor-sdk-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca8a3795a9839b57f4876d3ab960be99cb56dc40",
+      "version": "0.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9e331dc7b620b877e7d414a165d396d61ade67e1",
       "version": "0.1.0",
       "port-version": 0


### PR DESCRIPTION
Adds two new ports for the DEPZ sensor SDK, a contract-first decode/codec library for the DEPZ USB sensor line (SR04, VL53L8CX/CH, BNO086):

- **depz-sensor-sdk-c** — C11 decode/codec layer (CRCs, packet framing, USB identity, firmware-container parsing, per-sensor decode). Exports `depz::sensor_sdk_c` + a `depz-sensor-sdk-c-config.cmake`.
- **depz-sensor-sdk-cpp** — C++17 decode layer (framed-protocol parser and per-sensor wire codecs). Pure codecs, no I/O. Exports `depz::sensor_sdk_cpp` + a `depz-sensor-sdk-cpp-config.cmake`.

Both are static libraries sourced from tag `v0.1.0` of https://github.com/depz-ai/depz-sensor-sdk (MIT). The two libraries live in `packages/depz-sensor-sdk-c` and `packages/depz-sensor-sdk-cpp` subdirectories of the source repo, so each portfile points `vcpkg_cmake_configure` at the appropriate `SOURCE_SUBDIR`.

**Notes for reviewers**
- The `depz-sensor-sdk-c` subdirectory does not ship a standalone `LICENSE` file; the repository's MIT license text lives in the sibling `depz-sensor-sdk-cpp/LICENSE` and applies to the whole monorepo (it also carries the BSD-3-Clause note covering the shared VL53L8 advanced-DCI codecs used by both libraries), so the C port's `vcpkg_install_copyright` references that file.
- Versions registered via `vcpkg x-add-version`.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optionally, this port adds a feature that cannot be tested automatically, so I built it locally by running `./vcpkg install <port> --triplet <triplet>`.
- [x] Only one version is in the port's `versions/*.json`, or if multiple, they are for backports of security-critical fixes.
- [x] Only one version is added to each modified port's versions file.
