### PR TITLE
[slick-net] Update to v3.1.0

### DIFF
--- a/ports/slick-net/portfile.cmake
+++ b/ports/slick-net/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-net
     REF "v${VERSION}"
-    SHA512 e60051992d54ccb451d10bdf3e1074935eca75e570973c4cd7d0c4e814e9f9f4ecf40fe0bef750eb9df483c5d056a8fa7192c9b661f97488cfa749b06cbe5af5
+    SHA512 6c7ba6ea36c8bf2ed8d634c4083184433747db45d98bf3ac935caab30ccccdba0b2791b88e6485b4c08937a5bac1f7b4fa93e456b0bc67124aac4395706dd99a
     HEAD_REF main
     PATCHES
         slick-dependencies.patch

--- a/ports/slick-net/slick-dependencies.patch
+++ b/ports/slick-net/slick-dependencies.patch
@@ -1,31 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b8fc933..d331402 100644
+index 827d7d8..0604127 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -41,8 +41,8 @@ if (slick-shm_FOUND)
-     message(STATUS "slick-shm: ${slick-shm_VERSION}")
- endif()
- 
--find_package(slick-queue 1.5.0 CONFIG QUIET)
--if (NOT slick-queue_FOUND)
-+find_package(slick-queue CONFIG REQUIRED)
-+if (FALSE)
-     message(STATUS "Fetching slick-queue...")
-     include(FetchContent)
-     # Disable tests for slick-queue
-@@ -57,8 +57,8 @@ else()
-     message(STATUS "Found slick-queue: ${slick-queue_VERSION}")
- endif()
- 
--find_package(slick-stream-buffer 1.0.5 CONFIG QUIET)
--if (NOT slick-stream-buffer_FOUND)
-+find_package(slick-stream-buffer CONFIG REQUIRED)
-+if (FALSE)
-     message(STATUS "Fetching slick-stream-buffer...")
-     include(FetchContent)
-     set(BUILD_SLICK_STREAM_BUFFER_TESTS OFF CACHE BOOL "" FORCE)
-@@ -72,8 +72,8 @@ else()
-     message(STATUS "Found slick-stream-buffer: ${slick-stream-buffer_VERSION}")
+@@ -45,8 +45,8 @@ if (slick-shm_FOUND)
+     message(STATUS "Found slick-shm ${slick-shm_VERSION}: ${slick-shm_DIR}")
  endif()
  
 -find_package(slick-stream-buffer-multiplexer 1.0.1 CONFIG QUIET)
@@ -35,8 +13,8 @@ index b8fc933..d331402 100644
      message(STATUS "Fetching slick-stream-buffer-multiplexer...")
      include(FetchContent)
      set(BUILD_SLICK_STREAM_BUFFER_MULTIPLEXER_TESTS OFF CACHE BOOL "" FORCE)
-@@ -87,8 +87,8 @@ else()
-     message(STATUS "Found slick-stream-buffer-multiplexer: ${slick-stream-buffer-multiplexer_VERSION}")
+@@ -72,8 +72,8 @@ if (slick-stream-buffer_FOUND)
+     message(STATUS "Found slick-stream-buffer ${slick-stream-buffer_VERSION}: ${slick-stream-buffer_DIR}")
  endif()
  
 -find_package(slick-dynamic-buffer 1.0.1 CONFIG QUIET)
@@ -47,55 +25,17 @@ index b8fc933..d331402 100644
      include(FetchContent)
      set(BUILD_SLICK_DYNAMIC_BUFFER_TESTS OFF CACHE BOOL "" FORCE)
 diff --git a/cmake/slick-net-config.cmake.in b/cmake/slick-net-config.cmake.in
-index 8735d0b..fa9ec15 100644
+index 1bde373..f8cd2c1 100644
 --- a/cmake/slick-net-config.cmake.in
 +++ b/cmake/slick-net-config.cmake.in
-@@ -3,11 +3,11 @@
- include(CMakeFindDependencyMacro)
- 
+@@ -5,8 +5,8 @@ include(CMakeFindDependencyMacro)
  # Find required dependencies
--find_dependency(Boost CONFIG REQUIRED COMPONENTS beast context)
--find_dependency(OpenSSL CONFIG REQUIRED)
-+find_dependency(Boost CONFIG COMPONENTS beast context)
-+find_dependency(OpenSSL CONFIG)
- 
--find_dependency(slick-queue 1.5.0 CONFIG QUIET)
--if(NOT slick-queue_FOUND)
-+find_dependency(slick-queue CONFIG)
-+if(FALSE)
-     message(STATUS "Fetching slick-queue...")
-     include(FetchContent)
-     # Disable slick-queue tests
-@@ -20,8 +20,8 @@ if(NOT slick-queue_FOUND)
-     FetchContent_MakeAvailable(slick-queue)
- endif()
- 
--find_dependency(slick-stream-buffer 1.0.5 CONFIG QUIET)
--if (NOT slick-stream-buffer_FOUND)
-+find_dependency(slick-stream-buffer CONFIG)
-+if (FALSE)
-     message(STATUS "Fetching slick-stream-buffer...")
-     include(FetchContent)
-     set(BUILD_SLICK_STREAM_BUFFER_TESTS OFF CACHE BOOL "" FORCE)
-@@ -33,8 +33,8 @@ if (NOT slick-stream-buffer_FOUND)
-     FetchContent_MakeAvailable(slick-stream-buffer)
- endif()
- 
--find_dependency(slick-stream-buffer-multiplexer 1.0.1 CONFIG QUIET)
--if (NOT slick-stream-buffer-multiplexer_FOUND)
+ find_dependency(Boost CONFIG COMPONENTS beast context)
+ find_dependency(OpenSSL CONFIG)
+-find_dependency(slick-stream-buffer-multiplexer 1.0.1 CONFIG)
+-find_dependency(slick-dynamic-buffer 1.0.1 CONFIG)
 +find_dependency(slick-stream-buffer-multiplexer CONFIG)
-+if (FALSE)
-     message(STATUS "Fetching slick-stream-buffer-multiplexer...")
-     include(FetchContent)
-     set(BUILD_SLICK_STREAM_BUFFER_MULTIPLEXER_TESTS OFF CACHE BOOL "" FORCE)
-@@ -46,8 +46,8 @@ if (NOT slick-stream-buffer-multiplexer_FOUND)
-     FetchContent_MakeAvailable(slick-stream-buffer-multiplexer)
- endif()
- 
--find_dependency(slick-dynamic-buffer 1.0.1 CONFIG QUIET)
--if (NOT slick-dynamic-buffer_FOUND)
 +find_dependency(slick-dynamic-buffer CONFIG)
-+if (FALSE)
-     message(STATUS "Fetching slick-dynamic-buffer...")
-     include(FetchContent)
-     set(BUILD_SLICK_DYNAMIC_BUFFER_TESTS OFF CACHE BOOL "" FORCE)
+ 
+ # Include the targets file
+ include("${CMAKE_CURRENT_LIST_DIR}/slick-net-targets.cmake")

--- a/ports/slick-net/vcpkg.json
+++ b/ports/slick-net/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-net",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A modern C++20 networking library providing HTTP/HTTPS client, WebSocket/WebSocket Secure client, and HTTP streaming support built on Boost.Beast and Boost.Asio",
   "homepage": "https://github.com/SlickQuant/slick-net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9401,7 +9401,7 @@
       "port-version": 0
     },
     "slick-net": {
-      "baseline": "3.0.0",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "slick-object-pool": {

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "236e88b59a26428df468f28553d452a641a41761",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "54b2f9ef57e1d90470e2d85ed378914b3793d3b0",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
