### PR TITLE
[neko-network] Update version to v1.0.4

### DIFF
--- a/ports/neko-network/portfile.cmake
+++ b/ports/neko-network/portfile.cmake
@@ -1,8 +1,8 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hoshimoe/NekoNetwork
-    REF v1.0.3
-    SHA512 394bcd82743c25c1954dcce6699bc0c13a2ac8f00b06d082659aface2d6efeccb736feaa5c94a4eef2789194f2d7adefae0c476bf27866547be48602c90226b5
+    REF v1.0.4
+    SHA512 522523dbdfc189064c2abfc5cbe7aeadbf29abdd259169a6269bc06f1d31caa85e87b6f6eb4b2f95866c4a0ded03e0bbb0872d14fbef4cddda04119d6b21b2d1
     HEAD_REF main
 )
 

--- a/ports/neko-network/vcpkg.json
+++ b/ports/neko-network/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "neko-network",
-  "version": "1.0.3",
-  "port-version": 1,
+  "version": "1.0.4",
   "description": "Neko Network is a modern, easy-to-use, and efficient C++20 network library built on top of libcurl.",
   "homepage": "https://github.com/hoshimoe/NekoNetwork",
   "license": "MIT OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7033,8 +7033,8 @@
       "port-version": 1
     },
     "neko-network": {
-      "baseline": "1.0.3",
-      "port-version": 1
+      "baseline": "1.0.4",
+      "port-version": 0
     },
     "neko-schema": {
       "baseline": "1.1.5",

--- a/versions/n-/neko-network.json
+++ b/versions/n-/neko-network.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "902de892c3aa065ee87e3440fecf372fbc59ea7a",
+      "version": "1.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "fced68a170ea70f6ed76d68fb4655f583f2d26e3",
       "version": "1.0.3",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.