### PR TITLE
[neko-event] Update version to v1.0.2

### DIFF
--- a/ports/neko-event/portfile.cmake
+++ b/ports/neko-event/portfile.cmake
@@ -1,8 +1,8 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hoshimoe/NekoEvent
-    REF v1.0.1
-    SHA512 2c9579def648a0feaaf0763d11801b70260d8f56bd477fcafc9d45cb7c2c5c8ab365f77c925aad46a75aa85c5c0730efee9ace0b6a5f3025a3166a776908a8e7
+    REF v1.0.2
+    SHA512 65dc87a7ca3c3b1b4ae7d5ef04342dc7c314784a8a3ccdb08fac7def8fbf2c9ef7ec8c44148e5bf9060e84356d3545a58a501067ee7ff0572320483dc8c4ed5c
     HEAD_REF main
 )
 

--- a/ports/neko-event/vcpkg.json
+++ b/ports/neko-event/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "neko-event",
-  "version": "1.0.1",
-  "port-version": 1,
+  "version": "1.0.2",
   "description": "A modern easy to use type-safe and high-performance event handling system for C++ ",
   "homepage": "https://github.com/hoshimoe/NekoEvent",
   "license": "MIT OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7021,8 +7021,8 @@
       "port-version": 0
     },
     "neko-event": {
-      "baseline": "1.0.1",
-      "port-version": 1
+      "baseline": "1.0.2",
+      "port-version": 0
     },
     "neko-function": {
       "baseline": "1.0.11",

--- a/versions/n-/neko-event.json
+++ b/versions/n-/neko-event.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fca9c35d5bf462de73361b332242bfae6ae5961",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0764ebfa469ab6dc87156f4430ea846e99f974a8",
       "version": "1.0.1",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
