### PR TITLE
[c4core] update to 0.6.0

### DIFF
--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/c4core
     REF "v${VERSION}"
-    SHA512 dd7847b7aad705edf41c6ece246c345ccd92ce38344ade582d5c5e14a99c7cc94e732bea20ea5594b7a572225f7ad1820cc2cd003ee21a682e3102d9d0c8a6c5
+    SHA512 c485fa36a27e97e597ab069322eb712780577c91b4d924cf12a9acc5f59f0ec925d5f9b09dfe74a756fb456c835eb6a226f9e63e9f412c5b1248d244380074a4
     HEAD_REF master
     PATCHES
         disable-cpack.patch

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c4core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1565,7 +1565,7 @@
       "port-version": 0
     },
     "c4core": {
-      "baseline": "0.5.0",
+      "baseline": "0.6.0",
       "port-version": 0
     },
     "c89stringutils": {

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40f2016c5f407a9b64e4179d3ccfa54aed642bf2",
+      "version": "0.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "113893d57424aaba2ef8021cb18314fa71721e52",
       "version": "0.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/biojppm/c4core/releases/tag/v0.6.0
