### PR TITLE
[directx-headers, directx12-agility] Update for 1.619.5

### DIFF
--- a/ports/directx-headers/portfile.cmake
+++ b/ports/directx-headers/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectX-Headers
     REF v${VERSION}
-    SHA512 21bf2d6e4fdcaa331afb6de20c87ebec59b5bad36c155655acd725fde46faedd4cf1503646857b2a5d02f50fbacd8c55de91a79b2a616b05535704de4fbe777e
+    SHA512 7f7705ddcf95ce1e81fcacfa1dc60288dcaeabbea6538bdd10acdab2a4a944724bb285b4549b4ae5c8f01a8940e2a4e725eb0efb5ccaa9f48483a57c7a0ee239
     HEAD_REF main
 )
 

--- a/ports/directx-headers/vcpkg.json
+++ b/ports/directx-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx-headers",
-  "version": "1.619.4",
+  "version": "1.619.5",
   "description": "Official DirectX 12 Headers",
   "homepage": "https://devblogs.microsoft.com/directx/",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # DX12 SDK Debug Layer i
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 6a275381027ed758714eedf1ccaeea446b1d9afeddc1f6b6bbc3c85939ef9ffd02b7fae780cd50da635b66b09f5fce99535788551cd64e3663b9e59fe6f7d9de
+    SHA512 f7c0a819610066d7cf03d18a4349f51b4f1e9b4f1b3f8ff5f7fbd9490e683471696e6fe50a11f8639efe3247c16ae18799f30bd36096160797dd880a0fceb47f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.619.4",
+  "version": "1.619.5",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2521,11 +2521,11 @@
       "port-version": 0
     },
     "directx-headers": {
-      "baseline": "1.619.4",
+      "baseline": "1.619.5",
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.619.4",
+      "baseline": "1.619.5",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx-headers.json
+++ b/versions/d-/directx-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae5de268690a6a9216cf835574d1da1b5ffacf87",
+      "version": "1.619.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "604aa5530f61c53f4ea0f456d935398f12429c93",
       "version": "1.619.4",
       "port-version": 0

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45f817bf50b8a179a86a396e1182e4fdaf8da33e",
+      "version": "1.619.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6d5764870d5cb3f67025ce4fbca6432f1e47180",
       "version": "1.619.4",
       "port-version": 0


### PR DESCRIPTION
Updates the DirectX-Headers and DirectX 12 Agility SDK ports for the 1.619.5 servicing release.

- `directx-headers` 1.619.5
  - Source: https://github.com/microsoft/DirectX-Headers/releases/tag/v1.619.5
  - Updates the source archive SHA512.
- `directx12-agility` 1.619.5
  - Source: https://www.nuget.org/packages/Microsoft.Direct3D.D3D12/1.619.5
  - Updates the NuGet package SHA512.
- Refreshes the baseline and version database entries for both ports.

Validation:

- `vcpkg x-ci-verify-versions`
- `vcpkg install directx-headers:x64-windows --clean-after-build`
- `vcpkg install directx12-agility:x64-windows --clean-after-build`

Both ports built and installed successfully at version 1.619.5.
