### PR TITLE
Change from Ubuntu 24.04 "Noble" to Debian 13 "Trixie".

### DIFF
--- a/scripts/azure-pipelines/android/Dockerfile
+++ b/scripts/azure-pipelines/android/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.4
 # DisableDockerDetector "Used to build the container deployed to Azure Container Registry"
-FROM ubuntu:noble-20260113
+FROM debian:trixie-20260623
 
-ADD https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb /packages-microsoft-prod.deb
+ADD https://packages.microsoft.com/config/debian/13/packages-microsoft-prod.deb /packages-microsoft-prod.deb
 ADD https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.18+8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.18_8.tar.gz /OpenJDK17U-jdk_x64_linux_hotspot_17.0.18_8.tar.gz
 ADD https://dl.google.com/android/repository/commandlinetools-linux-14742923_latest.zip /commandlinetools-linux-14742923_latest.zip
 ADD https://dl.google.com/android/repository/build-tools_r36.1_linux.zip /build-tools_r36.1_linux.zip
@@ -42,7 +42,7 @@ ENV APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
   libxcb-cursor-dev libxkbcommon-x11-dev libsm6 libsm-dev"
 
 ## PowerShell
-ENV APT_PACKAGES="$APT_PACKAGES powershell azcopy"
+ENV APT_PACKAGES="$APT_PACKAGES powershell"
 
 # The BUILD_DATE argument forces cache invalidation so we get updated apt dependencies
 ARG BUILD_DATE
@@ -68,6 +68,14 @@ apt-get -y update
 apt-get -y dist-upgrade
 
 apt-get -y --no-install-recommends install $APT_PACKAGES
+
+# AzCopy
+curl -L -o /tmp/azcopy.tar.gz https://aka.ms/downloadazcopy-v10-linux
+mkdir -p /tmp/azcopy
+tar xzf /tmp/azcopy.tar.gz -C /tmp/azcopy
+find /tmp/azcopy -name azcopy -type f -exec cp '{}' /usr/local/bin/azcopy ';'
+chmod +x /usr/local/bin/azcopy
+rm -rf /tmp/azcopy /tmp/azcopy.tar.gz
 
 # OpenJDK
 tar xzf OpenJDK17U-jdk_x64_linux_hotspot_17.0.18_8.tar.gz

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   - name: VCPKG_DOWNLOADS
     value: /mnt/vcpkg-ci/downloads
   - name: ANDROID_DOCKER_IMAGE
-    value: 'vcpkgandroidwus.azurecr.io/vcpkg-android:2026-02-10'
+    value: 'vcpkgandroidwus.azurecr.io/vcpkg-android:2026-07-07'
   - name: LINUX_DOCKER_IMAGE
     value: ${{ parameters.linuxDockerImage }}
   steps:

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -9,11 +9,11 @@ parameters:
   - name: x64LinuxDockerImage
     displayName: 'Linux Docker Image to use for the x64 Linux build'
     type: string
-    default: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-04-20'
+    default: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-07-07'
   - name: arm64LinuxDockerImage
     displayName: 'Linux Docker Image to use for the arm64 Linux build'
     type: string
-    default: 'vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-04-20'
+    default: 'vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-07-07'
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring (^ matches begin, $ matches end)'
     type: string

--- a/scripts/azure-pipelines/example-debian-provision-for-docker.sh
+++ b/scripts/azure-pipelines/example-debian-provision-for-docker.sh
@@ -13,8 +13,8 @@ export DEBIAN_FRONTEND=noninteractive
 ## Docker
 apt-get -y --no-install-recommends install ca-certificates gnupg lsb-release
 mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 apt-get update
 apt-get -y --no-install-recommends install docker-ce docker-ce-cli

--- a/scripts/azure-pipelines/linux-arm64/Dockerfile
+++ b/scripts/azure-pipelines/linux-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20260410
+FROM debian:trixie-20260623
 
 ARG BUILD_DATE
 ARG POWERSHELL_VERSION=7.6.0
