### PR TITLE
[eccodes] Fix missing tl-expected dependency in CMake config

### DIFF
--- a/ports/eccodes/use-external-tl-expected.patch
+++ b/ports/eccodes/use-external-tl-expected.patch
@@ -42,3 +42,15 @@ index 04b03eb..7f97c37 100644
          $<$<BOOL:${libaec_FOUND}>:libaec::aec>
      PUBLIC_LIBS
          ${CMATH_LIBRARIES}
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 2106df1..cfaa8fe 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -94,6 +94,7 @@ foreach( tool ${test_c_bins} )
+                             LIBS      eccodes )
+ endforeach()
+ 
++target_link_libraries(unit_tests tl::expected)
+ 
+ # Now add each test (shell scripts)
+ #################################################

--- a/ports/eccodes/use-external-tl-expected.patch
+++ b/ports/eccodes/use-external-tl-expected.patch
@@ -19,6 +19,17 @@ index c63a982..5bc325f 100644
  )
  set( ECCODES_LIBRARIES       eccodes )
  
+diff --git a/eccodes-import.cmake.in b/eccodes-import.cmake.in
+index c0155c8..3245f4f 100644
+--- a/eccodes-import.cmake.in
++++ b/eccodes-import.cmake.in
+@@ -1,3 +1,6 @@
++include(CMakeFindDependencyMacro)
++find_dependency(tl-expected CONFIG)
++
+ set( ECCODES_DEFINITION_PATH ${eccodes_BASE_DIR}/@ECCODES_DEFINITION_SUFF@ )
+ set( ECCODES_SAMPLES_PATH ${eccodes_BASE_DIR}/@ECCODES_SAMPLES_SUFF@ )
+ set( ECCODES_IFS_SAMPLES_PATH ${eccodes_BASE_DIR}/@ECCODES_IFS_SAMPLES_SUFF@ )
 diff --git a/src/eccodes/CMakeLists.txt b/src/eccodes/CMakeLists.txt
 index 04b03eb..7f97c37 100644
 --- a/src/eccodes/CMakeLists.txt
@@ -31,16 +42,3 @@ index 04b03eb..7f97c37 100644
          $<$<BOOL:${libaec_FOUND}>:libaec::aec>
      PUBLIC_LIBS
          ${CMATH_LIBRARIES}
-
-diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index 2106df1..cfaa8fe 100644
---- a/tests/CMakeLists.txt
-+++ b/tests/CMakeLists.txt
-@@ -94,6 +94,7 @@ foreach( tool ${test_c_bins} )
-                             LIBS      eccodes )
- endforeach()
- 
-+target_link_libraries(unit_tests tl::expected)
- 
- # Now add each test (shell scripts)
- #################################################

--- a/ports/eccodes/vcpkg.json
+++ b/ports/eccodes/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eccodes",
   "version": "2.48.0",
+  "port-version": 1,
   "description": "ECMWF GRIB, BUFR and GTS decoding and encoding library and tools",
   "homepage": "https://github.com/ecmwf/eccodes",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2770,7 +2770,7 @@
     },
     "eccodes": {
       "baseline": "2.48.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ecm": {
       "baseline": "6.28.0",

--- a/versions/e-/eccodes.json
+++ b/versions/e-/eccodes.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d280d1f3134d37d0329a517ba0471788917881be",
+      "git-tree": "64840128a033dbea7ed8c9f2b036e8bcbfefbc12",
       "version": "2.48.0",
       "port-version": 1
     },

--- a/versions/e-/eccodes.json
+++ b/versions/e-/eccodes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d280d1f3134d37d0329a517ba0471788917881be",
+      "version": "2.48.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0da520cc5ef1c1263c740fcf0836e3c43e61fc23",
       "version": "2.48.0",
       "port-version": 0


### PR DESCRIPTION
Load tl-expected from eccodes-import.cmake.in before the exported ecCodes targets are imported.

This ensures the tl::expected target exists when downstream projects call find_package(eccodes CONFIG REQUIRED), preventing CMake generation failures.
