### PR TITLE
[s2n] Update to 1.7.6

### DIFF
--- a/ports/s2n/portfile.cmake
+++ b/ports/s2n/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aws/s2n-tls
     REF "v${VERSION}"
-    SHA512 38cd44543d961c06939762cdc29ef48df981467e7985bc3072db7b09a957fa85a0bacd1067186ef8bcfe5790aba4554e8e5b6cdc5a78bd932bf65342f3ac5549
+    SHA512 bb9c7d994c3f888641d1e20ce64ee7fc56e435680a48777f5a7c522526faff902b527eb63cca7b01bf1386d7f13154dbc77c449e24a0bcabd1814823c62e934b
     PATCHES
         fix-cmake-target-path.patch
         openssl.patch

--- a/ports/s2n/vcpkg.json
+++ b/ports/s2n/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "s2n",
-  "version": "1.7.3",
+  "version": "1.7.6",
   "description": "C99 implementation of the TLS/SSL protocols.",
   "homepage": "https://github.com/aws/s2n-tls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9049,7 +9049,7 @@
       "port-version": 0
     },
     "s2n": {
-      "baseline": "1.7.3",
+      "baseline": "1.7.6",
       "port-version": 0
     },
     "safeint": {

--- a/versions/s-/s2n.json
+++ b/versions/s-/s2n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c155a5aa4b0450c7334c49b6d4b7f74f40dd39c0",
+      "version": "1.7.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "b3812c1ee08fe304c232b47b020fa03dc5f17193",
       "version": "1.7.3",
       "port-version": 0


### PR DESCRIPTION
Updates the `s2n` port from 1.7.3 to 1.7.6 (latest release, 2026-07-21).

`ports/s2n/portfile.cmake` derives `REF` from `${VERSION}`, so only the version and `SHA512` change.

**Motivation:** 1.7.3 is affected by CVE-2026-16317 (CVSS v4.0 8.3) — missing validation of the outer `content_type` byte on TLS 1.3 encrypted records, which lets an active on-path attacker silently drop individual application-data records. Fixed upstream in v1.7.6. There is currently no version in the registry that carries the fix.

- [x] Changes comply with the maintainer guide
- [x] SHA512s are updated for each updated download
- [x] The `"supports"` clause reflects platforms that may be fixed by this new version
- [x] Any fixed `CMake` targets are updated (n/a — no target changes)
- [x] Any patches that are no longer applied are deleted (n/a — port has no patches)
- [x] The version database is updated (`vcpkg x-add-version s2n`)