@@ -10,8 +10,8 @@ set -eux
 apt-get update
 apt-get install --no-install-recommends -y curl gnupg ca-certificates
 
-UBUNTU_VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
-curl -L -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/${UBUNTU_VERSION_ID}/packages-microsoft-prod.deb
+DEBIAN_VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
+curl -L -o packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/${DEBIAN_VERSION_ID}/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb
 rm -f packages-microsoft-prod.deb
 

--- a/scripts/azure-pipelines/linux/Dockerfile
+++ b/scripts/azure-pipelines/linux/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # DisableDockerDetector "Used to build the container deployed to Azure Container Registry"
-FROM ubuntu:noble-20260410
+FROM debian:trixie-20260623
 ADD provision-image.sh /provision-image.sh
 # The BUILD_DATE argument forces cache invalidation so we get updated apt dependencies
 ARG BUILD_DATE

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Add apt repos
 
 DEBIAN_VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
-NVIDIA_REPO_VERSION=debian13
+NVIDIA_REPO_VERSION="debian${DEBIAN_VERSION_ID}"
 DEBIAN_ARCHITECTURE=$(dpkg --print-architecture)
 
 case "$DEBIAN_ARCHITECTURE" in
@@ -49,7 +49,7 @@ dpkg -i packages-microsoft-prod.deb
 rm -f packages-microsoft-prod.deb
 
 apt-get -y update
-apt-get -y upgrade
+apt-get -y dist-upgrade
 
 # Add apt packages
 

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -9,17 +9,20 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Add apt repos
 
-# Detect Ubuntu VERSION_ID from /etc/os-release (e.g., "24.04") and format to "2404"
-UBUNTU_VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
-NVIDIA_REPO_VERSION=$(echo "$UBUNTU_VERSION_ID" | sed 's/\.//')
+DEBIAN_VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
+NVIDIA_REPO_VERSION=debian13
 DEBIAN_ARCHITECTURE=$(dpkg --print-architecture)
 
 case "$DEBIAN_ARCHITECTURE" in
 amd64)
   NVIDIA_REPO_ARCHITECTURE=x86_64
+  CUDNN_REDIST_ARCH=linux-x86_64
+  AZCOPY_URL=https://aka.ms/downloadazcopy-v10-linux
   ;;
 arm64)
   NVIDIA_REPO_ARCHITECTURE=sbsa
+  CUDNN_REDIST_ARCH=linux-sbsa
+  AZCOPY_URL=https://aka.ms/downloadazcopy-v10-linux-arm64
   ;;
 *)
   echo "Unsupported CUDA repository architecture: $DEBIAN_ARCHITECTURE" >&2
@@ -28,32 +31,22 @@ arm64)
 esac
 
 POWERSHELL_VERSION=7.6.0
+CUDNN_VERSION=9.24.0.43
 
-# Apt dependencies; needed for add-apt-repository and curl downloads to work
+# Apt dependencies; needed for repository setup and curl downloads to work
 apt-get -y update
-apt-get --no-install-recommends -y install ca-certificates curl apt-transport-https lsb-release gnupg software-properties-common
+apt-get --no-install-recommends -y install ca-certificates curl apt-transport-https gnupg
 
 ## CUDA
-curl -L -o /etc/apt/preferences.d/cuda-repository-pin-600 "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${NVIDIA_REPO_VERSION}/${NVIDIA_REPO_ARCHITECTURE}/cuda-ubuntu${NVIDIA_REPO_VERSION}.pin"
-apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${NVIDIA_REPO_VERSION}/${NVIDIA_REPO_ARCHITECTURE}/3bf863cc.pub"
-add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${NVIDIA_REPO_VERSION}/${NVIDIA_REPO_ARCHITECTURE}/ /"
+curl -fsSL "https://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_REPO_VERSION}/${NVIDIA_REPO_ARCHITECTURE}/8793F200.pub" |
+  gpg --dearmor -o /usr/share/keyrings/cuda-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/cuda-archive-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_REPO_VERSION}/${NVIDIA_REPO_ARCHITECTURE}/ /" |
+  tee /etc/apt/sources.list.d/cuda-${NVIDIA_REPO_VERSION}.list
 
 ## PowerShell
