### PR TITLE
[catch2] Remove pdb file copying from catch2 port

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -43,22 +43,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/catch2/generators/internal"
 
 file(WRITE "${CURRENT_PACKAGES_DIR}/include/catch.hpp" "#include <catch2/catch_all.hpp>")
 
-# Copy pdb files to lib folders
-if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-  # Catch2 builds static libraries even when shared libraries are requested.
-  # We thus cannot use vcpkg_copy_pdbs which only works for dlls but have to search for the pdbs manually.
-  file(GLOB_RECURSE catch2_pdb_files "${CURRENT_BUILDTREES_DIR}/*.pdb")
-  list(FILTER catch2_pdb_files INCLUDE REGEX ".*${TARGET_TRIPLET}.*")
-  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    set(catch2_release_pdb_files ${catch2_pdb_files})
-    list(FILTER catch2_release_pdb_files INCLUDE REGEX ".*${TARGET_TRIPLET}-rel.*")
-    file(COPY ${catch2_release_pdb_files} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-  endif()
-  if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    set(catch2_debug_pdb_files ${catch2_pdb_files})
-    list(FILTER catch2_debug_pdb_files INCLUDE REGEX ".*${TARGET_TRIPLET}-dbg.*")
-    file(COPY ${catch2_debug_pdb_files} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-  endif()
-endif()
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.15.2",
+  "port-version": 1,
   "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1630,7 +1630,7 @@
     },
     "catch2": {
       "baseline": "3.15.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cblas": {
       "baseline": "2025-10-29",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9ae6cad3ea0560a771254eef09d760f4c77acbe",
+      "version-semver": "3.15.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "7cd846defc0d7e34de9fa622c83fc901f7a6d8f4",
       "version-semver": "3.15.2",
       "port-version": 0


### PR DESCRIPTION
This reverts the changes from my PR https://github.com/microsoft/vcpkg/pull/49707.

It can lead to conflicts when different ports try to copy pdb files with the same name. 

As already noted in the previous PR, the correct fix is to use a custom triplet which uses embedded debug information for ports with static linking. 

For anyone else wondering how that works, I fixed the warning by adding the following to my `.vcpkg-overlays/triplets/x64-msvc.cmake` overlay triplet
```
# In general we want to have debug info in a separate .pdb database (compiler flag /Zi).
# However, some ports always use static linking and do not copy pdb files during installation.
# To avoid warnings about missing pdb files, we use embedded debug info for those ports (compiler flag /Z7).
if (PORT MATCHES "polyclipping|catch2")
  set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/../toolchains/win-msvc-Z7.cmake)
else()
  set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/../toolchains/win-msvc-Zi.cmake)
endif()
```
and having two separate toolchain files which only differ in how they set the debug information flag.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
