### PR TITLE
[simd] Avoid build race.

### DIFF
--- a/ports/simd/portfile.cmake
+++ b/ports/simd/portfile.cmake
@@ -6,6 +6,14 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-platform-detection.patch
+        use-preconfigured-version-header.patch
+)
+
+# Avoid upstream's debug and release configure steps racing to generate this shared source-tree file.
+configure_file(
+    "${SOURCE_PATH}/prj/txt/SimdVersion.h.txt"
+    "${SOURCE_PATH}/src/Simd/SimdVersion.h"
+    @ONLY
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64"))

--- a/ports/simd/use-preconfigured-version-header.patch
+++ b/ports/simd/use-preconfigured-version-header.patch
@@ -1,0 +1,17 @@
+diff --git a/prj/cmake/CMakeLists.txt b/prj/cmake/CMakeLists.txt
+index ebe2847..15922a8 100644
+--- a/prj/cmake/CMakeLists.txt
++++ b/prj/cmake/CMakeLists.txt
+@@ -114,12 +114,6 @@ endif()
+ include_directories("${SIMD_ROOT}/src")
+ 
+ if(SIMD_GET_VERSION)
+-	if (WIN32 AND NOT (CYGWIN OR MSYS))
+-		string(REPLACE "/" "\\" SIMD_ROOT_WINDOWS ${SIMD_ROOT})
+-		execute_process(COMMAND "${SIMD_ROOT}/prj/cmd/GetVersion.cmd" "${SIMD_ROOT_WINDOWS}" "${SIMD_INFO}")
+-	else()
+-		execute_process(COMMAND bash "${SIMD_ROOT}/prj/sh/GetVersion.sh" "${SIMD_ROOT}" "${SIMD_INFO}")
+-	endif()
+ else()
+ 	add_definitions(-DSIMD_VERSION="unknown")
+ endif()

--- a/ports/simd/vcpkg.json
+++ b/ports/simd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simd",
   "version": "7.1.162",
+  "port-version": 1,
   "description": "Simd image processing and machine learning library, designed for C and C++ programmers",
   "homepage": "https://github.com/ermig1979/Simd",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9358,7 +9358,7 @@
     },
     "simd": {
       "baseline": "7.1.162",
-      "port-version": 0
+      "port-version": 1
     },
     "simde": {
       "baseline": "0.8.2",

--- a/versions/s-/simd.json
+++ b/versions/s-/simd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a13bc1bf73c5267ce83b5e662dc54f0e25c99dd",
+      "version": "7.1.162",
+      "port-version": 1
+    },
+    {
       "git-tree": "4334e58736a5d5482d2dd73f71afbf3c0f6cdecb",
       "version": "7.1.162",
       "port-version": 0


### PR DESCRIPTION
In https://dev.azure.com/vcpkg/public/_build/results?buildId=135039&view=results we see a transient failure on x64-linux that appears to be the debug and release configures trying to party on the same file concurrently leading to it being malformed.

Generate the file ourselves and delete the configure code that was trying to generate it.
