### PR TITLE
[openssl] support non-MSVC compilers on Windows via the unix flow

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -73,7 +73,19 @@ if(OPENSSL_NO_AUTOLOAD_CONFIG)
     vcpkg_list(APPEND CONFIGURE_OPTIONS no-autoload-config)
 endif()
 
+# The nmake flow only builds with MSVC; other compilers targeting Windows
+# (e.g. clang through a chainloaded toolchain, or cross builds from hosts
+# without MSVC tools) go through the unix flow with a clang Configure target.
+set(use_nmake_flow OFF)
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_cmake_get_vars(cmake_vars_file)
+    include("${cmake_vars_file}")
+    if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "[/\\\\]cl\\.exe$")
+        set(use_nmake_flow ON)
+    endif()
+endif()
+
+if(use_nmake_flow)
     include("${CMAKE_CURRENT_LIST_DIR}/windows/portfile.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/install-pc-files.cmake")
 else()

--- a/ports/openssl/unix/90-clang-windows.conf
+++ b/ports/openssl/unix/90-clang-windows.conf
@@ -1,0 +1,24 @@
+# Configure target for building openssl with a GNU-driver clang targeting
+# x86_64-pc-windows-msvc through the unix flow (native on Windows or
+# cross-compiled). CC/AR/RANLIB and the SDK include paths arrive via the
+# environment; this target adds what the environment cannot: the target
+# triple, Windows system defines, the dynamic CRT selection, and the
+# Windows link libraries.
+my %targets = (
+    "clang-windows-msvc" => {
+        inherit_from     => [ "BASE_unix" ],
+        cflags           => picker(default => "--target=x86_64-pc-windows-msvc",
+                                   debug   => "-Xclang --dependent-lib=msvcrtd -D_DEBUG",
+                                   release => "-Xclang --dependent-lib=msvcrt"),
+        defines          => add("_MT", "_DLL", "UNICODE", "_UNICODE",
+                                "WIN32_LEAN_AND_MEAN", "_CRT_SECURE_NO_WARNINGS"),
+        lib_cppflags     => "-DL_ENDIAN",
+        sys_id           => "WIN64A",
+        asm_arch         => 'x86_64',
+        perlasm_scheme   => "mingw64",
+        bn_ops           => "SIXTY_FOUR_BIT",
+        thread_scheme    => "winthreads",
+        dso_scheme       => "win32",
+        ex_libs          => add("-lws2_32", "-lgdi32", "-lcrypt32", "-ladvapi32", "-luser32"),
+    },
+);

--- a/ports/openssl/unix/portfile.cmake
+++ b/ports/openssl/unix/portfile.cmake
@@ -118,6 +118,18 @@ elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
     if(NOT " ${VCPKG_DETECTED_CMAKE_C_FLAGS} " MATCHES " -pthread ")
         vcpkg_list(APPEND CONFIGURE_OPTIONS no-threads)
     endif()
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    # clang targeting windows-msvc through the unix flow. The Configure
+    # target adds what the environment cannot: Windows system defines, the
+    # CRT selection, the Windows link libraries and the perlasm flavor.
+    # Module/engine DSOs stay off; the win32 DSO scheme requires them to be
+    # built as DLLs, which the unix flow does not do.
+    if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        message(FATAL_ERROR "Only x64 is implemented for clang targeting windows-msvc")
+    endif()
+    set(OPENSSL_ARCH clang-windows-msvc)
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/90-clang-windows.conf" DESTINATION "${SOURCE_PATH}/Configurations")
+    vcpkg_list(APPEND CONFIGURE_OPTIONS no-module no-dso no-engine)
 else()
     message(FATAL_ERROR "Unknown platform")
 endif()

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.6.3",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7498,7 +7498,7 @@
     },
     "openssl": {
       "baseline": "3.6.3",
-      "port-version": 0
+      "port-version": 1
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e848153f34617931cc4f052dc31337a11b93a8da",
+      "version": "3.6.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "b4a2360e8425d8d5e2a24436804b592bef26980b",
       "version": "3.6.3",
       "port-version": 0


### PR DESCRIPTION
The port's Windows path always builds through nmake with cl, bypassing toolchains where the triplet selects another compiler (e.g. clang through a chainloaded toolchain, or cross builds from hosts without MSVC tools — the nmake flow cannot run there at all). Same situation as libsodium's msbuild path in #52803.

This PR detects the configured compiler with `vcpkg_cmake_get_vars` and routes non-`cl.exe` compilers through the existing unix flow, adding a `clang-windows-msvc` Configure target that supplies what the environment cannot: the target triple, Windows system defines, CRT selection, Windows link libraries, and the `mingw64` perlasm scheme — clang assembles the gas-syntax perlasm output directly to COFF, so the assembly crypto (AES-NI, AVX-512, SHA extensions) stays enabled. Modules/engine DSOs are disabled for this target; the guard limits it to x64 (other architectures would need their own Configure targets).

MSVC and non-Windows builds are unchanged — the nmake flow and its `install-pc-files` post-processing are byte-identical, only reached through the new compiler check.

Tested: openssl 3.6.3 cross-compiled for x64-windows from a Linux host with clang 22 through this exact port: configure/build/install green for release and debug, producing COFF `libcrypto.a`/`libssl.a` with the perlasm objects included (verified `T aesni_cbc_encrypt` and the aesni/vpaes/avx512 object files in the archive). Related: #52803, #52808.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download — n/a, no source change
- [x] `./vcpkg x-add-version openssl` was run (3.6.3#1)
