### PR TITLE
[mgclient] update to 1.8.0

### DIFF
--- a/ports/mgclient/portfile.cmake
+++ b/ports/mgclient/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO memgraph/mgclient
     REF "v${VERSION}"
-    SHA512 0c4c0b1231f3f5e232ef9a80a01a58e00d2d50dc1e7bb4a6c25d800c93d7f77b8b21679af9ce26fc98a54813c54fac0a5e7eb8eb9a0eb78dbd88ce1ad569a2e2
+    SHA512 c3f897f48907d2e163c032d046b74d83218e1621d2929eb2e3688aa21d679c35b2720a309f51b984b13f5326d306e91b2d290da9684aa1ed165d8576576970f9
     HEAD_REF master
     PATCHES
         export-cmake.patch

--- a/ports/mgclient/vcpkg.json
+++ b/ports/mgclient/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mgclient",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "description": "C/C++ Memgraph Client ",
   "homepage": "https://github.com/memgraph/mgclient",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6577,7 +6577,7 @@
       "port-version": 6
     },
     "mgclient": {
-      "baseline": "1.6.0",
+      "baseline": "1.8.0",
       "port-version": 0
     },
     "mgnlibs": {

--- a/versions/m-/mgclient.json
+++ b/versions/m-/mgclient.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "589c66dfd69ccb2f573076479031ab44b106cb7f",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f90931d1b3030077ae885f070a1c55eff7374751",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/memgraph/mgclient/releases/tag/v1.8.0