-curl -L -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/${UBUNTU_VERSION_ID}/packages-microsoft-prod.deb
+curl -L -o packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/${DEBIAN_VERSION_ID}/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb
 rm -f packages-microsoft-prod.deb
-add-apt-repository universe
-
-## Azure CLI
-mkdir -p /etc/apt/keyrings
-curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-    gpg --dearmor |
-    tee /etc/apt/keyrings/microsoft.gpg > /dev/null
-chmod go+r /etc/apt/keyrings/microsoft.gpg
-
-AZ_DIST=$(lsb_release -cs)
-echo "deb [arch=${DEBIAN_ARCHITECTURE} signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_DIST main" |
-    tee /etc/apt/sources.list.d/azure-cli.list
 
 apt-get -y update
 apt-get -y upgrade
@@ -163,6 +156,8 @@ APT_PACKAGES="$APT_PACKAGES libbluetooth-dev"
 APT_PACKAGES="$APT_PACKAGES libtirpc-dev"
 
 ## CUDA
+APT_PACKAGES="$APT_PACKAGES xz-utils"
+
 # The intent is to install everything that does not require an actual GPU, driver, or GUI.
 # Intentionally omitted: cuda-demo-suite-13-2 cuda-documentation-13-2 cuda-driver-*
 #                        cuda-gdb-13-2 cuda-gdb-src-13-2 cuda-nsight-* cuda-nvdisasm
@@ -171,20 +166,12 @@ APT_PACKAGES="$APT_PACKAGES libtirpc-dev"
 #                        cuda-toolkit-13-2 cuda-tools-13-2 cuda-command-line-tools-13-2
 #                        cuda-runtime-13-2
 #                        All libraries for which there is a -dev suffix included here
-# cudnn9-jit-cuda-13 : cudnn9-jit appears to conflict with cudnn9-dev packages:
-# root@c47a4cc2ea72:/# apt install cudnn9-jit-cuda-13
-# The following additional packages will be installed:
-#   cudnn9-jit-cuda-13-2 libcudnn9-jit-cuda-13 libcudnn9-jit-dev-cuda-13
-# The following packages will be REMOVED:
-#   cudnn9-cuda-13 cudnn9-cuda-13-2 libcudnn9-cuda-13 libcudnn9-dev-cuda-13 libcudnn9-static-cuda-13
-# The following NEW packages will be installed:
-#   cudnn9-jit-cuda-13 cudnn9-jit-cuda-13-2 libcudnn9-jit-cuda-13 libcudnn9-jit-dev-cuda-13
 APT_PACKAGES="$APT_PACKAGES cuda-cccl-13-2 cuda-compat-13-2 cuda-compiler-13-2 cuda-crt-13-2 \
   cuda-cudart-dev-13-2 cuda-cuobjdump-13-2 cuda-cupti-dev-13-2 cuda-cuxxfilt-13-2 \
   cuda-driver-dev-13-2 cuda-libraries-dev-13-2 cuda-minimal-build-13-2 cuda-nvcc-13-2 \
   cuda-nvml-dev-13-2 cuda-nvrtc-dev-13-2 cuda-nvtx-13-2 libnvvm-13-2 \
-  cuda-sanitizer-13-2 cuda-toolkit-13-2-config-common cudnn9-cuda-13 gds-tools-13-2 \
-  libcublas-13-2 libcudnn9-dev-cuda-13 libcufft-dev-13-2 libcurand-dev-13-2 libcusolver-dev-13-2 \
+  cuda-sanitizer-13-2 cuda-toolkit-13-2-config-common gds-tools-13-2 \
+  libcublas-13-2 libcufft-dev-13-2 libcurand-dev-13-2 libcusolver-dev-13-2 \
   libcusparse-dev-13-2 libnccl-dev libnpp-dev-13-2 libnvfatbin-dev-13-2 libnvjitlink-dev-13-2 \
   libnvjpeg-dev-13-2"
 
