### PR TITLE
[luau] update to 0.729

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f215957..b8462b8 100644
+index bfbda9a..4ccd3bd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,45 +87,45 @@ add_library(Luau.VM.Internals INTERFACE)
+@@ -89,51 +89,51 @@ add_library(Luau.VM.Internals INTERFACE)
  include(Sources.cmake)
  
  target_compile_features(Luau.Common PUBLIC cxx_std_17)
@@ -23,6 +23,14 @@ index f215957..b8462b8 100644
 -target_include_directories(Luau.Bytecode PUBLIC Bytecode/include)
 +target_include_directories(Luau.Bytecode PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Bytecode/include> $<INSTALL_INTERFACE:include/luau>)
  target_link_libraries(Luau.Bytecode PUBLIC Luau.Common)
+ 
+ target_compile_features(Luau.Inliner PUBLIC cxx_std_17)
+-target_include_directories(Luau.Inliner PUBLIC Inliner/include)
++target_include_directories(Luau.Inliner PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Inliner/include> $<INSTALL_INTERFACE:include/luau>)
+ target_include_directories(Luau.Inliner PRIVATE Bytecode/src)
+-target_link_libraries(Luau.Inliner PRIVATE Luau.VM Luau.VM.Internals)
++target_link_libraries(Luau.Inliner PRIVATE Luau.VM $<BUILD_INTERFACE:Luau.VM.Internals>)
+ target_link_libraries(Luau.Inliner PUBLIC Luau.Bytecode)
  
  target_compile_features(Luau.Compiler PUBLIC cxx_std_17)
 -target_include_directories(Luau.Compiler PUBLIC Compiler/include)
@@ -59,30 +67,25 @@ index f215957..b8462b8 100644
  target_link_libraries(Luau.Require PUBLIC Luau.Config Luau.VM)
  
  target_include_directories(isocline PUBLIC extern/isocline/include)
-@@ -230,22 +230,6 @@ if(MSVC AND LUAU_BUILD_TESTS)
-     set_target_properties(Luau.CLI.Test PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
+@@ -240,7 +240,7 @@ if(MSVC AND LUAU_BUILD_TESTS)
  endif()
  
--# embed .natvis inside the library debug information
+ # embed .natvis inside the library debug information
 -if(MSVC)
--    target_link_options(Luau.Ast INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/Ast.natvis)
--    target_link_options(Luau.Analysis INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/Analysis.natvis)
--    target_link_options(Luau.CodeGen INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/CodeGen.natvis)
--    target_link_options(Luau.VM INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/VM.natvis)
--endif()
--
--# make .natvis visible inside the solution
++if(0)
+     target_link_options(Luau.Ast INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/Ast.natvis)
+     target_link_options(Luau.Analysis INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/Analysis.natvis)
+     target_link_options(Luau.CodeGen INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/CodeGen.natvis)
+@@ -248,7 +248,7 @@ if(MSVC)
+ endif()
+ 
+ # make .natvis visible inside the solution
 -if(MSVC_IDE)
--    target_sources(Luau.Ast PRIVATE tools/natvis/Ast.natvis)
--    target_sources(Luau.Analysis PRIVATE tools/natvis/Analysis.natvis)
--    target_sources(Luau.CodeGen PRIVATE tools/natvis/CodeGen.natvis)
--    target_sources(Luau.VM PRIVATE tools/natvis/VM.natvis)
--endif()
--
- # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
- add_library(osthreads INTERFACE)
- if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
-@@ -338,3 +322,57 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
++if(0)
+     target_sources(Luau.Ast PRIVATE tools/natvis/Ast.natvis)
+     target_sources(Luau.Analysis PRIVATE tools/natvis/Analysis.natvis)
+     target_sources(Luau.CodeGen PRIVATE tools/natvis/CodeGen.natvis)
+@@ -348,3 +348,58 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
          endif()
      endif()
  endforeach()
@@ -104,7 +107,7 @@ index f215957..b8462b8 100644
 +)
 +
 +install(
-+  TARGETS Luau.Common Luau.Ast Luau.Bytecode Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.Require
++  TARGETS Luau.Common Luau.Ast Luau.Bytecode Luau.Inliner Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.Require
 +  EXPORT unofficial-luau-targets
 +  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -123,6 +126,7 @@ index f215957..b8462b8 100644
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Common/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Ast/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Bytecode/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Inliner/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Compiler/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Config/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Analysis/include/"

--- a/ports/luau/fix-unittest.patch
+++ b/ports/luau/fix-unittest.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b8462b8..4a794ba 100644
+index 4ccd3bd..cf0a18b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -222,11 +222,11 @@ if(MSVC AND LUAU_BUILD_CLI)
+@@ -230,11 +230,11 @@ if(MSVC AND LUAU_BUILD_CLI)
      # the default stack size that MSVC linker uses is 1 MB; we need more stack space in Debug because stack frames are larger
      set_target_properties(Luau.Analyze.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
@@ -13,5 +13,5 @@ index b8462b8..4a794ba 100644
      # the default stack size that MSVC linker uses is 1 MB; we need more stack space in Debug because stack frames are larger
 +    set_target_properties(Luau.UnitTest PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
      set_target_properties(Luau.CLI.Test PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
+     set_target_properties(Luau.Conformance PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
- 

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 3b0f5ff16a80c5dd0ae9d77ccefa1efbf7583b16065212bc26d42a5603aedbe60fae21ab82343a69ea8b2c21bfdfe926456f9da4f144cfa6e1678713a73ca990
+    SHA512 a7386a9fdce0b4d27d39cd6c6bb64e899945146b17163b02fa477a269ba971ac96e2cc1d7482346b80cde50e2d0230cf5a9a29bd1b4da7e13114ab23717ee48b
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.726",
+  "version": "0.729",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6297,7 +6297,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.726",
+      "baseline": "0.729",
       "port-version": 0
     },
     "lunarg-vulkantools": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d92bdc4384054e753c2f38febbe6f5c675110bb",
+      "version": "0.729",
+      "port-version": 0
+    },
+    {
       "git-tree": "f82e619d699d373875ec6a53db3f5c5db97de728",
       "version": "0.726",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/luau-lang/luau/releases/tag/0.729
