### PR TITLE
[ini-cpp] Add new port

### DIFF
--- a/ports/ini-cpp/portfile.cmake
+++ b/ports/ini-cpp/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SSARCandy/ini-cpp
+    REF "v${VERSION}"
+    SHA512 14f50416eafa3acb457d64a64c04e4e9b2d666519bf540e879ee0b5df8b078c8c776d87bb353b10fc8852566247d5b46af3da9feba926a27c1526594e77381e4
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/ini/ini.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/ini")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/ini-cpp/usage
+++ b/ports/ini-cpp/usage
@@ -1,0 +1,4 @@
+ini-cpp is header-only and can be used from CMake via:
+
+    find_path(INI_CPP_INCLUDE_DIRS "ini/ini.h")
+    target_include_directories(main PRIVATE ${INI_CPP_INCLUDE_DIRS})

--- a/ports/ini-cpp/vcpkg.json
+++ b/ports/ini-cpp/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "ini-cpp",
+  "version": "2.0.0",
+  "description": "Single-header INI file reader and writer for modern C++ (C++17), with type-aware getters and sensible defaults",
+  "homepage": "https://github.com/SSARCandy/ini-cpp",
+  "license": "BSD-3-Clause"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4040,6 +4040,10 @@
       "baseline": "2023-04-12",
       "port-version": 0
     },
+    "ini-cpp": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "inih": {
       "baseline": "62",
       "port-version": 1

--- a/versions/i-/ini-cpp.json
+++ b/versions/i-/ini-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f8ec2b3ee7ce24b444c05ddf829478396da12dc4",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds [ini-cpp](https://github.com/SSARCandy/ini-cpp), a single-header INI file reader/writer for C++17 (type-aware getters with defaults, round-trip write support). BSD-3-Clause, developed publicly since 2020.

Tested locally with `./vcpkg install ini-cpp --triplet x64-linux`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development — first release v1.0.0 in 2020-05; latest v2.0.0.
- [x] The packaged project shows strong association with the chosen port name.
    - [x] The project is amongst the first web search results for "ini-cpp": the exact-name repo https://github.com/SSARCandy/ini-cpp is the top result; it is also listed under Configuration on fffaraz/awesome-cpp.
- [x] Optional dependencies of the build are all controlled by the port — header-only, nothing is built; no dependencies.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says (tag v2.0.0 → `2.0.0`).
- [x] The license declaration in `vcpkg.json` matches what upstream says (BSD-3-Clause, LICENSE.txt).
- [x] The installed "copyright" file matches what upstream says (upstream LICENSE.txt).
- [x] The source code of the component installed comes from an authoritative source (upstream GitHub release tarball).
- [x] The generated "usage text" is brief and accurate — a usage file is provided because the port installs no CMake config (plain header), using the standard `find_path` pattern.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version` and committing the result.
- [x] Exactly one version is added in each modified versions file.