### PR TITLE
[chess-engine] Add new port

### DIFF
--- a/ports/chess-engine/portfile.cmake
+++ b/ports/chess-engine/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ByteMe6/chess-engine
+    REF "v${VERSION}"
+    SHA512 4cf92b26c135cb87c4aff96fb41a2bce71f7f60de6fdf8a67675cd941927a5d1d5be3570cb97afdbe582d02c4375597275cedc42b1cffe83f6fe22fb590c7b9e
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/src/chessEngine.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/chess-engine/vcpkg.json
+++ b/ports/chess-engine/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "chess-engine",
+  "version": "1.1.0",
+  "description": "Minimal chess engine in C++17 - move generation, validation and ASCII board rendering. STL only.",
+  "homepage": "https://github.com/ByteMe6/chess-engine",
+  "license": "GPL-3.0-only"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1732,6 +1732,10 @@
       "baseline": "2.1.4",
       "port-version": 0
     },
+    "chess-engine": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "chipmunk": {
       "baseline": "7.0.3",
       "port-version": 7

--- a/versions/c-/chess-engine.json
+++ b/versions/c-/chess-engine.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2f6e0e3d45a22f0e967ebb814f6670844d650e57",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new port: [chess-engine](https://github.com/ByteMe6/chess-engine) — a minimal header-only chess engine in C++17 (move generation, validation, check/mate/stalemate, castling, en passant, promotion, draw rules, FEN import/export, ASCII board rendering). No dependencies beyond the STL.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.