### PR TITLE
[winsparkle] Update to version 0.9.4

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,55 +1,62 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/vslavik/winsparkle/releases/download/v${VERSION}/WinSparkle-${VERSION}.zip"
     FILENAME "winsparkle-v${VERSION}.zip"
-    SHA512 2a6201c72919142df2dc60a60d2e6721d816688dda401524bfb7cfdb167fadb452c24fd98500c1781e17b0009676345332d1ced94a596150ceb57aff58419c37
+    SHA512 48306b9ca09e00dff6384767aed6e15f07dbb5463b6430cb18076195eea40c128cf952e68a300c920964276351c893aed93d3f81ac1d01db6caa0727885b2ef1
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
 )
 
-file(GLOB HEADER_LIST "${SOURCE_PATH}/include/*.h")
+# WinSparkle 0.9.4's binary ZIP retains this top-level directory when
+# NO_REMOVE_ONE_LEVEL is used.
+set(WINSPARKLE_ROOT "${SOURCE_PATH}/WinSparkle-${VERSION}")
+
+if(NOT EXISTS "${WINSPARKLE_ROOT}/include/winsparkle.h")
+    message(FATAL_ERROR "Unexpected WinSparkle archive layout under: ${SOURCE_PATH}")
+endif()
+
+file(GLOB HEADER_LIST "${WINSPARKLE_ROOT}/include/*.h")
 file(INSTALL ${HEADER_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
-file(GLOB TOOLS_LIST "${SOURCE_PATH}/bin/*.bat")
+
+file(GLOB TOOLS_LIST "${WINSPARKLE_ROOT}/bin/*.bat")
 file(INSTALL ${TOOLS_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
-# Note: It is an explicit design goal for WinSparkle to be a single
-# self-contained DLL with no external dependencies (to the point that
-# it even links to static CRT!). This matters for e.g. in-app delta updates
-# or re-launching the app after update. It is not statically linked even if a
-# static linking is used for everything else.
+# WinSparkle is distributed as a self-contained DLL even for static triplets.
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
-if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-
-    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-
-    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-    file(INSTALL "${SOURCE_PATH}/ARM64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SOURCE_PATH}/ARM64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SOURCE_PATH}/ARM64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-
-    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well
-    file(INSTALL "${SOURCE_PATH}/ARM64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SOURCE_PATH}/ARM64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SOURCE_PATH}/ARM64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(WINSPARKLE_ARCH_DIR "Win32/Release")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(WINSPARKLE_ARCH_DIR "x64/Release")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(WINSPARKLE_ARCH_DIR "ARM64/Release")
 else()
     message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+set(WINSPARKLE_BINARY_DIR "${WINSPARKLE_ROOT}/${WINSPARKLE_ARCH_DIR}")
+
+foreach(FILE_NAME IN ITEMS WinSparkle.dll WinSparkle.pdb)
+    file(INSTALL
+        "${WINSPARKLE_BINARY_DIR}/${FILE_NAME}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+    )
+    file(INSTALL
+        "${WINSPARKLE_BINARY_DIR}/${FILE_NAME}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endforeach()
+
+file(INSTALL
+    "${WINSPARKLE_BINARY_DIR}/WinSparkle.lib"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+)
+file(INSTALL
+    "${WINSPARKLE_BINARY_DIR}/WinSparkle.lib"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${WINSPARKLE_ROOT}/COPYING")

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "winsparkle",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
   "homepage": "https://winsparkle.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10993,7 +10993,7 @@
       "port-version": 5
     },
     "winsparkle": {
-      "baseline": "0.9.3",
+      "baseline": "0.9.4",
       "port-version": 0
     },
     "wintoast": {

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a630ac6b10c26c95890e5ceb205bb31eedc0764",
+      "version": "0.9.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "5cf3f59ac0e714d753ae7ccc7c05bd88fc633b07",
       "version": "0.9.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.