### PR TITLE
[krpc-cnano] Update to 0.6.0

### DIFF
--- a/ports/krpc-cnano/portfile.cmake
+++ b/ports/krpc-cnano/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/krpc/krpc/releases/download/v${VERSION}/krpc-cnano-${VERSION}.zip"
+    FILENAME "krpc-cnano-${VERSION}.zip"
+    SHA512 a7c678cec62944bbfab575f45808aa62df50fa4b6ba7d34e4732ff506d6065b7f4599fcc3ab40d0031d83038b1c71469522bc7ab0639338009d7a4e7886c8368
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    SOURCE_BASE "krpc-cnano-${VERSION}"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DKRPC_FETCH_NANOPB=OFF
+        -DKRPC_REGENERATE_PROTO=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/krpc_cnano PACKAGE_NAME krpc_cnano)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/COPYING.LESSER"
+    "${CURRENT_INSTALLED_DIR}/share/nanopb/copyright"
+)

--- a/ports/krpc-cnano/usage
+++ b/ports/krpc-cnano/usage
@@ -1,0 +1,4 @@
+krpc_cnano provides CMake integration:
+
+    find_package(krpc_cnano CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE krpc_cnano::krpc_cnano)

--- a/ports/krpc-cnano/vcpkg.json
+++ b/ports/krpc-cnano/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "krpc-cnano",
+  "version": "0.6.0",
+  "description": "kRPC C-nano client — control Kerbal Space Program from C programs via RPC",
+  "homepage": "https://krpc.github.io/krpc",
+  "license": "LGPL-3.0-or-later AND Zlib",
+  "dependencies": [
+    "nanopb",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4616,6 +4616,10 @@
       "baseline": "1.22.2",
       "port-version": 1
     },
+    "krpc-cnano": {
+      "baseline": "0.6.0",
+      "port-version": 0
+    },
     "ktx": {
       "baseline": "4.4.2",
       "port-version": 0

--- a/versions/k-/krpc-cnano.json
+++ b/versions/k-/krpc-cnano.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "18623ef56cbfe560cbac6e69239005c16384d8ea",
+      "version": "0.6.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Updates the `krpc-cnano` port to 0.6.0.

Release: https://github.com/krpc/krpc/releases/tag/v0.6.0