### PR TITLE
[pcapplusplus] Bump to 26.07

### DIFF
--- a/ports/pcapplusplus/portfile.cmake
+++ b/ports/pcapplusplus/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO seladb/PcapPlusPlus
     REF "v${PCAPPLUSPLUS_VERSION}"
-    SHA512 83f95e82cbbd10a88b6d333d2b6c6f1e4fef8b0b86f8ad6202cf77d50bf7a1c6afdcb0254962c37cc1c4b55e2e9700b97cc6222129990ff86fcefc7b06621cd0
+    SHA512 06c1440a7f88cbef13e5cd2bfbd3c2c1be73f859fc778a25760e0af9ff988b2814a0888d6fadbb3771dfc155dacda5860aa865d8ec5f2cf348d1a1aa29d1cdf4
     HEAD_REF master
 )
 

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pcapplusplus",
-  "version": "25.5",
-  "port-version": 1,
+  "version": "26.7",
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",
   "documentation": "https://pcapplusplus.github.io",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7713,8 +7713,8 @@
       "port-version": 9
     },
     "pcapplusplus": {
-      "baseline": "25.5",
-      "port-version": 1
+      "baseline": "26.7",
+      "port-version": 0
     },
     "pcg": {
       "baseline": "2022-04-09",

--- a/versions/p-/pcapplusplus.json
+++ b/versions/p-/pcapplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb2a6b2beb2e166d076f90003b246593dd5b27da",
+      "version": "26.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "e7ae6087eafa63b40ae1f7f2505f896d75d3e2f2",
       "version": "25.5",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.