### PR TITLE
[libnsfemu] Add new port

### DIFF
--- a/ports/libnsfemu/portfile.cmake
+++ b/ports/libnsfemu/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sdcb/libnsfemu
+    REF v1.0.0
+    SHA512 25944afe3ea19cf5783457c2d67d1ae34d3195305a0d81164efe59bb433c83a6562fde697cf1c5fa9769fe985d272880077707275772af0423002f1a91eb7cca
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DNSFEMU_BUILD_TOOLS=OFF
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libnsfemu")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libnsfemu/usage
+++ b/ports/libnsfemu/usage
@@ -1,0 +1,4 @@
+libnsfemu provides CMake targets:
+
+    find_package(libnsfemu CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE libnsfemu::nsfemu)

--- a/ports/libnsfemu/vcpkg.json
+++ b/ports/libnsfemu/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libnsfemu",
+  "version": "1.0.0",
+  "description": "A tiny C NSF playback library.",
+  "homepage": "https://github.com/sdcb/libnsfemu",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5420,6 +5420,10 @@
       "baseline": "0.8.8",
       "port-version": 0
     },
+    "libnsfemu": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "libobfuscate": {
       "baseline": "2024-07-10",
       "port-version": 0

--- a/versions/l-/libnsfemu.json
+++ b/versions/l-/libnsfemu.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7981d2140c475c6ad51fb9ed95ea9640751ca4c0",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds libnsfemu 1.0.0 as a new port.

libnsfemu is a tiny C library for playing NSF (Nintendo Sound Format) music, focused on the base NES 2A03 APU. It provides in-memory NSF loading and signed 16-bit little-endian PCM output.

Upstream repository: https://github.com/sdcb/libnsfemu

- Uses the upstream GitHub v1.0.0 release tag with SHA512 verification.
- Installs the CMake package config and exported target `libnsfemu::nsfemu`.

Validation performed locally with MSVC:
- x64-windows
- x64-windows-static
- x64-windows-static-md
- x86-windows