### PR TITLE
[libsodium] support non-MSVC compilers on Windows via the make-based …

### DIFF
--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -13,7 +13,19 @@ vcpkg_from_github(
         001-mingw-i386.patch
 )
 
+# The msbuild solution only builds with MSVC; other compilers targeting
+# windows (e.g. clang, in cross builds or clang-based triplets) go through
+# the make-based path like every other platform.
+set(USE_MSBUILD OFF)
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_cmake_get_vars(cmake_vars_file)
+    include("${cmake_vars_file}")
+    if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "[/\\\\]cl\\.exe$")
+        set(USE_MSBUILD ON)
+    endif()
+endif()
+
+if(USE_MSBUILD)
     set(lib_linkage "LIB")
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         set(lib_linkage "DLL")
@@ -55,6 +67,20 @@ else()
     if(NOT VCPKG_TARGET_IS_MINGW)
         list(APPEND OPTIONS --disable-pie)
     endif()
+    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+        if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+            message(FATAL_ERROR "Shared libsodium is not implemented for non-MSVC compilers on Windows: libtool silently builds an unusable static archive for this target. Build libsodium static, or with MSVC.")
+        endif()
+        # getpid links via the oldnames.lib compatibility alias, so
+        # configure's link check false-passes; no header declares it for
+        # the MSVC CRT, breaking compilation. The msbuild-built binaries
+        # never define HAVE_GETPID either.
+        list(APPEND OPTIONS "ac_cv_func_getpid=no")
+        # The library's own objects must not reference its symbols through
+        # dllimport; export.h defaults to that when neither SODIUM_STATIC nor
+        # SODIUM_DLL_EXPORT is defined, which the make build does not do.
+        vcpkg_replace_string("${SOURCE_PATH}/src/libsodium/include/sodium/export.h" "#ifdef SODIUM_STATIC" "#if 1")
+    endif()
 
     vcpkg_make_configure(
         AUTORECONF
@@ -72,7 +98,7 @@ endif()
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/sodium/export.h" "#ifdef SODIUM_STATIC" "#if 1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/sodium/export.h" "#ifdef SODIUM_STATIC" "#if 1" IGNORE_UNCHANGED)
 endif()
 
 # vcpkg legacy

--- a/ports/libsodium/vcpkg.json
+++ b/ports/libsodium/vcpkg.json
@@ -1,14 +1,19 @@
 {
   "name": "libsodium",
   "version": "1.0.22",
+  "port-version": 1,
   "description": "A modern and easy-to-use crypto library",
   "homepage": "https://libsodium.org/",
   "license": "ISC",
   "dependencies": [
     {
-      "name": "vcpkg-make",
+      "name": "vcpkg-cmake-get-vars",
       "host": true,
-      "platform": "!windows | mingw"
+      "platform": "windows & !mingw"
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
     },
     {
       "name": "vcpkg-msbuild",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5682,7 +5682,7 @@
     },
     "libsodium": {
       "baseline": "1.0.22",
-      "port-version": 0
+      "port-version": 1
     },
     "libsonic": {
       "baseline": "0.2.0",

--- a/versions/l-/libsodium.json
+++ b/versions/l-/libsodium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95eb2b61a8632cbfe65fd3cf259f8805b8792364",
+      "version": "1.0.22",
+      "port-version": 1
+    },
+    {
       "git-tree": "74ee7dfd5fc96bb0b291f6ebe61d3bef57f80512",
       "version": "1.0.22",
       "port-version": 0


### PR DESCRIPTION
…build

The msbuild solution always compiles with MSVC, bypassing toolchains where the triplet selects another compiler (e.g. clang through a chainloaded toolchain, or cross builds from hosts without MSVC tools). Detect the configured compiler with vcpkg_cmake_get_vars and route non-cl compilers through the same vcpkg_make path every other platform uses.

The only accommodation needed is pre-seeding configure's getpid check: it false-passes by linking against the oldnames.lib compatibility alias while no MSVC CRT header declares getpid(), which later breaks compilation under C99+ implicit-declaration rules. An upstream fix for the check itself has been submitted to jedisct1/libsodium.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
