### PR TITLE
[gtest] Fix clang-cl 22 character conversion

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(CHARACTER_CONVERSION_PATCH
+    URLS "https://github.com/google/googletest/commit/fa8438ae6b70c57010177de47a9f13d7041a6328.patch?full_index=1"
+    FILENAME "googletest-fa8438ae6b70c57010177de47a9f13d7041a6328.patch"
+    SHA512 fe436859fc5cafdc18e7fcb6d12903ea7a4aa37a3a913132d717ab9f8d5495ead9e4ddbbb89d70199f498588ff04e7b47ea988cc3032ef46dabe03eb4110dd5f
+)
+
 if (EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
     file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/src)
 endif()
@@ -12,6 +18,7 @@ vcpkg_from_github(
         001-fix-UWP-death-test.patch
         clang-tidy-no-lint.patch
         fix-main-lib-path.patch
+        "${CHARACTER_CONVERSION_PATCH}"
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" GTEST_FORCE_SHARED_CRT)

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtest",
   "version-semver": "1.17.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Google Testing and Mocking Framework",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3630,7 +3630,7 @@
     },
     "gtest": {
       "baseline": "1.17.0",
-      "port-version": 2
+      "port-version": 3
     },
     "gtk": {
       "baseline": "4.22.4",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dab84cf3bb50ef2ca3e0b0212c1d55e9e05a75bc",
+      "version-semver": "1.17.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "b8a81820356e90917e5eb5dfe0092bfac57dbb12",
       "version-semver": "1.17.0",
       "port-version": 2


### PR DESCRIPTION
GoogleTest 1.17.0 uses `ImplicitCast_` for conversions between different `charN_t` types, which clang-cl 22 rejects. This backports google/googletest@fa8438ae6b70c57010177de47a9f13d7041a6328.

Tested on Windows with MSVC 14.51 and clang-cl 22.1.3. Debug and release builds passed.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The `supports` clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed CI baseline and CI feature baseline entries are removed, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is updated with `vcpkg x-add-version --all`.
- [x] Exactly one version is added in each modified versions file.
