### PR TITLE
[cofetch] Add new port

### DIFF
--- a/ports/cofetch/portfile.cmake
+++ b/ports/cofetch/portfile.cmake
@@ -1,0 +1,25 @@
+# Header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SSARCandy/cofetch
+    REF "v${VERSION}"
+    SHA512 f6249895461d8db7b2f3d7801944fadaeab85fe648bbc01840f523dafd23c4fe267a2669540a892c4a3af1d50296d0d4f48b497a8de019fd11adbe2e6ea4e495
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCOFETCH_INSTALL=ON
+        -DCOFETCH_BUILD_EXAMPLES=OFF
+        -DCOFETCH_USE_VENDORED_ASIO=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cofetch)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cofetch/vcpkg.json
+++ b/ports/cofetch/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "cofetch",
+  "version": "0.1.2",
+  "description": "Chainable async HTTP client for C++ event loops, built on libcurl multi and ASIO. One API serves callbacks, std::future, and C++20 co_await",
+  "homepage": "https://github.com/SSARCandy/cofetch",
+  "license": "MIT",
+  "dependencies": [
+    "asio",
+    "curl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1888,6 +1888,10 @@
       "baseline": "2024-09-04",
       "port-version": 0
     },
+    "cofetch": {
+      "baseline": "0.1.2",
+      "port-version": 0
+    },
     "coin": {
       "baseline": "4.0.8",
       "port-version": 1

--- a/versions/c-/cofetch.json
+++ b/versions/c-/cofetch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "311c32c4633cb5018f41b11326c64466ae4d42e3",
+      "version": "0.1.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds [cofetch](https://github.com/SSARCandy/cofetch), a header-only chainable async HTTP client for C++ event loops built on libcurl multi + ASIO — one API serves plain callbacks, `std::future`, and C++20 `co_await`. MIT. Docs: https://ssarcandy.tw/cofetch

Tested locally with `./vcpkg install cofetch --triplet x64-linux`, plus a `find_package(cofetch CONFIG)` consumer that compiles, links, and runs against the installed package.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Some other reason (please explain) — young project (first release 2026-07) but complete and actively maintained: CI matrix (gcc/clang/macOS, C++17 floor job, Boost.Asio job), 98% test coverage, benchmark suite, full docs site. I am the upstream maintainer and will keep the port current. If the project needs more public history before inclusion, I'm happy to close and come back later.
- [x] The packaged project shows strong association with the chosen port name.
    - [x] The project is amongst the first web search results for "cofetch c++": https://github.com/SSARCandy/cofetch and https://ssarcandy.tw/cofetch
- [x] Optional dependencies of the build are all controlled by the port — `asio` and `curl` are unconditional dependencies in `vcpkg.json`; the vendored asio submodule and examples are explicitly disabled; Boost.Asio mode is off by default and not exposed.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says (tag v0.1.2 → `0.1.2`).
- [x] The license declaration in `vcpkg.json` matches what upstream says (MIT).
- [x] The installed "copyright" file matches what upstream says (upstream LICENSE).
- [x] The source code of the component installed comes from an authoritative source (upstream GitHub release tarball).
- [x] The generated "usage text" is brief and accurate — no usage file added; the auto-generated text (`find_package(cofetch CONFIG REQUIRED)` + `cofetch::cofetch`) is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version` and committing the result.
- [x] Exactly one version is added in each modified versions file.