### PR TITLE
[zxc] Update to 0.13.1

### DIFF
--- a/ports/zxc/portfile.cmake
+++ b/ports/zxc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hellobertrand/zxc
     REF v${VERSION}
-    SHA512 d2a09c411e24ae2535ab5b8a279660ad375717b0323d7bec393ab0eb36072dceb3e09fa903000641dac4fbdc2cf3abf3558cd25fd7a5f238d00163a090fdf522
+    SHA512 4ceb737bd6c703da5883c58f04a12801353841a1e4423a7df4cca55291131cf69c2e1a9d9f86de7e9511d9dd30016f226b179a054adba2250e5dbf160c3bc0a5
     HEAD_REF main
 )
 
@@ -40,6 +40,11 @@ if ("util" IN_LIST FEATURES)
             zxc
         AUTO_CLEAN
     )
+    # Upstream installs "unzxc" as a POSIX-only symlink to zxc that defaults to
+    # decompression. Recreate it alongside the relocated tool (skipped on Windows).
+    if(NOT VCPKG_TARGET_IS_WINDOWS)
+        file(CREATE_LINK "zxc" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/unzxc" SYMBOLIC)
+    endif()
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zxc/vcpkg.json
+++ b/ports/zxc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zxc",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "High-performance asymmetric lossless compression library",
   "homepage": "https://github.com/hellobertrand/zxc",
   "license": "BSD-3-Clause AND MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11389,7 +11389,7 @@
       "port-version": 0
     },
     "zxc": {
-      "baseline": "0.13.0",
+      "baseline": "0.13.1",
       "port-version": 0
     },
     "zycore": {

--- a/versions/z-/zxc.json
+++ b/versions/z-/zxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8eff2cd4a76438fa10dce95cade9a5f2a08eb50e",
+      "version": "0.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b21b5c556df701e454bd0146211a3ee548d1f5b2",
       "version": "0.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.