### PR TITLE
[libcorrect] Update to 2026-02-04

### DIFF
--- a/ports/libcorrect/portfile.cmake
+++ b/ports/libcorrect/portfile.cmake
@@ -1,13 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO quiet/libcorrect
-    REF f5a28c74fba7a99736fe49d3a5243eca29517ae9
-    SHA512 1367834c2a081e007b3eeeacb5bbe912617cce97cbd19d43193078f352fef103a54f030ef61a2def4ab7517476cf6be5d6a1736e43ae84913fe84a56340b69ce
+    REF ee82e6673a806dfdf0a969b975ab36596ecc5401
+    SHA512 a75593ca6c54c3cb4bbdb0bbf2c8aa98fa512e43aaa3434d5a6b23c60b976a0e4d7771999fc56883ff09f4352e2a697f576c5289f64b5bff5a5089eec06dd0ea
     HEAD_REF master
-    PATCHES fix-ninja.patch
+    PATCHES
+        fix-ninja.patch
 )
+
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHAVE_LIBFEC=OFF
+)
 vcpkg_cmake_install()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libcorrect/vcpkg.json
+++ b/ports/libcorrect/vcpkg.json
@@ -1,16 +1,12 @@
 {
   "name": "libcorrect",
-  "version-date": "2018-10-11",
+  "version-date": "2026-02-04",
   "description": "libcorrect is a library for Forward Error Correction",
   "homepage": "https://github.com/quiet/libcorrect",
   "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4873,7 +4873,7 @@
       "port-version": 0
     },
     "libcorrect": {
-      "baseline": "2018-10-11",
+      "baseline": "2026-02-04",
       "port-version": 0
     },
     "libcpplocate": {

--- a/versions/l-/libcorrect.json
+++ b/versions/l-/libcorrect.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cffad0543c2666a5374699f674afcbab51dd54ff",
+      "version-date": "2026-02-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f2ef3266828a1332359d747a80bb46da933c773",
       "version-date": "2018-10-11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.