### PR TITLE
[vulkan-validationlayers] Support clang targeting windows-msvc

### DIFF
--- a/ports/vulkan-validationlayers/fix-clang-windows-def-exports.diff
+++ b/ports/vulkan-validationlayers/fix-clang-windows-def-exports.diff
@@ -1,0 +1,17 @@
+diff --git a/layers/CMakeLists.txt b/layers/CMakeLists.txt
+index 4a8ca7d..e091a8d 100644
+--- a/layers/CMakeLists.txt
++++ b/layers/CMakeLists.txt
+@@ -541,6 +541,12 @@ elseif(MINGW)
+     target_sources(vvl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.def)
+     target_compile_options(vvl PRIVATE -Wa,-mbig-obj)
+     set_target_properties(vvl PROPERTIES PREFIX "") # remove the prefix "lib" so the manifest json "library_path" matches
++elseif(WIN32)
++    # A GNU-frontend clang targeting *-windows-msvc (i.e. clang/clang++, not
++    # clang-cl) is detected as neither MSVC nor MINGW, so without this branch it
++    # falls through to the ELF --version-script case below, which the Windows
++    # linker (lld-link) rejects. Forward the MSVC-style .def through the driver.
++    target_link_options(vvl PRIVATE LINKER:/DEF:${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.def)
+ elseif(APPLE)
+ 
+ # IOS and APPLE can both be true (FYI)

--- a/ports/vulkan-validationlayers/portfile.cmake
+++ b/ports/vulkan-validationlayers/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         disable_vendored_phmap.diff
+        fix-clang-windows-def-exports.diff
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/layers/external/parallel_hashmap") # ensure that we use vcpkg's parallel-hashmap instead of upstream's vendored copy

--- a/ports/vulkan-validationlayers/vcpkg.json
+++ b/ports/vulkan-validationlayers/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-validationlayers",
   "version": "1.4.350.1",
+  "port-version": 1,
   "description": "Vulkan Validation Layers (VVL)",
   "homepage": "https://github.com/KhronosGroup/Vulkan-ValidationLayers",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10854,7 +10854,7 @@
     },
     "vulkan-validationlayers": {
       "baseline": "1.4.350.1",
-      "port-version": 0
+      "port-version": 1
     },
     "vvenc": {
       "baseline": "1.14.0",

--- a/versions/v-/vulkan-validationlayers.json
+++ b/versions/v-/vulkan-validationlayers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "123ee841ccabee9ea392b47800fe78e276cf4869",
+      "version": "1.4.350.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a8da0226f3a8816ed88458b00954ef37b5f2cf75",
       "version": "1.4.350.1",
       "port-version": 0


### PR DESCRIPTION
Building `vulkan-validationlayers` with a GNU-frontend clang targeting
`*-windows-msvc` (i.e. `clang`/`clang++`, not `clang-cl`) fails to link the
`vvl` target:

```
lld-link: error: --version-script is not allowed in non-GNU link mode
```

VVL's `layers/CMakeLists.txt` selects the symbol-export mechanism by
compiler/platform (`MSVC` → `/DEF:`, `MINGW` → `.def` source, `APPLE`,
`ANDROID`, else → `--version-script`). A GNU-frontend clang targeting the MSVC
ABI is neither `MSVC` nor `MINGW` in CMake terms, so it falls through to the
final ELF `--version-script` branch, which `lld-link` rejects.

This adds a patch with a `WIN32 AND NOT MINGW` branch that forwards the
existing MSVC-style `.def` through the compiler driver (`LINKER:/DEF:`), which
`lld-link` accepts. The MSVC, MinGW and non-Windows paths are untouched.

The same fix is submitted upstream: KhronosGroup/Vulkan-ValidationLayers#12727.
This port patch is the interim carrier until a VVL release includes it.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] The name of the port matches an existing name; only `port-version` is bumped (1.4.350.1#0 → #1).
- [x] Versions database updated via `vcpkg x-add-version`.
