### PR TITLE
[livepp] Update to 2.11.3

### DIFF
--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS https://liveplusplus.tech/downloads/${LIVEPP_FILE}
     FILENAME "${LIVEPP_FILE}"
-    SHA512 1b75d9922a46dc6e4176c6581a5c457e3f7f00d5a1a26e3976cab619c45c834730088169fe8dfd5f95d543851db7467f3dd0d92733d4bc00f8da5bfdef55af3d
+    SHA512 1ed5b9ff453bb5b290f97cdfdcdd3ca0e85842fa6a45418ab628d8f86c2d07ae42d19e3893201e19a72c7e63a44ad4e194c3db39ef72eedbee40231f7640349d
 )
 
 vcpkg_extract_source_archive(

--- a/ports/livepp/vcpkg.json
+++ b/ports/livepp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "livepp",
-  "version-semver": "2.11.2",
+  "version-semver": "2.11.3",
   "description": "Hot-reload for C & C++ transforms workflows and decreases iteration times.",
   "homepage": "https://liveplusplus.tech/",
   "documentation": "https://liveplusplus.tech/docs/documentation.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6153,7 +6153,7 @@
       "port-version": 0
     },
     "livepp": {
-      "baseline": "2.11.2",
+      "baseline": "2.11.3",
       "port-version": 0
     },
     "llama-cpp": {

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8289c23c661628a0b37ab3a6049083b4a56e4ca",
+      "version-semver": "2.11.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "95f6017c139b140d8b7f57f1f8510a091499693a",
       "version-semver": "2.11.2",
       "port-version": 0


### PR DESCRIPTION
Update livepp port from 2.11.2 to 2.11.3 : https://liveplusplus.tech/releases.html

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.