### PR TITLE
[doctest] Update to 2.5.3

### DIFF
--- a/ports/doctest/portfile.cmake
+++ b/ports/doctest/portfile.cmake
@@ -1,9 +1,10 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO doctest/doctest
     REF "v${VERSION}"
-    SHA512 9105552d3e6a1e21f6342cf3a3ed4521d1535336fbbd2243515092206746aa1da90a2e0df8043079b181114b63bac1f3f414e34e391a6815eba09e28802342de
+    SHA512 d7222ae62cf2ac0f858567af0e539bd34cef47827004f805261007943e8e02370fcf16cbf0302581766353bf28317dd280a885fdc775baaa3e519aa2cf2f2eca
     HEAD_REF master
 )
 
@@ -11,13 +12,13 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
+        -DDOCTEST_WITH_MAIN_IN_STATIC_LIB=OFF
         -DDOCTEST_WITH_TESTS=OFF
 )
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/doctest/vcpkg.json
+++ b/ports/doctest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "doctest",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "The fastest feature-rich C++11/14/17/20 single-header testing framework",
   "homepage": "https://github.com/doctest/doctest",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2601,7 +2601,7 @@
       "port-version": 0
     },
     "doctest": {
-      "baseline": "2.5.2",
+      "baseline": "2.5.3",
       "port-version": 0
     },
     "double-conversion": {

--- a/versions/d-/doctest.json
+++ b/versions/d-/doctest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0803364e7e4a64135c72f47bf4670ca89a964bc2",
+      "version": "2.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "723776a5f5e78a6c0bfae3399d6e2ba5073a23c6",
       "version": "2.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: The previous removal of the whole `/lib` dir also removed the pkg file