### PR TITLE
[libzim] update to 9.8.1

### DIFF
--- a/ports/libzim/cross-builds.diff
+++ b/ports/libzim/cross-builds.diff
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index add8aa0..1f085d5 100644
+index 900feb8..e34a7b3 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,9 +1,9 @@
  project('libzim', ['c', 'cpp'],
-   version : '9.8.0',
+   version : '9.8.1',
    license : 'GPL2',
 -  default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 +  default_options : ['c_std=c11', 'cpp_std=c++17'])

--- a/ports/libzim/portfile.cmake
+++ b/ports/libzim/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openzim/libzim
     REF "${VERSION}"
-    SHA512 dbddee0a7beadc041df416e3ecc2c0dba4afacfb4a5245dd02b4466d582979d9eeb8e027e095bf719f856c95563653e6d6d3b2fae59315d997f3740eac4b392c
+    SHA512 16ea86511991be2f3c6deb47a96e6578c2f8117d1783508b6f10d89a42fa7ec19cf8dca6cde34f537a5b715240ec1a0ebee0d27081e3a2195c9ff8c59317639f
     HEAD_REF main
     PATCHES
         cross-builds.diff

--- a/ports/libzim/vcpkg.json
+++ b/ports/libzim/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libzim",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "The Libzim is the reference implementation for the ZIM file format. It's a software library to read and write ZIM files on many systems and architectures. More information about the ZIM format and the openZIM project at https://openzim.org/.",
   "homepage": "https://github.com/openzim/libzim",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6105,7 +6105,7 @@
       "port-version": 0
     },
     "libzim": {
-      "baseline": "9.8.0",
+      "baseline": "9.8.1",
       "port-version": 0
     },
     "libzip": {

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cf29f8705786767377f7a047fa3888bbd59cca7",
+      "version": "9.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2e92226ca26dc4a480d7adb958ae003be8eb440e",
       "version": "9.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/openzim/libzim/releases/tag/9.8.1
