### PR TITLE
[libdvdcss] update to 1.6.0

### DIFF
--- a/ports/libdvdcss/portfile.cmake
+++ b/ports/libdvdcss/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://code.videolan.org/
     REPO videolan/libdvdcss
     REF "${VERSION}"
-    SHA512 276ab26a7295bb45dd852c8d8ad262dfb6f8bc4dae347b1f83ac6949aaea4cabf4cf84f79dabf2442d207c1f9bffca07793748794aa338a4694327672326799b
+    SHA512 511f1e43845af22ed31da32e54a25168a3d1754bec6cf21704017ef0e1819976b97a483c2df5dd6aa11df1a2496a528124c4b9eb8c6b75b21c707d16121799ba
     HEAD_REF master
 )
 

--- a/ports/libdvdcss/vcpkg.json
+++ b/ports/libdvdcss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdvdcss",
-  "version-semver": "1.5.0",
+  "version-semver": "1.6.0",
   "description": "Accessing DVDs like a block device library",
   "homepage": "https://www.videolan.org/developers/libdvdcss.html",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4961,7 +4961,7 @@
       "port-version": 0
     },
     "libdvdcss": {
-      "baseline": "1.5.0",
+      "baseline": "1.6.0",
       "port-version": 0
     },
     "libdvdnav": {

--- a/versions/l-/libdvdcss.json
+++ b/versions/l-/libdvdcss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fb18044b0e531223caad36643a08823accfbf0c",
+      "version-semver": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef5409a54c842eb19d5f231ef9c43edb390df768",
       "version-semver": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://code.videolan.org/videolan/libdvdcss/-/tags/1.6.0
