### PR TITLE
[behaviortree-cpp] Update to 4.9.1

### DIFF
--- a/ports/behaviortree-cpp/fix-dependencies.patch
+++ b/ports/behaviortree-cpp/fix-dependencies.patch
@@ -1,28 +1,59 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b496f7a..6bfce73 100644
+index b496f7a..85bd21d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -229,7 +229,7 @@ target_link_libraries(${BTCPP_LIBRARY}
+@@ -226,24 +226,24 @@ target_link_libraries(${BTCPP_LIBRARY}
+     PRIVATE
          Threads::Threads
          ${CMAKE_DL_LIBS}
-         $<BUILD_INTERFACE:minitrace::minitrace>
+-        $<BUILD_INTERFACE:minitrace::minitrace>
++        minitrace::minitrace
 -        $<BUILD_INTERFACE:tinyxml2::tinyxml2>
 +        tinyxml2::tinyxml2
          $<BUILD_INTERFACE:minicoro::minicoro>
-         $<BUILD_INTERFACE:flatbuffers::flatbuffers>
+-        $<BUILD_INTERFACE:flatbuffers::flatbuffers>
++        flatbuffers::flatbuffers
      PUBLIC
+         ${BTCPP_EXTRA_LIBRARIES}
+ )
+ 
+ if(BTCPP_GROOT_INTERFACE)
+     target_link_libraries(${BTCPP_LIBRARY}
+         PUBLIC
+-            $<BUILD_INTERFACE:cppzmq>
++            cppzmq
+     )
+ endif()
+ 
+ if(BTCPP_SQLITE_LOGGING)
+     target_link_libraries(${BTCPP_LIBRARY}
+         PRIVATE
+-            $<BUILD_INTERFACE:SQLite::SQLite3>
++            SQLite3::SQLite3
+     )
+ endif()
 diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
 index eaed471..73c3d4c 100644
 --- a/cmake/Config.cmake.in
 +++ b/cmake/Config.cmake.in
-@@ -1,5 +1,10 @@
+@@ -1,5 +1,18 @@
  @PACKAGE_INIT@
  
 +include(CMakeFindDependencyMacro)
 +
 +find_dependency(Threads)
++find_dependency(flatbuffers CONFIG)
++find_dependency(minitrace CONFIG)
 +find_dependency(tinyxml2 CONFIG)
++if(@BTCPP_GROOT_INTERFACE@)
++    find_dependency(cppzmq CONFIG)
++endif()
++if(@BTCPP_SQLITE_LOGGING@)
++    find_dependency(SQLite3)
++endif()
 +
  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
  
  set(@PROJECT_NAME@_TARGETS "BT::@PROJECT_NAME@")
+
+

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -12,8 +12,16 @@ vcpkg_from_github(
 # Set BTCPP_SHARED_LIBS based on VCPKG_LIBRARY_LINKAGE
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BTCPP_SHARED_LIBS)
 
-# Remove vendored lexy directory to prevent conflicts with foonathan-lexy port
-file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/lexy")
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        groot BTCPP_GROOT_INTERFACE
+        sqlite BTCPP_SQLITE_LOGGING
+)
+
+if("groot" IN_LIST FEATURES)
+    # Avoid shadowing zeromq's vcpkg CMake wrapper during cppzmq's dependency lookup.
+    file(REMOVE "${SOURCE_PATH}/cmake/FindZeroMQ.cmake")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -22,18 +30,27 @@ vcpkg_cmake_configure(
         -DBTCPP_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
         -DBTCPP_BUILD_TOOLS=OFF
-        -DBTCPP_GROOT_INTERFACE=OFF
-        -DBTCPP_SQLITE_LOGGING=OFF
         -DBTCPP_SHARED_LIBS=${BTCPP_SHARED_LIBS}
+        -DUSE_VENDORED_CPPZMQ=OFF
         -DUSE_VENDORED_FLATBUFFERS=OFF
         -DUSE_VENDORED_MINITRACE=OFF
         -DUSE_VENDORED_TINYXML2=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/behaviortree_cpp PACKAGE_NAME behaviortree_cpp)
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    COMMENT [[
+The installed headers contain embedded copies of the following libraries:
+- linb::any and expected-lite, licensed under BSL-1.0. Copyright notices are retained in the headers; see https://www.boost.org/LICENSE_1_0.txt.
+- nlohmann/json and magic_enum, licensed under MIT. Copyright and SPDX notices are retained in the headers.
+]]
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/3rdparty/minicoro/LICENSE"
+)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BehaviorTree/BehaviorTree.CPP
     REF "${VERSION}"
-    SHA512 a1a9a1f2f649c0bfdb2e141445a376f9a325a6102fa647c4b20dad0de7c2a782c265ac0a7addd4bb5a75e16347f6b7d5ce091df265bcd45cc626db237db81ec5
+    SHA512 23ac30d7824282f641372f709b6b7a800a2947113bbb09d599f68547a3a67f509992cd0ca251e86b101062fe0d6697373b6851d21e7648578aadf1aa924e7ccf
     HEAD_REF master
     PATCHES
         remove-source-charset.diff # because vcpkg's default toolchain uses /utf-8 which is incompatible with /source-charset

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -3,10 +3,9 @@
   "version": "4.9.1",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
+  "license": null,
   "supports": "!uwp",
   "dependencies": [
-    "boost-coroutine2",
-    "cppzmq",
     "flatbuffers",
     "minitrace",
     "tinyxml2",
@@ -18,5 +17,19 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "groot": {
+      "description": "Enable the Groot2 publisher interface.",
+      "dependencies": [
+        "cppzmq"
+      ]
+    },
+    "sqlite": {
+      "description": "Enable SQLite logging.",
+      "dependencies": [
+        "sqlite3"
+      ]
+    }
+  }
 }

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp",

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "119c9afb1f3df26539fd05c70b6f448ed7732e20",
+      "git-tree": "7937cd10b44475db72ed206e2c8a09e3cf7d96d9",
       "version": "4.9.1",
       "port-version": 0
     },

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8be49f79313c6d1456c3f272869515e10cb9c4d",
+      "version": "4.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b60425ab98f9d10f6ed150a082f0c0478575f64",
       "version": "4.9.0",
       "port-version": 0

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8be49f79313c6d1456c3f272869515e10cb9c4d",
+      "git-tree": "119c9afb1f3df26539fd05c70b6f448ed7732e20",
       "version": "4.9.1",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -673,7 +673,7 @@
       "port-version": 0
     },
     "behaviortree-cpp": {
-      "baseline": "4.9.0",
+      "baseline": "4.9.1",
       "port-version": 0
     },
     "benchmark": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
