### PR TITLE
[shader-slang] Fix dangling symlinks in tools/ that break binary cache packing

### DIFF
--- a/ports/shader-slang/portfile.cmake
+++ b/ports/shader-slang/portfile.cmake
@@ -131,6 +131,7 @@ file(INSTALL ${libs} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 file(GLOB dyn_libs
 	"${BINDIST_PATH}/lib/*.dylib"
 	"${BINDIST_PATH}/lib/*.so"
+	"${BINDIST_PATH}/lib/*.so.0.${VERSION}" # On linux, some of the .so files are postfixed by the version.
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/shader-slang/vcpkg.json
+++ b/ports/shader-slang/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "shader-slang",
   "version": "2026.7.1",
+  "port-version": 1,
   "description": "Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs. Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, and Stanford.",
   "homepage": "https://github.com/shader-slang/slang",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9298,7 +9298,7 @@
     },
     "shader-slang": {
       "baseline": "2026.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "shaderc": {
       "baseline": "2026.2",

--- a/versions/s-/shader-slang.json
+++ b/versions/s-/shader-slang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e66d96cd65c5fe7cc82b086f76d0b90275f8cb51",
+      "version": "2026.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "30632b5e40d6e091ee97e68fdf0d256f80cbb105",
       "version": "2026.7.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #51190. Thanks to @dmnq-f for the report and for pinpointing the cause in the `dyn_libs` glob.

On Linux, `tools/shader-slang/` is populated from a `dyn_libs` glob that matched only `lib/*.so` — which in the Linux release archive are symlinks to the versioned `*.so.0.${VERSION}` real files. `file(INSTALL)` preserves symlinks, so the tools directory ended up with four dangling symlinks (`libgfx.so`, `libslang.so`, `libslang-compiler.so`, `libslang-rt.so`). NuGet binary caching then fails to pack the package with `System.IO.FileNotFoundException` on the missing symlink targets.

This mirrors the `*.so.0.${VERSION}` pattern already used by the `libs` glob into the `dyn_libs` glob, so the versioned targets are installed next to the tools and the symlinks resolve. No change on Windows/macOS — the pattern matches nothing in those archives.

Validated on x64-linux:

```console
$ ./vcpkg remove shader-slang
$ ./vcpkg install shader-slang --triplet x64-linux
$ find packages/shader-slang_x64-linux -xtype l
(no output — was 4 dangling symlinks before the fix)
$ ls -la packages/shader-slang_x64-linux/tools/shader-slang
libgfx.so -> libgfx.so.0.2026.7.1
libgfx.so.0.2026.7.1
libslang-compiler.so -> libslang-compiler.so.0.2026.7.1
libslang-compiler.so.0.2026.7.1
libslang-rt.so -> libslang-rt.so.0.2026.7.1
libslang-rt.so.0.2026.7.1
libslang.so -> libslang-compiler.so.0.2026.7.1
... (glslang/glsl-module/llvm libs and the slang/slangc/slangd/slangi tools unchanged)
$ ./vcpkg x-ci-verify-versions ports/shader-slang
$ packages/shader-slang_x64-linux/tools/shader-slang/slangc -v
2026.7.1
```

A binary-cache round-trip with the `files` provider (store → remove → restore) also completes cleanly with zero dangling symlinks in the installed tree.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (n/a — no downloads changed)
- [x] The "supports" clause reflects platforms that may be fixed by this new version. (unchanged)
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (n/a)
- [x] Any patches that are no longer applied are deleted from the port's directory. (n/a)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
