### PR TITLE
[behaviortree-cpp] Update to 4.10.0

### DIFF
--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BehaviorTree/BehaviorTree.CPP
     REF "${VERSION}"
-    SHA512 23ac30d7824282f641372f709b6b7a800a2947113bbb09d599f68547a3a67f509992cd0ca251e86b101062fe0d6697373b6851d21e7648578aadf1aa924e7ccf
+    SHA512 1c76440baa562ddae8d63e2c2ea0d2ebdd7863771486c6729e6c646928659feeb551a7d0cd6483d93e96f5d8f2a3f29e59a102e9dbb97406b4e90317dd804c2b
     HEAD_REF master
     PATCHES
         remove-source-charset.diff # because vcpkg's default toolchain uses /utf-8 which is incompatible with /source-charset

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "license": null,

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20fe3189af122ba6e459ac42e8d70f851463073f",
+      "version": "4.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7937cd10b44475db72ed206e2c8a09e3cf7d96d9",
       "version": "4.9.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -673,7 +673,7 @@
       "port-version": 0
     },
     "behaviortree-cpp": {
-      "baseline": "4.9.1",
+      "baseline": "4.10.0",
       "port-version": 0
     },
     "benchmark": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.