### PR TITLE
[srell] update sha512

### DIFF
--- a/ports/srell/portfile.cmake
+++ b/ports/srell/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://www.akenotsuki.com/misc/srell/releases/srell${VERSION}.zip"
     FILENAME "srell${VERSION}.zip"
-    SHA512 02d8292212ad570cc5fd37820c47097bef025b3f896a536ce9de2d3bd07bf961e6ab58d80caa216e40eaf0d75862f617010bae8bca7d2f424a81c832c8874697
+    SHA512 08e4629daf31083db6799390f1a4c942fdcd21358e90568666e060c1d7563c878281c6e2f2bb6ebf9889bfc5606166d0664ff0b6b4657bbcbed18c42dbf707f5
 )
 
 vcpkg_extract_source_archive(

--- a/ports/srell/vcpkg.json
+++ b/ports/srell/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "srell",
   "version-string": "2026.01",
+  "port-version": 1,
   "description": "SRELL (std::regex-like library) is a regular expression template library for C++.",
   "homepage": "https://www.akenotsuki.com/misc/srell/en/",
   "license": "BSD-2-Clause"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9718,7 +9718,7 @@
     },
     "srell": {
       "baseline": "2026.01",
-      "port-version": 0
+      "port-version": 1
     },
     "srpc": {
       "baseline": "0.10.4",

--- a/versions/s-/srell.json
+++ b/versions/s-/srell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ef58f2efd3e3c16c5835ecab1086b2b9ed2038f",
+      "version-string": "2026.01",
+      "port-version": 1
+    },
+    {
       "git-tree": "db0f1e4839e943b561727238a0579c95588115e5",
       "version-string": "2026.01",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
