### PR TITLE
[directx-headers, directx12-agility] Update for 1.619.4 release

### DIFF
--- a/ports/directx-headers/portfile.cmake
+++ b/ports/directx-headers/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectX-Headers
     REF v${VERSION}
-    SHA512 3c907ca4aa34dd6775321bc71267c041ab87a1d981c09ca53f8974891f4b47d01e35fefd164280da7ad7497e1c827d8bed4797ca1015c44a8aa563fa38055ec0
+    SHA512 21bf2d6e4fdcaa331afb6de20c87ebec59b5bad36c155655acd725fde46faedd4cf1503646857b2a5d02f50fbacd8c55de91a79b2a616b05535704de4fbe777e
     HEAD_REF main
 )
 

--- a/ports/directx-headers/vcpkg.json
+++ b/ports/directx-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx-headers",
-  "version": "1.619.1",
+  "version": "1.619.4",
   "description": "Official DirectX 12 Headers",
   "homepage": "https://devblogs.microsoft.com/directx/",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # DX12 SDK Debug Layer i
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 8d8525e95369e364120762b91d1f6d3770bab78135cff3dd958309c8bb9a19bdf141570d9d9e50a36f6de6cc6e7be30a7e39cf0af78ac41ea3134b41ddb0683e
+    SHA512 6a275381027ed758714eedf1ccaeea446b1d9afeddc1f6b6bbc3c85939ef9ffd02b7fae780cd50da635b66b09f5fce99535788551cd64e3663b9e59fe6f7d9de
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.619.3",
+  "version": "1.619.4",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2517,11 +2517,11 @@
       "port-version": 0
     },
     "directx-headers": {
-      "baseline": "1.619.1",
+      "baseline": "1.619.4",
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.619.3",
+      "baseline": "1.619.4",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx-headers.json
+++ b/versions/d-/directx-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d1c885da6a485da2d3c51e0f30996d22bbfe8de",
+      "version": "1.619.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c72ef469531efe40c3f03534597a92fe3484dd0f",
       "version": "1.619.1",
       "port-version": 0

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7eb3e601e4afc17395f2f1c31be8016f2f121c67",
+      "version": "1.619.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "580f82ca685a63f9a7275d13e8b1e01d92945bb5",
       "version": "1.619.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
