### PR TITLE
[fmt] Fix fallback uint128 bitwise not for 32-bit builds

### DIFF
--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -1,9 +1,17 @@
+vcpkg_download_distfile(FMT_BACKPORT_4813_PATCH
+    URLS https://github.com/fmtlib/fmt/commit/588b3a0f8f6a8bcf2a959cae882d5b2703e86737.patch?full_index=1
+    FILENAME fmt-backport-4813.patch
+    SHA512 afda8fdfcdcb4b0dd5df4d4dae96a57a85fb9c4b65d0b49d51258f0913d4aed93ed146ebf96ed7b277490b1dde6c7117f43332013071441a96c3147520de8368
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fmtlib/fmt
     REF "${VERSION}"
     SHA512 5ac2ba0f54a484999ed5407d82b77aad170cea49a267decd2c0eedadf3b14413e2a83fcc8e9ca9c16640595e019b8636e160f72314d8be50653324e82ac745eb
     HEAD_REF master
+    PATCHES
+        "${FMT_BACKPORT_4813_PATCH}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fmt",
   "version": "12.2.0",
+  "port-version": 1,
   "description": "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3170,7 +3170,7 @@
     },
     "fmt": {
       "baseline": "12.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "folly": {
       "baseline": "2026.02.23.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ca0b8c0026883daf28a0db75f6b4964bae2979a",
+      "version": "12.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "823af43db9df2c4be15c4331b36b3cc419afa02c",
       "version": "12.2.0",
       "port-version": 0


### PR DESCRIPTION
Fix #52881
Related fmtlib/fmt#4813