@@ -193,7 +180,7 @@ if [[ "$DEBIAN_ARCHITECTURE" == "amd64" ]]; then
 fi
 
 ## PowerShell + Azure
-APT_PACKAGES="$APT_PACKAGES azcopy azure-cli"
+APT_PACKAGES="$APT_PACKAGES azure-cli"
 
 if [[ "$DEBIAN_ARCHITECTURE" == "amd64" ]]; then
   APT_PACKAGES="$APT_PACKAGES powershell"
@@ -206,10 +193,19 @@ APT_PACKAGES="$APT_PACKAGES libspeechd-dev"
 if [[ $(grep microsoft /proc/version) ]]; then
 echo "Skipping install of ADO prerequisites on WSL."
 else
-APT_PACKAGES="$APT_PACKAGES libkrb5-3 zlib1g libicu74 debsums liblttng-ust1"
+APT_PACKAGES="$APT_PACKAGES libkrb5-3 zlib1g libicu76 debsums liblttng-ust1t64"
 fi
 
 apt-get --no-install-recommends -y install $APT_PACKAGES
+
+CUDNN_ARCHIVE=cudnn-${CUDNN_REDIST_ARCH}-${CUDNN_VERSION}_cuda13-archive
+curl -L -o /tmp/cudnn.tar.xz "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/${CUDNN_REDIST_ARCH}/${CUDNN_ARCHIVE}.tar.xz"
+mkdir -p /tmp/cudnn
+tar -xJf /tmp/cudnn.tar.xz -C /tmp/cudnn --strip-components=1
+cp -P /tmp/cudnn/include/cudnn*.h /usr/local/cuda/include/
+cp -P /tmp/cudnn/lib/libcudnn* /usr/local/cuda/lib64/
+chmod a+r /usr/local/cuda/include/cudnn*.h /usr/local/cuda/lib64/libcudnn*
+rm -rf /tmp/cudnn /tmp/cudnn.tar.xz
 
 if [[ "$DEBIAN_ARCHITECTURE" == "arm64" ]]; then
   curl -L -o /tmp/powershell-linux-arm64.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-arm64.tar.gz"
@@ -219,6 +215,13 @@ if [[ "$DEBIAN_ARCHITECTURE" == "arm64" ]]; then
   ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
   rm -f /tmp/powershell-linux-arm64.tar.gz
 fi
