### PR TITLE
[fancyargumentparser] Update to 1.0.3

### DIFF
--- a/ports/fancyargumentparser/portfile.cmake
+++ b/ports/fancyargumentparser/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simfeo/FancyArgumentParser
-    REF "v1.0.2"
-    SHA512 03419a87a0c0b7ed6aedf724eb498bbfd5a6f59c0151e56d2e56a1551dcd9d91e0142d6bf8fcb39dca740cda4d72d6719d3b24fbf35dc52eb38bca7590d10f75
+    REF "v1.0.3"
+    SHA512 72152ba4a78a55344f68ed9adf7ae187e2f695bda50e8b9014ac3f0e83a61b43340fd244bc1fd1b34249e2721f03f0a563a5e23d062951c908debfc348dcdeec
     HEAD_REF main
 )
 

--- a/ports/fancyargumentparser/vcpkg.json
+++ b/ports/fancyargumentparser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fancyargumentparser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A fancy and easy-to-use command-line argument parser for C++. Support C++11/C++14/C++17/C++20/C++23",
   "homepage": "https://github.com/simfeo/FancyArgumentParser",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2949,7 +2949,7 @@
       "port-version": 0
     },
     "fancyargumentparser": {
-      "baseline": "1.0.2",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "fann": {

--- a/versions/f-/fancyargumentparser.json
+++ b/versions/f-/fancyargumentparser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4213f70f7f7e3ceb5266b33ed07dc53c6a3ecf40",
+      "version": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "54c4004e2f72f8e1ad94e53d69307f5444a3a576",
       "version": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
Updates `fancyargumentparser` from 1.0.2 to 1.0.3.

The 1.0.3 release adds a C++20 module wrapper, value validators, `ParserSpec`
construction, by-name getters, and mixed positional/named argument support. The
port remains header-only (installs `argparse.h`); the module interface file is
intentionally not shipped, as vcpkg has no consumption story for a bare module
interface unit.

**Validation (locally, on Windows / x64-windows):**
- `./vcpkg install fancyargumentparser` — source downloads, SHA512 verifies,
  installs `argparse.h` + copyright, post-build validation passes.
- `./vcpkg x-add-version fancyargumentparser` re-run reports no changes, so the
  version database matches the committed port.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] SHA512s are updated for each downloaded asset.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
