### PR TITLE
[libavif] Add svt feature for SVT-AV1 encoding

### DIFF
--- a/ports/libavif/dependencies.diff
+++ b/ports/libavif/dependencies.diff
@@ -10,7 +10,7 @@ index a28e6c3..aaeb5d2 100644
      set(AVIF_LIB_USE_CXX ON)
  endif(AVIF_LIBYUV_ENABLED)
  
-@@ -849,13 +850,38 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+@@ -849,13 +850,43 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
  
      # Enable CMake configs in VCPKG mode
      if(BUILD_SHARED_LIBS OR VCPKG_TARGET_TRIPLET)
@@ -24,6 +24,11 @@ index a28e6c3..aaeb5d2 100644
 +                find_package(AOM CONFIG REQUIRED)
 +                list(APPEND avif_static_link_libs AOM::aom)
 +                string(APPEND avif_find_dependencies "find_dependency(AOM CONFIG)\n")
++            endif()
++            if(AVIF_CODEC_SVT_ENABLED)
++                find_package(SVT-AV1 CONFIG REQUIRED)
++                list(APPEND avif_static_link_libs SVT-AV1::SVT-AV1)
++                string(APPEND avif_find_dependencies "find_dependency(SVT-AV1 CONFIG)\n")
 +            endif()
 +            if(AVIF_CODEC_DAV1D_ENABLED)
 +                list(APPEND avif_static_link_libs ${DAV1D_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -17,6 +17,9 @@ endif()
 if("dav1d" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS "-DAVIF_CODEC_DAV1D=SYSTEM")
 endif()
+if("svt" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS "-DAVIF_CODEC_SVT=SYSTEM")
+endif()
 
 vcpkg_find_acquire_program(PKGCONFIG)
 

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libavif",
   "version-semver": "1.4.2",
+  "port-version": 1,
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",
@@ -26,6 +27,13 @@
       "description": "dav1d decoder library",
       "dependencies": [
         "dav1d"
+      ]
+    },
+    "svt": {
+      "description": "SVT-AV1 encoder library",
+      "supports": "!x86 & !arm32 & !uwp",
+      "dependencies": [
+        "svt-av1"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4798,7 +4798,7 @@
     },
     "libavif": {
       "baseline": "1.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libb2": {
       "baseline": "0.98.1",

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cad3f5196a32c420fb9aebfc2a8a5876e5c36129",
+      "version-semver": "1.4.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc1d820f4db3384d7184714b82878fe8fa5b71fc",
       "version-semver": "1.4.2",
       "port-version": 0


### PR DESCRIPTION
Adds an optional `svt` feature to the `libavif` port that enables the SVT-AV1 encoder, so developers can encode AVIF images using SVT-AV1. The feature is opt-in (disabled by default, matching the existing `aom` and `dav1d` features) and reuses the existing `svt-av1` port as the provider.

### Changes
- `vcpkg.json`: adds a `svt` feature depending on `svt-av1`, with `"supports": "!x86 & !arm32 & !uwp"` to match the `svt-av1` port; bumps `port-version` to 1.
- `portfile.cmake`: maps the feature to `-DAVIF_CODEC_SVT=SYSTEM`, mirroring the `aom`/`dav1d` blocks.
- `dependencies.diff`: extends the static CMake-config export so static consumers link `SvtAv1Enc` and get `find_dependency(SvtAv1Enc CONFIG)`.

### Verification
Built locally with `./vcpkg install libavif[svt]` on `arm64-osx`: builds and installs cleanly, `libavif-config.cmake` contains `find_dependency(SvtAv1Enc CONFIG)`, and `libavif.pc` lists `Requires: libjpeg SvtAv1Enc`. Existing `libavif`, `libavif[aom]`, and `libavif[dav1d]` remain unaffected (feature is not default).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (No downloads changed.)
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary. (Feature scoped to `!x86 & !arm32 & !uwp` to match `svt-av1`.)
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
