### PR TITLE
[srell] update to 2026.05

### DIFF
--- a/ports/srell/Unicode-license.txt
+++ b/ports/srell/Unicode-license.txt
@@ -1,0 +1,39 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2026 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.

--- a/ports/srell/portfile.cmake
+++ b/ports/srell/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://www.akenotsuki.com/misc/srell/releases/srell${VERSION}.zip"
     FILENAME "srell${VERSION}.zip"
-    SHA512 08e4629daf31083db6799390f1a4c942fdcd21358e90568666e060c1d7563c878281c6e2f2bb6ebf9889bfc5606166d0664ff0b6b4657bbcbed18c42dbf707f5
+    SHA512 fe5d401944bbc544e558c76c9916d3065ec1737be93336295a7231a56f1f8772caa4710cfe67842aca8058fbcce5f7e2cb17e6064ff0d0443ce1c8046add0c21
 )
 
 vcpkg_extract_source_archive(

--- a/ports/srell/portfile.cmake
+++ b/ports/srell/portfile.cmake
@@ -20,4 +20,7 @@ file(INSTALL
     DESTINATION "${CURRENT_PACKAGES_DIR}/include"
 )
 
-file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/license.txt"
+    COMMENT "The srell_ucfdata2.h and srell_updata3.h files were generated from the\nUnicode Data files, which are licensed under Unicode 3.0."
+)

--- a/ports/srell/portfile.cmake
+++ b/ports/srell/portfile.cmake
@@ -20,7 +20,10 @@ file(INSTALL
     DESTINATION "${CURRENT_PACKAGES_DIR}/include"
 )
 
-vcpkg_install_copyright(
-    FILE_LIST "${SOURCE_PATH}/license.txt"
-    COMMENT "The srell_ucfdata2.h and srell_updata3.h files were generated from the\nUnicode Data files, which are licensed under Unicode 3.0."
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/license.txt"
+    # The build produces Unicode-licensed generated headers.
+    # The Unicode-license.txt file was downloaded from:
+    # https://www.unicode.org/license.txt
+    "${CURRENT_PORT_DIR}/Unicode-license.txt"
 )

--- a/ports/srell/vcpkg.json
+++ b/ports/srell/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "srell",
-  "version-string": "2026.01",
-  "port-version": 1,
+  "version-string": "2026.05",
   "description": "SRELL (std::regex-like library) is a regular expression template library for C++.",
   "homepage": "https://www.akenotsuki.com/misc/srell/en/",
   "license": "BSD-2-Clause"

--- a/ports/srell/vcpkg.json
+++ b/ports/srell/vcpkg.json
@@ -3,5 +3,5 @@
   "version-string": "2026.05",
   "description": "SRELL (std::regex-like library) is a regular expression template library for C++.",
   "homepage": "https://www.akenotsuki.com/misc/srell/en/",
-  "license": "BSD-2-Clause"
+  "license": "BSD-2-Clause AND Unicode-3.0"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9717,8 +9717,8 @@
       "port-version": 0
     },
     "srell": {
-      "baseline": "2026.01",
-      "port-version": 1
+      "baseline": "2026.05",
+      "port-version": 0
     },
     "srpc": {
       "baseline": "0.10.4",

--- a/versions/s-/srell.json
+++ b/versions/s-/srell.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39721dcdc2fc1c4c3a572a2cc60d976460a8a63b",
+      "git-tree": "0fc2c01ccc9dc687537715324cd17bb9b18e43f1",
       "version-string": "2026.05",
       "port-version": 0
     },

--- a/versions/s-/srell.json
+++ b/versions/s-/srell.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c87c00535306dfa8924c56ef991e1d53b49ee3d3",
+      "git-tree": "39721dcdc2fc1c4c3a572a2cc60d976460a8a63b",
       "version-string": "2026.05",
       "port-version": 0
     },

--- a/versions/s-/srell.json
+++ b/versions/s-/srell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c87c00535306dfa8924c56ef991e1d53b49ee3d3",
+      "version-string": "2026.05",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ef58f2efd3e3c16c5835ecab1086b2b9ed2038f",
       "version-string": "2026.01",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] ~~All patch files in the port are applied and succeed.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This updates [srell] to the latest version.