### PR TITLE
[bcg729] Update to 2026-02-04

### DIFF
--- a/ports/bcg729/disable-alt-packaging.patch
+++ b/ports/bcg729/disable-alt-packaging.patch
@@ -1,10 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 69dbaef..695f4d0 100644
+index 7661f2e..a4eadcc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -125,5 +125,4 @@ install(FILES
- 	DESTINATION ${CONFIG_PACKAGE_LOCATION}
+@@ -115,4 +115,3 @@ install(FILES
  )
  
--add_subdirectory(build)
  
+-add_subdirectory(build)

--- a/ports/bcg729/portfile.cmake
+++ b/ports/bcg729/portfile.cmake
@@ -1,49 +1,39 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BelledonneCommunications/bcg729
-    REF 1.1.1
-    SHA512 e8cc4b7486a9a29fb729ab9fd9e3c4a2155573f38cec16f5a53db3b416fc1119ea5f5a61243a8d37cb0b64580c5df1b632ff165dc7ff47421fa567dafffaacd8
+    REF "${VERSION}"
+    SHA512 54befb0795176cbb7a37aa222491634b67e79268beaecc4713a3020d64773682ff78ec9c5d8c223c05ef939a38b64c85df9a79708f5f2647643ce4329abc29a8
     HEAD_REF master
     PATCHES
         disable-alt-packaging.patch
 )
 
-# Already removed upstream: https://github.com/BelledonneCommunications/bcg729/pull/19
-file(REMOVE "${SOURCE_PATH}/include/MSVC/stdint.h")
-
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC)
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DENABLE_STATIC=${ENABLE_STATIC}
-        -DENABLE_SHARED=${ENABLE_SHARED}
 )
+
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${SOURCE_PATH}/include/bcg729/decoder.h" "#ifdef BCG729_STATIC" "#if 1")
+    vcpkg_replace_string("${SOURCE_PATH}/include/bcg729/encoder.h" "#ifdef BCG729_STATIC" "#if 1")
+endif()
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME Bcg729)
-file(GLOB cmake_files "${CURRENT_PACKAGES_DIR}/share/Bcg729/cmake/*.cmake")
-file(COPY ${cmake_files} DESTINATION "${CURRENT_PACKAGES_DIR}/share/bcg729")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Bcg729/cmake")
-file(GLOB_RECURSE remaining_files "${CURRENT_PACKAGES_DIR}/share/Bcg729/*")
-if(NOT remaining_files)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Bcg729")
-endif()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-
+vcpkg_cmake_config_fixup(PACKAGE_NAME BCG729 CONFIG_PATH share/BCG729/cmake)
 vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
 
-file(READ "${SOURCE_PATH}/LICENSE.txt" GPL3)
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" [[
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE.txt"
+    COMMENT [[
 bcg729 is dual licensed, and is available either:
  - under a GNU/GPLv3 license, for free (open source). See below.
  - under a proprietary license, for a fee, to be used in closed source applications.
    Contact Belledonne Communications (https://www.linphone.org/contact)
-   for any question about costs and services.
-
-
-]] ${GPL3})
+   for any question about costs and services.]]
+)

--- a/ports/bcg729/vcpkg.json
+++ b/ports/bcg729/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "bcg729",
-  "version": "1.1.1",
-  "port-version": 4,
+  "version": "1.1.2",
   "description": "Bcg729 is an open source implementation of the ITU G.729 Annex A and B codec.",
   "homepage": "https://github.com/BelledonneCommunications/bcg729",
+  "license": "GPL-3.0-or-later OR LicenseRef-Proprietary",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/test_ports/vcpkg-ci-bcg729/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-bcg729/portfile.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-bcg729/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-bcg729/project/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-bcg729 LANGUAGES C)
+
+find_package(BCG729 CONFIG REQUIRED)
+add_executable(main main.c)
+target_link_libraries(main PRIVATE bcg729)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(bcg729 IMPORTED_TARGET REQUIRED libbcg729)
+add_executable(main_pkg main.c)
+target_link_libraries(main_pkg PRIVATE PkgConfig::bcg729)

--- a/scripts/test_ports/vcpkg-ci-bcg729/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-bcg729/project/main.c
@@ -1,0 +1,7 @@
+#include <bcg729/encoder.h>
+
+int main() {
+    initBcg729EncoderChannel(1);
+
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-bcg729/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-bcg729/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-bcg729",
+  "version-string": "ci",
+  "description": "Validates bcg729",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "bcg729"
+  ]
+}

--- a/versions/b-/bcg729.json
+++ b/versions/b-/bcg729.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aadcfedd667bb096cbf3fd6f6c1042c2f87dee47",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "00204704e4e35484bdbac4856b5d6891cdc7d211",
       "version": "1.1.1",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -657,8 +657,8 @@
       "port-version": 0
     },
     "bcg729": {
-      "baseline": "1.1.1",
-      "port-version": 4
+      "baseline": "1.1.2",
+      "port-version": 0
     },
     "bddisasm": {
       "baseline": "3.0.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Added test port, as there is currently no consuming port
