### PR TITLE
[apibrasil] Add new port

### DIFF
--- a/ports/apibrasil/portfile.cmake
+++ b/ports/apibrasil/portfile.cmake
@@ -1,0 +1,37 @@
+# Header + compiled library. Downloads the tagged release from GitHub, builds it
+# with the project's CMake, and installs headers + the apibrasil::apibrasil target.
+
+# The library does not export symbols for a Windows DLL, so build it static on
+# every triplet (avoids empty-DLL/link errors on dynamic triplets).
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO APIBrasil/apigratis-sdk-cpp
+    REF "v${VERSION}"
+    # Placeholder: rode 'vcpkg install apibrasil' uma vez e cole o "Actual hash"
+    # que o vcpkg imprime. Assim o hash e do tarball real da tag (independente
+    # deste arquivo, evitando dependencia circular).
+    SHA512 95f86a659c067287670db2d1cb5e4ec8f70fb603cbf97e5c990ffe61fe3a7538fb73423e8bc244a95d6ced4ade90dc6d73722c3ef97cbbdf91b195774eb5ecc0
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAPIBRASIL_BUILD_EXAMPLES=OFF
+        -DAPIBRASIL_BUILD_TESTS=OFF
+        -DAPIBRASIL_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME apibrasil CONFIG_PATH lib/cmake/apibrasil)
+
+# Headers only live in the release tree.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Usage help text shown after installation.
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/apibrasil/usage
+++ b/ports/apibrasil/usage
@@ -1,0 +1,4 @@
+apibrasil provides CMake targets:
+
+    find_package(apibrasil CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE apibrasil::apibrasil)

--- a/ports/apibrasil/vcpkg.json
+++ b/ports/apibrasil/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "apibrasil",
+  "version": "0.0.2",
+  "description": "SDK oficial C++ da plataforma APIBrasil - WhatsApp, SMS, consultas CPF/CNPJ, veiculos, CEP, correios, pagamentos PIX/boleto e mais.",
+  "homepage": "https://github.com/APIBrasil/apigratis-sdk-cpp",
+  "documentation": "https://doc.apibrasil.io",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "curl",
+      "default-features": false,
+      "features": [
+        "ssl"
+      ]
+    },
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/apibrasil.json
+++ b/versions/a-/apibrasil.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ae162239a59ccbec340f914aeca068b257226376",
+      "version": "0.0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -188,6 +188,10 @@
       "baseline": "5.2.0",
       "port-version": 1
     },
+    "apibrasil": {
+      "baseline": "0.0.2",
+      "port-version": 0
+    },
     "approval-tests-cpp": {
       "baseline": "10.13.0",
       "port-version": 0


### PR DESCRIPTION
Adds a new port for **apibrasil** — the official C++ SDK for the [APIBrasil](https://apibrasil.com.br) platform (WhatsApp, SMS, CPF/CNPJ lookups, vehicles, CEP, correios, PIX/boleto payments, and more).

- Upstream: https://github.com/APIBrasil/apigratis-sdk-cpp (release `v0.0.2`)
- Header + compiled **static** library; installs a CMake config exporting `apibrasil::apibrasil`.
- Dependencies: `nlohmann-json`, `curl`.

Builds and installs cleanly on `x64-windows` (verified locally with post-build checks passing) and compiles clean with GCC 13 + nlohmann-json 3.12 on Linux.

- [x] Changes comply with the maintainer guide.
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by running `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to the new port.