### PR TITLE
[libsrt] Update to version 1.5.6

### DIFF
--- a/ports/libsrt/portfile.cmake
+++ b/ports/libsrt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Haivision/srt
     REF "v${VERSION}"
-    SHA512 afb35de76be5c1b8558b3956586b8b7b044aa7709d7ce1b99b6b55e54f72c604eea50ae44962985c68ef681a69accb0a2a7f6a8678b8165e2aeee93632a0ff2f
+    SHA512 57641b35644b6bfa5998648fb808b615d11d8eab52fecb628a58414dbc87b1d781ea281c8ceef42a92f0c3796a05b41b8411bea95188ce751544f8195b7dbb66
     HEAD_REF master
     PATCHES
         fix-static.patch

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libsrt",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.",
   "homepage": "https://github.com/Haivision/srt",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5737,7 +5737,7 @@
       "port-version": 15
     },
     "libsrt": {
-      "baseline": "1.5.5",
+      "baseline": "1.5.6",
       "port-version": 0
     },
     "libsrtp": {

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "960841d0c8c261a61089338f116bb6d4000a0335",
+      "version": "1.5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "c874078f84e81cdbd7bc745cacc07fde3a10a56c",
       "version": "1.5.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.