### PR TITLE
[fast-float] Fix min/max macro compatibility

### DIFF
--- a/ports/fast-float/max-macro.diff
+++ b/ports/fast-float/max-macro.diff
@@ -1,0 +1,24 @@
+diff --git a/include/fast_float/ascii_number.h b/include/fast_float/ascii_number.h
+index 2bad1fb1..2748d65a 100644
+--- a/include/fast_float/ascii_number.h
++++ b/include/fast_float/ascii_number.h
+@@ -804,7 +804,7 @@ parse_int_string(UC const *p, UC const *pend, T &value,
+ 
+   // check other types overflow
+   if (!std::is_same<T, uint64_t>::value) {
+-    if (i > uint64_t(std::numeric_limits<T>::max()) + uint64_t(negative)) {
++    if (i > uint64_t((std::numeric_limits<T>::max)()) + uint64_t(negative)) {
+       answer.ec = std::errc::result_out_of_range;
+       return answer;
+     }
+@@ -821,8 +821,8 @@ parse_int_string(UC const *p, UC const *pend, T &value,
+     // - reinterpret_casting (~i + 1) would work, but it is not constexpr
+     // this is always optimized into a neg instruction (note: T is an integer
+     // type)
+-    value = T(-std::numeric_limits<T>::max() -
+-              T(i - uint64_t(std::numeric_limits<T>::max())));
++    value = T(-(std::numeric_limits<T>::max)() -
++              T(i - uint64_t((std::numeric_limits<T>::max)())));
+ #ifdef FASTFLOAT_VISUAL_STUDIO
+ #pragma warning(pop)
+ #endif

--- a/ports/fast-float/min-max-macro.diff
+++ b/ports/fast-float/min-max-macro.diff
@@ -1,5 +1,5 @@
 diff --git a/include/fast_float/ascii_number.h b/include/fast_float/ascii_number.h
-index 2bad1fb1..2748d65a 100644
+index 2bad1fb..2748d65 100644
 --- a/include/fast_float/ascii_number.h
 +++ b/include/fast_float/ascii_number.h
 @@ -804,7 +804,7 @@ parse_int_string(UC const *p, UC const *pend, T &value,
@@ -22,3 +22,16 @@ index 2bad1fb1..2748d65a 100644
  #ifdef FASTFLOAT_VISUAL_STUDIO
  #pragma warning(pop)
  #endif
+diff --git a/include/fast_float/parse_number.h b/include/fast_float/parse_number.h
+index c819c8a..58cdafd 100644
+--- a/include/fast_float/parse_number.h
++++ b/include/fast_float/parse_number.h
+@@ -96,7 +96,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
+   // asm). The value does not need to be std::numeric_limits<float>::min(), any
+   // small value so that 1 + x should round to 1 would do (after accounting for
+   // excess precision, as in 387 instructions).
+-  static float volatile fmin = std::numeric_limits<float>::min();
++  static float volatile fmin = (std::numeric_limits<float>::min)();
+   float fmini = fmin; // we copy it so that it gets loaded at most once.
+ //
+ // Explanation:

--- a/ports/fast-float/portfile.cmake
+++ b/ports/fast-float/portfile.cmake
@@ -1,23 +1,21 @@
+set(VCPKG_BUILD_TYPE release)  # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fastfloat/fast_float
     REF "v${VERSION}"
     SHA512 eec563358117b593e882a9069074a269d811e8989457a0d57e50c5d2f4d534b6820308082bb70c0a8a8388513e92b64f12c5213389eff726ad0483eacba961ff
     HEAD_REF master
+    PATCHES
+        max-macro.diff
 )
-
-set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DFASTFLOAT_INSTALL=ON
 )
-
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME FastFloat CONFIG_PATH share/cmake/FastFloat)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-BOOST" "${SOURCE_PATH}/LICENSE-MIT")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/fast-float/portfile.cmake
+++ b/ports/fast-float/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     SHA512 eec563358117b593e882a9069074a269d811e8989457a0d57e50c5d2f4d534b6820308082bb70c0a8a8388513e92b64f12c5213389eff726ad0483eacba961ff
     HEAD_REF master
     PATCHES
-        max-macro.diff
+        min-max-macro.diff
 )
 
 vcpkg_cmake_configure(

--- a/ports/fast-float/usage
+++ b/ports/fast-float/usage
@@ -1,4 +1,0 @@
-fast-float provides CMake targets:
-
-    find_package(FastFloat CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE FastFloat::fast_float)

--- a/ports/fast-float/vcpkg.json
+++ b/ports/fast-float/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fast-float",
   "version": "8.2.10",
+  "port-version": 1,
   "description": "Fast and exact implementation of the C++ from_chars functions for float and double types: 4x faster than strtod",
   "homepage": "https://github.com/fastfloat/fast_float",
   "license": "Apache-2.0 OR BSL-1.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2970,7 +2970,7 @@
     },
     "fast-float": {
       "baseline": "8.2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "fast-obj": {
       "baseline": "1.3",

--- a/versions/f-/fast-float.json
+++ b/versions/f-/fast-float.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eb0c026b825d23755ef080fa882cfbfa3465c8c0",
+      "git-tree": "d609d1085e170250d979f88d2db0e0d95350d2bc",
       "version": "8.2.10",
       "port-version": 1
     },

--- a/versions/f-/fast-float.json
+++ b/versions/f-/fast-float.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb0c026b825d23755ef080fa882cfbfa3465c8c0",
+      "version": "8.2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "2c2512ee776af9bbefa8bb23b919e815d2c346d2",
       "version": "8.2.10",
       "port-version": 0


### PR DESCRIPTION
Fix use with pristine `windows.h`.
Cherry-picked from https://github.com/microsoft/vcpkg/pull/52532.
Plus minor cleanup.