### PR TITLE
[soundtouch] update to 2.4.1

### DIFF
--- a/ports/soundtouch/portfile.cmake
+++ b/ports/soundtouch/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     GITHUB_HOST https://codeberg.org
     REPO soundtouch/soundtouch
     REF ${VERSION}
-    SHA512 97e4afcce100f210d89c665dd83f4eaa7b0bec88ba35ba1cf29729e9260d143a5c0f89156646c4dddc83030c5f6b8493c6abc1a82bfba52ed6a87929c8e0fdea
+    SHA512 da289a53c155188b6a0d696838b9711030594df2746a026288aa58ed029bfccb114f588d53f40d0e6b6f23c6e550e6e7f3b64aa21bfebc9b5a508f126be30a5d
     HEAD_REF master
     PATCHES
         fix-install-includes.patch

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -21,13 +21,7 @@
     },
     "soundtouchdll": {
       "description": "Build the SoundTouchDLL C wrapper dynamic library",
-      "supports": "!staticcrt",
-      "dependencies": [
-        {
-          "name": "atlmfc",
-          "platform": "windows"
-        }
-      ]
+      "supports": "!static"
     }
   }
 }

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "soundtouch",
-  "version": "2.4.0",
-  "port-version": 2,
+  "version": "2.4.1",
   "description": "SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.",
   "homepage": "https://www.surina.net/soundtouch",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9561,8 +9561,8 @@
       "port-version": 0
     },
     "soundtouch": {
-      "baseline": "2.4.0",
-      "port-version": 2
+      "baseline": "2.4.1",
+      "port-version": 0
     },
     "soxr": {
       "baseline": "0.1.3",

--- a/versions/s-/soundtouch.json
+++ b/versions/s-/soundtouch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4876f64c021f998ab9aebdd4523333d213128b38",
+      "version": "2.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f59f015c5d4e9b45ae7a9348348a96306e81907b",
       "version": "2.4.0",
       "port-version": 2


### PR DESCRIPTION
This just followes a patch version bump to 2.4.1.
The diver was a build failure die to an altered tar ball on code berg for 2.4.0 no longer passing the checksum test. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The ersion database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

