### PR TITLE
[ecm] update to 6.28.0

### DIFF
--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/extra-cmake-modules
     REF "v${VERSION}"
-    SHA512 789f7a876acd2187b1363c1d863bf3a2726a9f1ffe08a2e2e4a2d8b41fb054fb7b65cd078619205faed7b59f61c3af78b08ac778a37390e21603646a800cb093
+    SHA512 1cf0785d61191305e62f3374a11f98de7bcceab5d03ee30ad178bb95c310c7f1ef86b9ba6f5c7f4de375000784b7981006361f4fa0c39436165dd45a6566e7d3
     HEAD_REF master
     PATCHES
         fix_generateqmltypes.patch # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/201

--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ecm",
-  "version": "6.27.0",
+  "version": "6.28.0",
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://invent.kde.org/frameworks/extra-cmake-modules",
   "documentation": "https://api.kde.org/ecm/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2777,7 +2777,7 @@
       "port-version": 1
     },
     "ecm": {
-      "baseline": "6.27.0",
+      "baseline": "6.28.0",
       "port-version": 0
     },
     "ecos": {

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9de734f61a70dd89c58b996418e001e8dc88067b",
+      "version": "6.28.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5e0c7944f8a64ba368440318a4a583af715fb0e9",
       "version": "6.27.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/KDE/extra-cmake-modules/releases/tag/v6.28.0
