### PR TITLE
[kdiagram] Update to 3.0.1

### DIFF
--- a/ports/kdiagram/portfile.cmake
+++ b/ports/kdiagram/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/kdiagram
     REF "v${VERSION}"
-    SHA512 5a3b958aaf386b1cde3c840963521306ded5b1975cc293dbb36c60cacd52a62badaf64a6c5f3cd63fc65f02d0ba181d318496d665f08140299720cd022a855e7
+    SHA512 1f629a9662f7bb6b630a383ca4200d9c6f9e1d96931826bf2b563844917227640c303e51a35b47e445a7943e6396231e2e8c9a2a39bf62ce7ad815417b35d910
     HEAD_REF master
 )
 
@@ -16,15 +16,13 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME KChart CONFIG_PATH lib/cmake/KChart DO_NOT_DELETE_PARENT_CONFIG_PATH)
-vcpkg_cmake_config_fixup(PACKAGE_NAME KGantt CONFIG_PATH lib/cmake/KGantt)
+vcpkg_cmake_config_fixup(PACKAGE_NAME KChart6 CONFIG_PATH lib/cmake/KChart6 DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME KGantt6 CONFIG_PATH lib/cmake/KGantt6)
 vcpkg_copy_pdbs()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.GPL.txt")

--- a/ports/kdiagram/vcpkg.json
+++ b/ports/kdiagram/vcpkg.json
@@ -8,7 +8,10 @@
     "ecm",
     {
       "name": "qtbase",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "widgets"
+      ]
     },
     "qtsvg",
     {

--- a/ports/kdiagram/vcpkg.json
+++ b/ports/kdiagram/vcpkg.json
@@ -1,16 +1,24 @@
 {
   "name": "kdiagram",
-  "version": "2.8.0",
+  "version": "3.0.1",
   "description": "Powerful libraries (KChart, KGantt) for creating business diagrams",
   "homepage": "https://invent.kde.org/graphics/kdiagram",
-  "license": "LGPL-2.0-or-later",
+  "license": "GPL-2.0-or-later",
   "dependencies": [
     "ecm",
     {
-      "name": "qt5-base",
+      "name": "qtbase",
       "default-features": false
     },
-    "qt5-svg",
+    "qtsvg",
+    {
+      "name": "qttools",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "linguist"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4329,7 +4329,7 @@
       "port-version": 1
     },
     "kdiagram": {
-      "baseline": "2.8.0",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "kdreports": {

--- a/versions/k-/kdiagram.json
+++ b/versions/k-/kdiagram.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f29e758a500864e2c5b9ebc7956a733c175766ab",
+      "git-tree": "f6bc20177e905b7698a258be00ed7d3c3a720fe8",
       "version": "3.0.1",
       "port-version": 0
     },

--- a/versions/k-/kdiagram.json
+++ b/versions/k-/kdiagram.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f29e758a500864e2c5b9ebc7956a733c175766ab",
+      "version": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b7691b8b0eff5a06890b18cc0067d314168bbacc",
       "version": "2.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.