### PR TITLE
# [libsl3] Add libsl3

### DIFF
--- a/ports/libsl3/portfile.cmake
+++ b/ports/libsl3/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO a4z/libsl3
     REF "v${VERSION}"
-    SHA512 07b3b15ff5ff716c08ad4aa9792e95f75ea8a4f34ac271bf85a82baeff63d5159b21b2bd38c7206a061b4a51e8bea320315945438dc221bb7332de5788152368
+    SHA512 392c73c9387a17286ea48e2cb5b70b8fc4713f5749947235631d5a297f11e69cafb92aed15fe766c071784dccd4e5e2fbb3c3ce715c7ffbc6495ee3913f9b12d
     HEAD_REF main
 )
 
@@ -14,13 +14,13 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCMAKE_CXX_STANDARD=17
         -DCMAKE_CXX_STANDARD_REQUIRED=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
+        -Dsl3_BUILD_DOCS=OFF
         -Dsl3_USE_COMMON_COMPILER_WARNINGS=OFF
         -Dsl3_USE_INTERNAL_SQLITE3=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sl3)
+vcpkg_cmake_config_fixup(PACKAGE_NAME sl3 CONFIG_PATH lib/cmake/sl3)
 vcpkg_copy_pdbs()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libsl3/portfile.cmake
+++ b/ports/libsl3/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO a4z/libsl3
+    REF "v${VERSION}"
+    SHA512 07b3b15ff5ff716c08ad4aa9792e95f75ea8a4f34ac271bf85a82baeff63d5159b21b2bd38c7206a061b4a51e8bea320315945438dc221bb7332de5788152368
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CXX_STANDARD_REQUIRED=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
+        -Dsl3_USE_COMMON_COMPILER_WARNINGS=OFF
+        -Dsl3_USE_INTERNAL_SQLITE3=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sl3)
+vcpkg_copy_pdbs()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.md")

--- a/ports/libsl3/usage
+++ b/ports/libsl3/usage
@@ -1,0 +1,4 @@
+libsl3 provides CMake targets:
+
+    find_package(sl3 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE a4z::sl3)

--- a/ports/libsl3/vcpkg.json
+++ b/ports/libsl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libsl3",
-  "version": "1.2.51003",
+  "version": "1.2.53003",
   "description": "A C++ interface for SQLite 3.x.",
   "homepage": "https://github.com/a4z/libsl3",
   "documentation": "https://a4z.github.io/libsl3/",

--- a/ports/libsl3/vcpkg.json
+++ b/ports/libsl3/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libsl3",
+  "version": "1.2.51003",
+  "description": "A C++ interface for SQLite 3.x.",
+  "homepage": "https://github.com/a4z/libsl3",
+  "documentation": "https://a4z.github.io/libsl3/",
+  "license": "MPL-2.0",
+  "dependencies": [
+    "sqlite3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5657,7 +5657,7 @@
       "port-version": 0
     },
     "libsl3": {
-      "baseline": "1.2.51003",
+      "baseline": "1.2.53003",
       "port-version": 0
     },
     "libslirp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5656,6 +5656,10 @@
       "baseline": "3.8.1",
       "port-version": 0
     },
+    "libsl3": {
+      "baseline": "1.2.51003",
+      "port-version": 0
+    },
     "libslirp": {
       "baseline": "4.9.1",
       "port-version": 0

--- a/versions/l-/libsl3.json
+++ b/versions/l-/libsl3.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "be35db8f5f98e8770ffa1dcb538b19e3ce11af5b",
-      "version": "1.2.51003",
+      "git-tree": "2057d3d5824beedb60282d76d85f742339ff19b9",
+      "version": "1.2.53003",
       "port-version": 0
     }
   ]

--- a/versions/l-/libsl3.json
+++ b/versions/l-/libsl3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "be35db8f5f98e8770ffa1dcb538b19e3ce11af5b",
+      "version": "1.2.51003",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/libsl3/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ x The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


