### PR TITLE
[patternia] update to 0.9.4

### DIFF
--- a/ports/patternia/portfile.cmake
+++ b/ports/patternia/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO sentomk/patternia
-  REF 0cd3b1111a10d0160001b3be384fb008eee7278f # url of v0.9.4 returns 300, so use the commit hash instead
-  SHA512 2dcef8489db10d2cad5989f809acd6442c0f7b14d07cf12cf87478acb778f2bf72d25970f0e143f52a6e5134c4f7727f70ac8e1456ba2a11c5c42001ff1da770
+  REF "v${VERSION}"
+  SHA512 4d65b63c456f9dca5798194f2771b3b3481ab30469aeddb1fdc28ff47ad2790b9f6d2c4b52261ea36352070c3f6f73e19f84c1c3e5724dbd845886201b650a61
   HEAD_REF main
 )
 

--- a/ports/patternia/portfile.cmake
+++ b/ports/patternia/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO sentomk/patternia
-  REF ae21772a77caffc7dbe4734030cf46c518416e2e # url of v0.9.3 returns 300, so use the commit hash instead
-  SHA512 2edf6a0f2f34d33777772355fdc5087145f98b5f00f238f1cadb57c380a6a7adb3b46874dde91203193d9afae65b610d1757f1eaace2970cde523ca095d82787
+  REF 0cd3b1111a10d0160001b3be384fb008eee7278f # url of v0.9.4 returns 300, so use the commit hash instead
+  SHA512 2dcef8489db10d2cad5989f809acd6442c0f7b14d07cf12cf87478acb778f2bf72d25970f0e143f52a6e5134c4f7727f70ac8e1456ba2a11c5c42001ff1da770
   HEAD_REF main
 )
 

--- a/ports/patternia/vcpkg.json
+++ b/ports/patternia/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "patternia",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Header-only pattern matching library for modern C++",
   "homepage": "https://github.com/sentomk/patternia",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7709,7 +7709,7 @@
       "port-version": 0
     },
     "patternia": {
-      "baseline": "0.9.3",
+      "baseline": "0.9.4",
       "port-version": 0
     },
     "pbc": {

--- a/versions/p-/patternia.json
+++ b/versions/p-/patternia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e67c3e1762caaf44c53c425537d1a9d50f59f9a",
+      "git-tree": "53df39cb080c68e38574bcd7c53cf1abe9a839ab",
       "version": "0.9.4",
       "port-version": 0
     },

--- a/versions/p-/patternia.json
+++ b/versions/p-/patternia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e67c3e1762caaf44c53c425537d1a9d50f59f9a",
+      "version": "0.9.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d0536df85c4fe9d6b7cf5a9975986d57c2a9edb",
       "version": "0.9.3",
       "port-version": 0


### PR DESCRIPTION
Updates patternia to 0.9.4.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be built.
- [x] The version database is updated (`vcpkg x-add-version patternia`).
- [x] Only one version is added in this PR.

Release notes: https://github.com/sentomk/patternia/releases/tag/v0.9.4

v0.9.4 introduces `PTN_BIND` member-anchored named guard placeholders, unified guard placeholder syntax, and combinator operator sugar. Header-only port; no build-system changes. Tested locally: `vcpkg install patternia` on x64-windows succeeds with the updated REF/SHA512.