### PR TITLE
Use forwarding link to privacy notice in bootstrap

### DIFF
--- a/docs/about/privacy.md
+++ b/docs/about/privacy.md
@@ -3,3 +3,4 @@
 The documentation for this topic has been moved to the following articles in [Microsoft Learn](https://learn.microsoft.com/vcpkg):
 
 * [Privacy](https://learn.microsoft.com/vcpkg/about/privacy)
+* [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839)

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -82,6 +82,6 @@ You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disa
 passing --disable-metrics to vcpkg on the command line,
 or by setting the VCPKG_DISABLE_METRICS environment variable.
 
-Read more about vcpkg telemetry at docs/about/privacy.md
+Read more about vcpkg telemetry at https://go.microsoft.com/fwlink/?LinkId=521839
 "@
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -264,6 +264,6 @@ You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disa
 passing --disable-metrics to vcpkg on the command line,
 or by setting the VCPKG_DISABLE_METRICS environment variable.
 
-Read more about vcpkg telemetry at docs/about/privacy.md
+Read more about vcpkg telemetry at https://go.microsoft.com/fwlink/?LinkId=521839
 EOF
 fi


### PR DESCRIPTION
To comply with latest privacy review, we should use a forwarding link to the Microsoft Privacy Statement.