### PR TITLE
[tree-sitter] Update to 0.26.11

### DIFF
--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter
     REF "v${VERSION}"
-    SHA512 43549754bcc862ad796c6e30434fb25ace6188ae6b607561f907f43f50131633b454e20d5d5abdc03a590a6e77bd1fe4932ac46fd93683ab34bba7a265aef0e4
+    SHA512 2175f7d1f913fffaba7395baa7b0a3228172bdc25169d22cf3e39fa3841df1a9902031e248e417328f8ea3e48e7042d34bf85a36c8545a79ca5f7321c6b9d848
     HEAD_REF master
     PATCHES
         unofficial-cmake.diff

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version-semver": "0.26.10",
+  "version-semver": "0.26.11",
   "description": "An incremental parsing system for programming tools.",
   "homepage": "https://tree-sitter.github.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10329,7 +10329,7 @@
       "port-version": 1
     },
     "tree-sitter": {
-      "baseline": "0.26.10",
+      "baseline": "0.26.11",
       "port-version": 0
     },
     "tree-sitter-c": {

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eab591fac8d2af2d1d53482a46ba507a6581f6de",
+      "version-semver": "0.26.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "7764961ba006e780f31f92f78cae1b0e30d617d1",
       "version-semver": "0.26.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

[tree-sitter](https://github.com/tree-sitter/tree-sitter) Update to [0.26.11](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.11)