+
+curl -L -o /tmp/azcopy.tar.gz "$AZCOPY_URL"
+mkdir -p /tmp/azcopy
+tar xzf /tmp/azcopy.tar.gz -C /tmp/azcopy
+find /tmp/azcopy -name azcopy -type f -exec cp '{}' /usr/local/bin/azcopy ';'
+chmod +x /usr/local/bin/azcopy
+rm -rf /tmp/azcopy /tmp/azcopy.tar.gz
 
 rm -rf /var/lib/apt/lists/*
 

--- a/scripts/azure-pipelines/update-containers.yml
+++ b/scripts/azure-pipelines/update-containers.yml
@@ -30,20 +30,20 @@ jobs:
         az acr login --name vcpkgandroidwus
         # Note that this is marking the *previous* image as EOL, not the one we're building as it attaches
         # to the SHA to which the tag points, not the tag itself.
-        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-android:2026-02-10 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-android:2026-02-10"
-        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-android:2026-02-10 --platform linux/amd64 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-android:2026-02-10 linux/amd64"
-        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-04-20 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-linux:2026-01-20"
-        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-04-20 --platform linux/amd64 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-linux:2026-01-20 linux/amd64"
+        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-android:2026-07-07 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-android:2026-07-07"
+        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-android:2026-07-07 --platform linux/amd64 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-android:2026-07-07 linux/amd64"
+        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-07-07 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-linux:2026-07-07"
+        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-07-07 --platform linux/amd64 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-linux:2026-07-07 linux/amd64"
         # Note that this is an image for *targeting* arm64, it's still an amd64 image, hence linux/amd64
-        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-04-20 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-arm64-linux:2026-03-18"
-        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-04-20 --platform linux/amd64 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-arm64-linux:2026-03-18 linux/amd64"
+        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-07-07 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-arm64-linux:2026-07-07"
+        oras attach --artifact-type application/vnd.microsoft.artifact.lifecycle --annotation "vnd.microsoft.artifact.lifecycle.end-of-life.date=$EndDate" vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-07-07 --platform linux/amd64 || echo "WARNING: Failed to attach lifecycle metadata to vcpkg-arm64-linux:2026-07-07 linux/amd64"
         cd scripts/azure-pipelines/android
         # to explain the ulimit thing, see https://github.com/docker/buildx/issues/379
-        docker buildx build . -t vcpkgandroidwus.azurecr.io/vcpkg-android:2026-02-10 --build-arg BUILD_DATE=$BuildDate --ulimit nofile=1024:1024
-        docker push vcpkgandroidwus.azurecr.io/vcpkg-android:2026-02-10
+        docker buildx build . -t vcpkgandroidwus.azurecr.io/vcpkg-android:2026-07-07 --build-arg BUILD_DATE=$BuildDate --ulimit nofile=1024:1024
+        docker push vcpkgandroidwus.azurecr.io/vcpkg-android:2026-07-07
         cd ../linux
-        docker buildx build . -t vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-04-20 --build-arg BUILD_DATE=$BuildDate --ulimit nofile=1024:1024
-        docker push vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-04-20
+        docker buildx build . -t vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-07-07 --build-arg BUILD_DATE=$BuildDate --ulimit nofile=1024:1024
+        docker push vcpkgandroidwus.azurecr.io/vcpkg-linux:2026-07-07
         cd ../linux-arm64
-        docker buildx build . -t vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-04-20 --build-arg BUILD_DATE=$BuildDate --ulimit nofile=1024:1024
-        docker push vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-04-20
+        docker buildx build . -t vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-07-07 --build-arg BUILD_DATE=$BuildDate --ulimit nofile=1024:1024
+        docker push vcpkgandroidwus.azurecr.io/vcpkg-arm64-linux:2026-07-07


### PR DESCRIPTION
Recent vulnerability scanner tools have flagged minor DoS and similar reports with updates unavailable except through agreement with Canonical, such as:

* https://ubuntu.com/security/notices/USN-8248-1 (needs 2.16.01-1ubuntu0.1~esm1)
* https://ubuntu.com/security/notices/USN-8344-1 (needs 24.0+dfsg-1ubuntu1.3+esm1)
* https://ubuntu.com/security/notices/USN-8344-3 (needs 24.0+dfsg-1ubuntu1.3+esm3)

These are not relevant for the vcpkg build lab use case, where the machine lives only as long as a build and we capture build logs rather than release binaries. The vcpkg team is also unable to establish an ESM relationship with Canonical, since company policy normally prefers Azure Linux.

We still want to use a more typical Linux distribution here because it is more likely to match customer environments. We already use Azure Linux 3 for cases that do not need to look like customer deployments, such as the container hosts and official vcpkg-tool release builds.

Switching to upstream Debian should stay close to the previous environment while better matching the broader Debian-derivative ecosystem.

| Package | Before: Ubuntu 24.04 "Noble" | Debian 12 "Bookworm" | After: Debian 13 "Trixie" |
|---|---:|---:|---:|
| GCC package `gcc` | `4:13.2.0-7ubuntu1` | `4:12.2.0-3` | `4:14.2.0-1` |
| GCC executable | `13.3.0-6ubuntu2~24.04.1` | `12.2.0-14+deb12u1` | `14.2.0-19` |
| CMake | `3.28.3-1build7` | `3.25.1-1` | `3.31.6-2` |
| Ninja / `ninja-build` | `1.11.1-2` | `1.11.1-2~deb12u1` | `1.12.1-1` |
| curl | `8.5.0-2ubuntu10.10` | `7.88.1-10+deb12u14` | `8.14.1-2+deb13u3` |
| zip | `3.0-13ubuntu0.2` | `3.0-13` | `3.0-15` |
| unzip | `6.0-28ubuntu4.1` | `6.0-28` | `6.0-29` |
