### PR TITLE
[log4cxx] Add version 1.8.0

### DIFF
--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/logging/log4cxx/${VERSION}/apache-log4cxx-${VERSION}.tar.gz"
     FILENAME "apache-log4cxx-${VERSION}.tar.gz"
-    SHA512 0e94946457423689af6d85074ab97b717e0cec85a4f548e6650b060e8f98b780f980b7d4a7780410fa64681376fb4bc62fab6ed9068fc944e07f9f32ac0413af
+    SHA512 2647b930c3d8d3f55b586943d691f0b40ef1c96276a95bbcb72a49db4130d690703d4f755faee2f5835684587a66ab04a0f715d1e4bfb1ae43da466804e7a879
 )
 
 vcpkg_extract_source_archive(

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -21,6 +21,8 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DLOG4CXX_INSTALL_PDB=OFF # Installing pdbs failed on debug static. So, disable it and let vcpkg_copy_pdbs() do it
+        -DLOG4CXX_ENABLE_ESMTP=OFF
+        -DLOG4CXX_ENABLE_ODBC=OFF
         -DBUILD_TESTING=OFF
         -DVCPKG_LOCK_FIND_PACKAGE_fmt=${VCPKG_LOCK_FIND_PACKAGE_fmt}
 )
@@ -43,4 +45,8 @@ ${_contents}"
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/NOTICE"
+)

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "log4cxx",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6233,7 +6233,7 @@
       "port-version": 0
     },
     "log4cxx": {
-      "baseline": "1.7.0",
+      "baseline": "1.8.0",
       "port-version": 0
     },
     "logme": {

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc95e9119e7602153306cb6af4266d517743dd6a",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5cd7c09e1cb7f87e7d8d1b42cf6d2b0848a0b12e",
       "version": "1.7.0",
       "port-version": 0

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cc95e9119e7602153306cb6af4266d517743dd6a",
+      "git-tree": "0074c4c67ceaaaaf1b90c319ed0b2ebdb49311ed",
       "version": "1.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

Changes are listed on [the Log4cxx website](https://logging.apache.org/log4cxx/1.8.0/changelog.html#rel_1_8_0)
