### PR TITLE
[draco] Fix missing <algorithm> include

### DIFF
--- a/ports/draco/portfile.cmake
+++ b/ports/draco/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(ALGORITHM_INCLUDE_PATCH
+    URLS "https://github.com/google/draco/commit/b283ba36eea52dc525ab4c9324ae6de2055d1191.patch?full_index=1"
+    FILENAME "draco-b283ba36eea52dc525ab4c9324ae6de2055d1191.patch"
+    SHA512 8dab3a74ec52b6628955c68e79cca70383ec283f0624c054ec3a29baf6455029b38aeded4ed819978f891a0192472116e7c57d3100e1bc714ec96f7e3d4be778
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/draco
@@ -10,6 +16,7 @@ vcpkg_from_github(
         fix-pkgconfig.patch
         disable-symlinks.patch
         install-linkage.diff
+        "${ALGORITHM_INCLUDE_PATCH}"
 )
 
 if(VCPKG_TARGET_IS_EMSCRIPTEN)

--- a/ports/draco/vcpkg.json
+++ b/ports/draco/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "draco",
   "version": "1.5.7",
+  "port-version": 1,
   "description": " A library for compressing and decompressing 3D geometric meshes and point clouds. It is intended to improve the storage and transmission of 3D graphics.",
   "homepage": "https://github.com/google/draco",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2634,7 +2634,7 @@
     },
     "draco": {
       "baseline": "1.5.7",
-      "port-version": 0
+      "port-version": 1
     },
     "drekar-launch-process-cpp": {
       "baseline": "0.1.0",

--- a/versions/d-/draco.json
+++ b/versions/d-/draco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35101cd58b1565cd39feee41a69cfc2d120642cb",
+      "version": "1.5.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "06799add74da6e9e4634e4c7f27b82b1149a8bb6",
       "version": "1.5.7",
       "port-version": 0


### PR DESCRIPTION
Draco 1.5.7's `ply_reader.cc` uses `std::all_of` without including `<algorithm>`. This backports the fix from google/draco#980.

Tested on Windows with MSVC 14.51 and clang-cl 22.1.3. Debug and release builds passed.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The `supports` clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed CI baseline and CI feature baseline entries are removed, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is updated with `vcpkg x-add-version --all`.
- [x] Exactly one version is added in each modified versions file.
