### PR TITLE
[neko-*] Update repository links after GitHub username change

### DIFF
--- a/ports/neko-event/portfile.cmake
+++ b/ports/neko-event/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoEvent
+    REPO hoshimoe/NekoEvent
     REF v1.0.1
     SHA512 2c9579def648a0feaaf0763d11801b70260d8f56bd477fcafc9d45cb7c2c5c8ab365f77c925aad46a75aa85c5c0730efee9ace0b6a5f3025a3166a776908a8e7
     HEAD_REF main

--- a/ports/neko-event/vcpkg.json
+++ b/ports/neko-event/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-event",
   "version": "1.0.1",
+  "port-version": 1,
   "description": "A modern easy to use type-safe and high-performance event handling system for C++ ",
-  "homepage": "https://github.com/moehoshio/NekoEvent",
+  "homepage": "https://github.com/hoshimoe/NekoEvent",
   "license": "MIT OR Apache-2.0",
   "dependencies": [
     "neko-schema",

--- a/ports/neko-function/portfile.cmake
+++ b/ports/neko-function/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoFunction
+    REPO hoshimoe/NekoFunction
     REF v1.0.11
     SHA512 3fbdba19085d76fe747ec38a2a4ad1e41c5d67f0e5ae320982bde35f796c9d89cbd304e6b11ef1bb4fa7101698f3b6737c6ddf94bd7f46f8f4e4061ef132c6ce
     HEAD_REF main

--- a/ports/neko-function/vcpkg.json
+++ b/ports/neko-function/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-function",
   "version": "1.0.11",
+  "port-version": 1,
   "description": "A comprehensive modern C++ utility library that provides practical functions for common programming tasks.",
-  "homepage": "https://github.com/moehoshio/NekoFunction",
+  "homepage": "https://github.com/hoshimoe/NekoFunction",
   "license": "MIT OR Apache-2.0",
   "dependencies": [
     "neko-schema",

--- a/ports/neko-log/portfile.cmake
+++ b/ports/neko-log/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoLog
+    REPO hoshimoe/NekoLog
     REF "v${VERSION}"
     SHA512 e64e01511dd77da3cfd648ac31911bd3ddda189817b818880568b80726d4ef2c7d118807164c4b18671e5d301a5c38f99209b66c030347d7d9c731497ff6c9a4
     HEAD_REF main

--- a/ports/neko-log/vcpkg.json
+++ b/ports/neko-log/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-log",
   "version": "1.0.7",
+  "port-version": 1,
   "description": "An easy-to-use, modern, lightweight, and efficient C++20 logging library",
-  "homepage": "https://github.com/moehoshio/NekoLog",
+  "homepage": "https://github.com/hoshimoe/NekoLog",
   "license": "MIT OR Apache-2.0",
   "supports": "!uwp",
   "dependencies": [

--- a/ports/neko-network/portfile.cmake
+++ b/ports/neko-network/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoNetwork
+    REPO hoshimoe/NekoNetwork
     REF v1.0.3
     SHA512 394bcd82743c25c1954dcce6699bc0c13a2ac8f00b06d082659aface2d6efeccb736feaa5c94a4eef2789194f2d7adefae0c476bf27866547be48602c90226b5
     HEAD_REF main

--- a/ports/neko-network/vcpkg.json
+++ b/ports/neko-network/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-network",
   "version": "1.0.3",
+  "port-version": 1,
   "description": "Neko Network is a modern, easy-to-use, and efficient C++20 network library built on top of libcurl.",
-  "homepage": "https://github.com/moehoshio/NekoNetwork",
+  "homepage": "https://github.com/hoshimoe/NekoNetwork",
   "license": "MIT OR Apache-2.0",
   "dependencies": [
     "curl",

--- a/ports/neko-schema/portfile.cmake
+++ b/ports/neko-schema/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoSchema
+    REPO hoshimoe/NekoSchema
     REF v1.1.5
     SHA512 a4383927168a06fc50623e8a0cdb4c1d9dabfa8a6f2ae6408aff5b468cd9a3bdca57262187c231231ad70eb2a6b65d5574a824cc0d4be6a43e62c4ecf342ef0b
     HEAD_REF main

--- a/ports/neko-schema/vcpkg.json
+++ b/ports/neko-schema/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-schema",
   "version": "1.1.5",
+  "port-version": 1,
   "description": "A lightweight C++20 header-only library providing fundamental type definitions and utilities for the Neko ecosystem",
-  "homepage": "https://github.com/moehoshio/NekoSchema",
+  "homepage": "https://github.com/hoshimoe/NekoSchema",
   "license": "MIT OR Apache-2.0",
   "supports": "!uwp",
   "dependencies": [

--- a/ports/neko-system/portfile.cmake
+++ b/ports/neko-system/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoSystem
+    REPO hoshimoe/NekoSystem
     REF v1.0.1
     SHA512 6ae5af6be464c7e0cfada4a87ac349537d0083dfaa8c02f421917525ceb62331632c3c203baedadaff44a7129817311cf5c72045e6b99e97b7bc17efeb2f475e
     HEAD_REF main

--- a/ports/neko-system/vcpkg.json
+++ b/ports/neko-system/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-system",
   "version": "1.0.1",
+  "port-version": 1,
   "description": "A cross-platform C++20 system information library providing memory information, platform detection, and system utilities.",
-  "homepage": "https://github.com/moehoshio/NekoSystem",
+  "homepage": "https://github.com/hoshimoe/NekoSystem",
   "license": "MIT OR Apache-2.0",
   "supports": "windows | linux | osx",
   "dependencies": [

--- a/ports/neko-threadpool/portfile.cmake
+++ b/ports/neko-threadpool/portfile.cmake
@@ -1,6 +1,6 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO moehoshio/NekoThreadPool
+    REPO hoshimoe/NekoThreadPool
     REF "v${VERSION}"
     SHA512 143e4bd8ca900a6a1680e62144ce39c8426057ed2b7f8b53267eb388fa54c2f7cca7e1e587b866e7f7e22759102765224217ecd083e406497d49f4a8600acccb
     HEAD_REF main

--- a/ports/neko-threadpool/vcpkg.json
+++ b/ports/neko-threadpool/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "neko-threadpool",
   "version": "1.0.2",
+  "port-version": 1,
   "description": "An easy-to-use and efficient C++ 20 thread pool that supports task priorities and task submission to specific threads.",
-  "homepage": "https://github.com/moehoshio/NekoThreadPool",
+  "homepage": "https://github.com/hoshimoe/NekoThreadPool",
   "license": "MIT OR Apache-2.0",
   "dependencies": [
     "neko-schema",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -806,7 +806,6 @@ nana:arm64-linux=fail
 nana:x64-linux=fail
 nanogui:arm64-linux=cascade
 nativefiledialog-extended:arm64-linux=cascade
-neko-network[nlog]:arm64-linux=feature-fails
 netcdf-c[core]:arm64-linux=combination-fails # error: cannot find math library
 netcdf-c[dap]:arm64-linux=feature-fails
 netcdf-c[szip]:arm64-linux=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7026,7 +7026,7 @@
     },
     "neko-function": {
       "baseline": "1.0.11",
-      "port-version": 0
+      "port-version": 1
     },
     "neko-log": {
       "baseline": "1.0.7",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7038,7 +7038,7 @@
     },
     "neko-schema": {
       "baseline": "1.1.5",
-      "port-version": 0
+      "port-version": 1
     },
     "neko-system": {
       "baseline": "1.0.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7022,7 +7022,7 @@
     },
     "neko-event": {
       "baseline": "1.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "neko-function": {
       "baseline": "1.0.11",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7046,7 +7046,7 @@
     },
     "neko-threadpool": {
       "baseline": "1.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "neon2sse": {
       "baseline": "2026-04-28",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7042,7 +7042,7 @@
     },
     "neko-system": {
       "baseline": "1.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "neko-threadpool": {
       "baseline": "1.0.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7034,7 +7034,7 @@
     },
     "neko-network": {
       "baseline": "1.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "neko-schema": {
       "baseline": "1.1.5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7030,7 +7030,7 @@
     },
     "neko-log": {
       "baseline": "1.0.7",
-      "port-version": 0
+      "port-version": 1
     },
     "neko-network": {
       "baseline": "1.0.3",

--- a/versions/n-/neko-event.json
+++ b/versions/n-/neko-event.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0764ebfa469ab6dc87156f4430ea846e99f974a8",
+      "version": "1.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "78a83aa6ffee7babcfafe463ed9d3e9b6816e4d0",
       "version": "1.0.1",
       "port-version": 0

--- a/versions/n-/neko-function.json
+++ b/versions/n-/neko-function.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8093584431237826806cee4174334b159c579f82",
+      "version": "1.0.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "12441d40c29162ed4b6fb0d50cd5670c9633407d",
       "version": "1.0.11",
       "port-version": 0

--- a/versions/n-/neko-log.json
+++ b/versions/n-/neko-log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "991be03bd6617ff1b63d4a4fb90bc1c00221f653",
+      "version": "1.0.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "682e99bd040f9fc0acf65c5c64845ef763d04837",
       "version": "1.0.7",
       "port-version": 0

--- a/versions/n-/neko-network.json
+++ b/versions/n-/neko-network.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fced68a170ea70f6ed76d68fb4655f583f2d26e3",
+      "version": "1.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "20dd2683cbee5d20007e9f616fbfe78864708139",
       "version": "1.0.3",
       "port-version": 0

--- a/versions/n-/neko-schema.json
+++ b/versions/n-/neko-schema.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "384a0f0f8e98c3caf54936eb9eec59f59b583d1b",
+      "version": "1.1.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "0cb7e01bf0741f74d40345c23fe0183fcd9fd4ec",
       "version": "1.1.5",
       "port-version": 0

--- a/versions/n-/neko-system.json
+++ b/versions/n-/neko-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e5703d450711c07bd882e3bffdef468a3ff1118",
+      "version": "1.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f9773ec8527ccfdd1b2fabff7fbdf0a81116d097",
       "version": "1.0.1",
       "port-version": 0

--- a/versions/n-/neko-threadpool.json
+++ b/versions/n-/neko-threadpool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac7c7b65b43572fe85e419dbc6dba8323be81d44",
+      "version": "1.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d0f15262c63c9a3cedc97a2dab3486069a533114",
       "version": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
This PR updates the repository references for the Neko ports following a GitHub username change:

- Old username: `moehoshio`
- New username: `hoshimoe`

The following fields are updated where applicable:

- `REPO` in `portfile.cmake`
- `homepage` in `vcpkg.json`

These related changes are grouped into a single PR because they all result from the same GitHub username change and contain no independent upstream package updates.

The upstream package versions, `REF` values, and `SHA512` hashes remain unchanged. The vcpkg `port-version` values and version database entries are updated as required for changes to the port metadata.