### PR TITLE
[embree] Update to 4.4.1

### DIFF
--- a/ports/embree/portfile.cmake
+++ b/ports/embree/portfile.cmake
@@ -1,12 +1,8 @@
-if(EXISTS "${CURRENT_INSTALLED_DIR}/share/embree/embree-config.cmake")
-    message(FATAL_ERROR "Port embree3 must be removed before installing embree.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RenderKit/embree
     REF v${VERSION}
-    SHA512 5e77a033192ade6562b50d32c806c6a467580722898ca52ccfe002b51279314055e9c0e6c969651b0d03716d04ab249301340cd2790556a0dbfb8c296e8f0574
+    SHA512 5700d6e16b3e9e5f0d087e421c831e14f054769dfa30edb45791fee3ab33c698355d8fad86791cea6bf200ebe7ce64f0394063d29dd927afe93d345c2cd6897a
     HEAD_REF master
     PATCHES
         avoid-library-conflicts.diff
@@ -57,6 +53,10 @@ if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
             -DCOMPILER_SUPPORTS_AVX512=OFF
         )
     endif()
+endif()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    list(APPEND FEATURE_OPTIONS "-DCOMPILER_SUPPORTS_AVX512=OFF")
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/embree/vcpkg.json
+++ b/ports/embree/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "embree",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "High Performance Ray Tracing Kernels.",
   "homepage": "https://github.com/RenderKit/embree",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2833,7 +2833,7 @@
       "port-version": 0
     },
     "embree": {
-      "baseline": "4.4.0",
+      "baseline": "4.4.1",
       "port-version": 0
     },
     "enchantum": {

--- a/versions/e-/embree.json
+++ b/versions/e-/embree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a495fc71b3251107850dbd9fdff6d388628d067",
+      "version": "4.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b9551ed23e8d3b213337a4128c234e47cf11363e",
       "version": "4.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: embree3 was removed in #47815. Therefore I think it it okay to remove the compatibility check.