### PR TITLE
[apibrasil] Add new port

### DIFF
--- a/ports/apibrasil/portfile.cmake
+++ b/ports/apibrasil/portfile.cmake
@@ -1,0 +1,34 @@
+# Header + compiled library. Downloads the tagged release from GitHub, builds it
+# with the project's CMake, and installs headers + the apibrasil::apibrasil target.
+
+# The library does not export symbols for a Windows DLL, so build it static on
+# every triplet (avoids empty-DLL/link errors on dynamic triplets).
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO APIBrasil/apigratis-sdk-cpp
+    REF "v${VERSION}"
+    # Placeholder: rode 'vcpkg install apibrasil' uma vez e cole o "Actual hash"
+    # que o vcpkg imprime. Assim o hash e do tarball real da tag (independente
+    # deste arquivo, evitando dependencia circular).
+    SHA512 df371bc33cfb8970d2376e70660fc1f803055edc3e85f182bf2b3f5ef551d29943ab2c59cfc9f5cc6f46bab881ff1aad60460bade7f82c3447fb38f29d914c18
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAPIBRASIL_BUILD_EXAMPLES=OFF
+        -DAPIBRASIL_BUILD_TESTS=OFF
+        -DAPIBRASIL_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME apibrasil CONFIG_PATH lib/cmake/apibrasil)
+
+# Headers only live in the release tree.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/apibrasil/usage
+++ b/ports/apibrasil/usage
@@ -1,0 +1,4 @@
+apibrasil provides CMake targets:
+
+    find_package(apibrasil CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE apibrasil::apibrasil)

--- a/ports/apibrasil/vcpkg.json
+++ b/ports/apibrasil/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "apibrasil",
+  "version": "0.0.1",
+  "description": "SDK oficial C++ da plataforma APIBrasil - WhatsApp, SMS, consultas CPF/CNPJ, veiculos, CEP, correios, pagamentos PIX/boleto e mais.",
+  "homepage": "https://github.com/APIBrasil/apigratis-sdk-cpp",
+  "documentation": "https://doc.apibrasil.io",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "curl",
+      "default-features": false,
+      "features": [
+        "ssl"
+      ]
+    },
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/apibrasil.json
+++ b/versions/a-/apibrasil.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "800d1c3e23e2da087a6e9621005d7acd47cbc3de",
+      "version": "0.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -188,6 +188,10 @@
       "baseline": "5.2.0",
       "port-version": 1
     },
+    "apibrasil": {
+      "baseline": "0.0.1",
+      "port-version": 0
+    },
     "approval-tests-cpp": {
       "baseline": "10.13.0",
       "port-version": 0


### PR DESCRIPTION
Adds a new port for **apibrasil** — the official C++ SDK for the [APIBrasil](https://apibrasil.com.br) platform (WhatsApp, SMS, CPF/CNPJ lookups, vehicles, CEP, correios, PIX/boleto payments, and more).

- Upstream: https://github.com/APIBrasil/apigratis-sdk-cpp (release `v0.0.1`)
- Header + compiled **static** library; installs a CMake config exporting `apibrasil::apibrasil`.
- Dependencies: `nlohmann-json`, `curl`.

Builds and installs cleanly on `x64-windows`; the library is C++17 and standard/POSIX only (also compiles clean with GCC 13 + nlohmann-json 3.12).

- [x] Changes comply with the maintainer guide.
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by running `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to the new port.