### PR TITLE
[libdicom] Remove unnecessary native compiler probe

### DIFF
--- a/ports/libdicom/cross-build.diff
+++ b/ports/libdicom/cross-build.diff
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 33ec4f1..fe5516f 100644
+index 33ec4f1..70dbf98 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -144,6 +144,9 @@ install_headers(
+@@ -144,12 +144,14 @@ install_headers(
  # src
  library_includes = include_directories('include')
  library_options = ['-DBUILDING_LIBDICOM']
@@ -12,7 +12,13 @@ index 33ec4f1..fe5516f 100644
  dict_build = executable(
    'dicom-dict-build',
    files('src/dicom-dict-build.c', 'src/dicom-dict-tables.c'),
-@@ -156,6 +159,7 @@ dict_lookup = custom_target(
+   dependencies : [uthash],
+   include_directories : library_includes,
+-  native : true,
+ )
+ dict_lookup = custom_target(
+   'dicom-dict-lookup',
+@@ -156,6 +158,7 @@ dict_lookup = custom_target(
    command : [dict_build, '@OUTPUT@'],
    output : ['dicom-dict-lookup.c', 'dicom-dict-lookup.h'],
  )

--- a/ports/libdicom/vcpkg.json
+++ b/ports/libdicom/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdicom",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "libdicom is a C library and a set of command-line tools for reading DICOM WSI files",
   "homepage": "https://github.com/ImagingDataCommons/libdicom",
   "documentation": "https://libdicom.readthedocs.io/en/latest/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4930,7 +4930,7 @@
     },
     "libdicom": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/l-/libdicom.json
+++ b/versions/l-/libdicom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9007d309a984c885ef9f5546f4f3c6690287ce5",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a9d1aeae23ee5262a4a225a5deceffda630958e6",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
Fix build issue in [CI 20260708.1 run](https://dev.azure.com/vcpkg/public/_build/results?buildId=134292&view=logs&j=4df292c1-f579-5a84-c7d0-98b54b894473&t=e1e8a0d9-53bb-5428-2171-3fb661a41a86).

Upstream builds `dicom-dict-build` as a native executable, this causes a redundant compiler probe that fails with `LNK1104`. The patch makes it so that the host compiler is used for native builds and the pre-generated dictionary is used for cross builds. 