### PR TITLE
[assimp] Update to 6.0.5

### DIFF
--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -1,11 +1,18 @@
+vcpkg_download_distfile(FIX_CPP17_HEADERS
+    URLS https://github.com/assimp/assimp/commit/9a486a72e43f92222969bfac7054554f97dd253f.patch?full_index=1
+    SHA512 209d79e2366567cc8090e06684ef2da795a317c81d17694590e95051a62123219ab9b700bd0640e5ae0dd0d8bb9d8c9377dadc9168f08968d3b970244dbdc353
+    FILENAME assimp_pr_6627.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO assimp/assimp
     REF "v${VERSION}"
-    SHA512 f3639e3964ea8ef41ce684eb1b764ece79f64a15ecae068846c5bc0853780e39f600776027d8843e6a3f47988daf067a164161a58f76ec6de13027ae1e473bfb
+    SHA512 57326194bf3a8e2ae793c739878231067fdd6d031531e910d4d20fc8a673eacf48f75e11bd21ca2e6421682f78585d445bffb647bdcb52e01b2cd4d3ff0e2c62
     HEAD_REF master
     PATCHES
         build_fixes.patch
+        "${FIX_CPP17_HEADERS}"
 )
 
 file(REMOVE "${SOURCE_PATH}/cmake-modules/FindZLIB.cmake")

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -103,4 +103,10 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/contrib/openddlparser/LICENSE"
+        "${SOURCE_PATH}/contrib/Open3DGC/o3dgcCommon.h"
+        "${SOURCE_PATH}/contrib/Open3DGC/o3dgcArithmeticCodec.cpp"
+)

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "assimp",
-  "version": "6.0.4",
-  "port-version": 3,
+  "version": "6.0.5",
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "6.0.5",
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
-  "license": "BSD-3-Clause",
+  "license": "BSD-2-Clause AND BSD-3-Clause AND MIT",
   "dependencies": [
     "jhasse-poly2tri",
     "kubazip",

--- a/ports/qt5-3d/assimp-config-test-cxx17.patch
+++ b/ports/qt5-3d/assimp-config-test-cxx17.patch
@@ -1,0 +1,7 @@
+diff --git a/config.tests/assimp/assimp.pro b/config.tests/assimp/assimp.pro
+index a3aa924..94d00a1 100644
+--- a/config.tests/assimp/assimp.pro
++++ b/config.tests/assimp/assimp.pro
+@@ -1 +1,2 @@
+ SOURCES += main.cpp
++CONFIG += c++17

--- a/ports/qt5-3d/portfile.cmake
+++ b/ports/qt5-3d/portfile.cmake
@@ -18,7 +18,6 @@ if(QT_UPDATE_VERSION)
 else()
     qt_build_submodule(
         "${SOURCE_PATH}"
-        OPTIONS "CONFIG+=c++17"
         BUILD_OPTIONS ${OPTIONS}
         BUILD_OPTIONS_RELEASE ${OPT_REL}
         BUILD_OPTIONS_DEBUG ${OPT_DBG}

--- a/ports/qt5-3d/portfile.cmake
+++ b/ports/qt5-3d/portfile.cmake
@@ -7,11 +7,24 @@ x_vcpkg_pkgconfig_get_modules(PREFIX assimp MODULES assimp LIBS)
 set(OPT_REL "ASSIMP_LIBS=${assimp_LIBS_RELEASE}")
 set(OPT_DBG "ASSIMP_LIBS=${assimp_LIBS_DEBUG}")
 
-qt_submodule_installation(
-    OPTIONS "CONFIG+=c++17"
-    BUILD_OPTIONS ${OPTIONS}
-    BUILD_OPTIONS_RELEASE ${OPT_REL}
-    BUILD_OPTIONS_DEBUG ${OPT_DBG}
+qt_download_submodule(
+    OUT_SOURCE_PATH SOURCE_PATH
+    PATCHES
+        assimp-config-test-cxx17.patch
 )
+
+if(QT_UPDATE_VERSION)
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+    qt_build_submodule(
+        "${SOURCE_PATH}"
+        OPTIONS "CONFIG+=c++17"
+        BUILD_OPTIONS ${OPTIONS}
+        BUILD_OPTIONS_RELEASE ${OPT_REL}
+        BUILD_OPTIONS_DEBUG ${OPT_DBG}
+    )
+
+    qt_install_copyright("${SOURCE_PATH}")
+endif()
 
 vcpkg_restore_env_variables(VARS QMAKEFLAGS)

--- a/ports/qt5-3d/portfile.cmake
+++ b/ports/qt5-3d/portfile.cmake
@@ -7,4 +7,11 @@ x_vcpkg_pkgconfig_get_modules(PREFIX assimp MODULES assimp LIBS)
 set(OPT_REL "ASSIMP_LIBS=${assimp_LIBS_RELEASE}")
 set(OPT_DBG "ASSIMP_LIBS=${assimp_LIBS_DEBUG}")
 
-qt_submodule_installation(BUILD_OPTIONS ${OPTIONS} BUILD_OPTIONS_RELEASE ${OPT_REL} BUILD_OPTIONS_DEBUG ${OPT_DBG})
+qt_submodule_installation(
+    OPTIONS "CONFIG+=c++17"
+    BUILD_OPTIONS ${OPTIONS}
+    BUILD_OPTIONS_RELEASE ${OPT_REL}
+    BUILD_OPTIONS_DEBUG ${OPT_DBG}
+)
+
+vcpkg_restore_env_variables(VARS QMAKEFLAGS)

--- a/ports/qt5-3d/vcpkg.json
+++ b/ports/qt5-3d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-3d",
   "version": "5.15.19",
+  "port-version": 1,
   "description": "Qt 3D provides functionality for near-realtime simulation systems with support for 2D and 3D rendering in both Qt C++ and Qt Quick applications.",
   "license": null,
   "dependencies": [

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "66d869a51e21d87c6637b51176926a6f28b012c8",
+      "git-tree": "96ef8bc1bffb6b1c8ba0a12f9a13b7278bbab90d",
       "version": "6.0.5",
       "port-version": 0
     },

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66d869a51e21d87c6637b51176926a6f28b012c8",
+      "version": "6.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "327397e12c4348d0a3637b297501126c3d715b68",
       "version": "6.0.4",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -341,8 +341,8 @@
       "port-version": 0
     },
     "assimp": {
-      "baseline": "6.0.4",
-      "port-version": 3
+      "baseline": "6.0.5",
+      "port-version": 0
     },
     "astr": {
       "baseline": "0.3.1",
@@ -8258,7 +8258,7 @@
     },
     "qt5-3d": {
       "baseline": "5.15.19",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-activeqt": {
       "baseline": "5.15.19",

--- a/versions/q-/qt5-3d.json
+++ b/versions/q-/qt5-3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e579c077bae8fd97ff48b6c86d7713d372e2e142",
+      "git-tree": "760444b59248761c839b34e03f1c04e969cd3b24",
       "version": "5.15.19",
       "port-version": 1
     },

--- a/versions/q-/qt5-3d.json
+++ b/versions/q-/qt5-3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11ce723256e83cd48710d8ad20ec5428c0ffbabb",
+      "git-tree": "e579c077bae8fd97ff48b6c86d7713d372e2e142",
       "version": "5.15.19",
       "port-version": 1
     },

--- a/versions/q-/qt5-3d.json
+++ b/versions/q-/qt5-3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11ce723256e83cd48710d8ad20ec5428c0ffbabb",
+      "version": "5.15.19",
+      "port-version": 1
+    },
+    {
       "git-tree": "6df6e5869920a6b605c8496ef1ff414522d1f5c5",
       "version": "5.15.19",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.