### PR TITLE
[libaec] Switch to GitHub repo

### DIFF
--- a/ports/libaec/portfile.cmake
+++ b/ports/libaec/portfile.cmake
@@ -1,9 +1,9 @@
-vcpkg_from_gitlab(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    GITLAB_URL https://gitlab.dkrz.de
-    REPO dkrz-sw/libaec
+    REPO Deutsches-Klimarechenzentrum/libaec
     REF "v${VERSION}"
-    SHA512 ede721986c1b7632ee2577964d02438a8ff5ed90481ea638412f6c2128af0bf1911ca3762acdbaf04fdcab75a363652bf5c992c11d9e38d4e5334f089d124617
+    SHA512 55bd605590015e0f903a231268265051336c172c18935fdfecead5630454a99811f3f196117556ad1b62f3052d54894fd8e257a9ea9f45cc03f59c93cde00cda
+    HEAD_REF main
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)

--- a/ports/libaec/vcpkg.json
+++ b/ports/libaec/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libaec",
   "version": "1.1.7",
+  "port-version": 1,
   "description": "Adaptive Entropy Coding library",
-  "homepage": "https://gitlab.dkrz.de/dkrz-sw/libaec",
+  "homepage": "https://github.com/Deutsches-Klimarechenzentrum/libaec",
   "license": "BSD-2-Clause",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4758,7 +4758,7 @@
     },
     "libaec": {
       "baseline": "1.1.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libaes-siv": {
       "baseline": "2020-10-15",

--- a/versions/l-/libaec.json
+++ b/versions/l-/libaec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "259c7e8019fc290edaf5b2e007b2627ede7ee2ff",
+      "version": "1.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "72f26b8b97b73d8e560c2167058dbeeeeff91f37",
       "version": "1.1.7",
       "port-version": 0


### PR DESCRIPTION

This switches the repo for libaec from GitLab to GitHub. Access to DKRZ's GitLab has been somewhat flaky in the recent past. The repo on GitHub will become the main repo for libaec and GitLab will only stay as a mirror. 

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] SHA512s are updated for each updated download.
- [ x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ x] All patch files in the port are applied and succeed.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Exactly one version is added in each modified versions file.
