### PR TITLE
[aws-c-common] Update to 0.14.4

### DIFF
--- a/ports/aws-c-common/portfile.cmake
+++ b/ports/aws-c-common/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-common
     REF "v${VERSION}"
-    SHA512 175b956b555db0ec52ab2421dd1821a75feb1b2e150b19add6b72da44e08b39911215b51225c2bbc37c1d61eabc5b093d08c7020bb758951dc452555c400fd41
+    SHA512 174997adfec0d20b4925bd941964d5c035f4ebce270f6b91f952c4eae80b74398c65d90889a179919f2c769419a6622247cc3f2a57e05bf6696e4c04b39e31a5
     HEAD_REF master
     PATCHES
         disable-internal-crt-option.patch # Disable internal crt option because vcpkg contains crt processing flow

--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-common",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT",

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddffc049f84afb8783e3fc3da028e20171b7719b",
+      "version": "0.14.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "0cb946479f1948c7abf6670ee096a85badea21e5",
       "version": "0.14.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -465,7 +465,7 @@
       "port-version": 0
     },
     "aws-c-common": {
-      "baseline": "0.14.3",
+      "baseline": "0.14.4",
       "port-version": 0
     },
     "aws-c-compression": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.