### PR TITLE
[chess-engine] Add new port

### DIFF
--- a/ports/chess-engine/portfile.cmake
+++ b/ports/chess-engine/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ByteMe6/chess-engine
+    REF "v${VERSION}"
+    SHA512 4cf92b26c135cb87c4aff96fb41a2bce71f7f60de6fdf8a67675cd941927a5d1d5be3570cb97afdbe582d02c4375597275cedc42b1cffe83f6fe22fb590c7b9e
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/src/chessEngine.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/chess-engine/vcpkg.json
+++ b/ports/chess-engine/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "chess-engine",
+  "version": "1.1.0",
+  "description": "Minimal chess engine in C++17 - move generation, validation and ASCII board rendering. STL only.",
+  "homepage": "https://github.com/ByteMe6/chess-engine",
+  "license": "GPL-3.0-only"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1732,6 +1732,10 @@
       "baseline": "2.1.4",
       "port-version": 0
     },
+    "chess-engine": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "chipmunk": {
       "baseline": "7.0.3",
       "port-version": 7

--- a/versions/c-/chess-engine.json
+++ b/versions/c-/chess-engine.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2f6e0e3d45a22f0e967ebb814f6670844d650e57",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new port: **chess-engine** 1.1.0 — a minimal header-only chess engine in C++17 (move generation, validation, and ASCII board rendering, STL only).

- Homepage: https://github.com/ByteMe6/chess-engine
- License: GPL-3.0-only
- Header-only (installs `chessEngine.hpp`); no dependencies beyond the C++17 STL.

<!-- Maintainer checklist -->
- [x] Changes comply with the [maintainer guide](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide).
- [x] The name of the port matches an existing name if this is a new version of the same library (n/a — new port).
- [x] SHA512s are updated for each downloaded file — generated and verified via a local `vcpkg install chess-engine` (post-build validation passed).
- [x] The "supports" clause reflects platform restrictions — none needed; header-only, portable across all triplets.
- [x] Any patches that are not applied upstream have an explanation — no patches.
- [x] The version database is up to date (`vcpkg x-add-version chess-engine`).
- [x] Only the relevant port files are changed.

Tested locally on x64-linux: downloads, extracts, installs the header + copyright, and passes post-build validation.
