### PR TITLE
[sdbus-cpp] Fix missing libsystemd module name in dependencies.diff

### DIFF
--- a/ports/sdbus-cpp/dependencies.diff
+++ b/ports/sdbus-cpp/dependencies.diff
@@ -17,7 +17,7 @@ index 8730086..0d7c288 100644
  #----------------------------------
  # TESTS
 diff --git a/cmake/sdbus-c++-config.cmake.in b/cmake/sdbus-c++-config.cmake.in
-index 035dc0f..974ef27 100644
+index 035dc0f..bd53402 100644
 --- a/cmake/sdbus-c++-config.cmake.in
 +++ b/cmake/sdbus-c++-config.cmake.in
 @@ -1,4 +1,11 @@
@@ -27,7 +27,7 @@ index 035dc0f..974ef27 100644
 +    include(CMakeFindDependencyMacro)
 +    find_dependency(Threads)
 +    find_dependency(PkgConfig)
-+    pkg_check_modules(Systemd IMPORTED_TARGET)
++    pkg_check_modules(Systemd IMPORTED_TARGET libsystemd)
 +endif()
 +
  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/ports/sdbus-cpp/vcpkg.json
+++ b/ports/sdbus-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdbus-cpp",
   "version": "2.3.1",
+  "port-version": 1,
   "description": "High-level C++ D-Bus library for Linux designed to provide easy-to-use yet powerful API in modern C++",
   "homepage": "https://github.com/Kistler-Group/sdbus-cpp",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9134,7 +9134,7 @@
     },
     "sdbus-cpp": {
       "baseline": "2.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sdflib": {
       "baseline": "2025-11-03",

--- a/versions/s-/sdbus-cpp.json
+++ b/versions/s-/sdbus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "edeecd9025d6b41064e026b5ee55162e2fb1b9b7",
+      "version": "2.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "137372d61f5032a794b0d1c7743af3a9a8766f8b",
       "version": "2.3.1",
       "port-version": 0


### PR DESCRIPTION
`ports/sdbus-cpp/dependencies.diff` patches the installed CMake package config so that consumers of a **static** `sdbus-c++` re-discover its private dependencies. The `pkg_check_modules` call in that patch is missing its module-name argument:

```cmake
if(NOT "@BUILD_SHARED_LIBS@")
    include(CMakeFindDependencyMacro)
    find_dependency(Threads)
    find_dependency(PkgConfig)
    pkg_check_modules(Systemd IMPORTED_TARGET)   # <-- no module name given
endif()
```

`pkg_check_modules(<prefix> [IMPORTED_TARGET] <moduleSpec>...)` treats every remaining argument as a module spec, so with none given it invokes `pkg-config` with an empty package list.

## Consequences

**1. `pkg-config` error spam on every consumer configure.** Each internal probe prints to stderr:

```
-- Checking for modules ''
Please specify at least one package name on the command line.
Please specify at least one package name on the command line.
... (14 times, with pkg-config 1.8.1 / CMake 4.2.1)
```

**2. `-lsystemd` is silently dropped from the consumer link line.** This is the real problem. An empty module list is vacuously satisfied, so `Systemd_FOUND` is set to `1` and an **empty** `PkgConfig::Systemd` imported target is created — with every `Systemd_*` variable blank:

```
Systemd_FOUND:INTERNAL=1
Systemd_MODULE_NAME:INTERNAL=
Systemd_VERSION:INTERNAL=
Systemd_LIBRARIES:INTERNAL=
Systemd_INCLUDE_DIRS:INTERNAL=
Systemd_LDFLAGS:INTERNAL=
__pkg_config_arguments_Systemd:INTERNAL=IMPORTED_TARGET
```

The installed `sdbus-c++-targets.cmake` records `libsystemd` as a private static-link dependency under exactly that target name:

```cmake
set_target_properties(SDBusCpp::sdbus-c++ PROPERTIES
  INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:>;\$<LINK_ONLY:PkgConfig::Systemd>;\$<LINK_ONLY:Threads::Threads>"
)
```

Because that target now exists but carries no usage requirements, the consumer's link line collapses to just the archive:

```
LINK_LIBRARIES = .../lib/libsdbus-c++.a
```

and linking fails with a wall of undefined references:

```
/usr/bin/ld: libsdbus-c++.a(SdBus.cpp.o): in function `sdbus::internal::SdBus::sd_bus_message_set_destination(sd_bus_message*, char const*)':
SdBus.cpp:(.text+0x1aee): undefined reference to `sd_bus_message_set_destination'
/usr/bin/ld: libsdbus-c++.a(SdBus.cpp.o): in function `sdbus::internal::SdBus::sd_bus_creds_ref(sd_bus_creds*)':
SdBus.cpp:(.text+0x1c4f): undefined reference to `sd_bus_creds_ref'
... (many more)
collect2: error: ld returned 1 exit status
```

Note that this fails *quietly*: `find_package(sdbus-c++)` reports success and configure exits `0`. Had the target not been created at all, CMake would at least have raised a hard "links to target ... but the target was not found" error at generate time.

## Fix

Name the module, matching what upstream's own `CMakeLists.txt` already does at configure time ([CMakeLists.txt#L94](https://github.com/Kistler-Group/sdbus-cpp/blob/v2.3.1/CMakeLists.txt#L94)):

```cmake
pkg_check_modules(Systemd IMPORTED_TARGET libsystemd)
```

Two notes for reviewers:

- **Why `PkgConfig::Systemd` is the right target and no alias is needed.** Upstream creates `Systemd::Libsystemd` as an `ALIAS` of `PkgConfig::Systemd`, and the patch's `$<INSTALL_INTERFACE:Systemd::Libsystemd>` uses the alias name. CMake resolves `ALIAS` targets when generating export files, so the *installed* targets file refers to `PkgConfig::Systemd` (see the property dump above) — precisely the target `pkg_check_modules(Systemd IMPORTED_TARGET ...)` creates. Re-creating the alias in the config file is therefore unnecessary.
- **Why hardcoding `libsystemd` is correct here.** Upstream searches `systemd`/`elogind`/`basu` in a loop, but this port pins `-DSDBUSCPP_SDBUS_LIB=systemd` in `portfile.cmake` and declares a `libsystemd` dependency in `vcpkg.json`, so the exported target always originates from the `libsystemd` module. The `libsystemd` port installs `libsystemd.pc` (it carries a `pkgconfig.patch` and calls `vcpkg_fixup_pkgconfig()`), and `FindPkgConfig` picks it up out of the vcpkg installed tree via `CMAKE_PREFIX_PATH`.

I deliberately kept this minimal and did not add upstream's `>=${MINIMUM_SDBUS_VERSION}` floor or its `GLOBAL` keyword — the version was already validated when the port was built. Happy to add either if you'd prefer closer parity with upstream.

## Scope

The patched block is guarded by `if(NOT "@BUILD_SHARED_LIBS@")`, so only **static** linkage is affected; dynamic triplets never execute it. That is most likely why this has gone unreported.

## Verification

Reproduced and fixed on Ubuntu 24.04, GCC 13.3, CMake 4.2.1, pkg-config 1.8.1, system libsystemd 255, by applying the port's `dependencies.diff` to a pristine `v2.3.1` checkout and configuring with the same options `portfile.cmake` passes (`-DBUILD_SHARED_LIBS=OFF -DSDBUSCPP_BUILD_DOCS=OFF -DSDBUSCPP_BUILD_LIBSYSTEMD=OFF -DSDBUSCPP_SDBUS_LIB=systemd`), then building a small consumer against the install tree. (Done directly rather than through a full `vcpkg install`, since the `libsystemd` port builds systemd from source; the failure is entirely at the CMake level.)

| | before | after |
|---|---|---|
| `Please specify at least one package name` | 14 | 0 |
| `Checking for module 'libsystemd'` | — | `Found libsystemd, version 255` |
| consumer `LINK_LIBRARIES` | `libsdbus-c++.a` | `libsdbus-c++.a /usr/lib/x86_64-linux-gnu/libsystemd.so` |
| consumer link | fails, undefined `sd_bus_*` | succeeds |

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. *(no downloads changed)*
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary. *(no change needed)*
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed. *(no entries needed changing)*
- [x] All patch files in the port are applied and succeed. *(verified with `git apply --check` against a pristine `v2.3.1` checkout)*
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.