### PR TITLE
[simdjson] update to 4.6.5

### DIFF
--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 003b96daab30ccaefdac60a9676cf623af5a8662016f988fc0ecaa2f36d8b48ba97f2431e6498dd16fc2b1d841798b2d06dabb0b7487efd4520c0de260e49056
+    SHA512 b4e47e0fbb3e9dc30d2b404fba2436f35542ef4511690ec6c051c8c493a94fec3fd8e1be15c410642633221e9969cf29bf812bd1f0d960206c36ba89a2dc07c7
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 b4e47e0fbb3e9dc30d2b404fba2436f35542ef4511690ec6c051c8c493a94fec3fd8e1be15c410642633221e9969cf29bf812bd1f0d960206c36ba89a2dc07c7
+    SHA512 47c99bca59b8d6ae31cba57b42d6260d5b314131b6e7b1d5d8c1585ec3753094706737f1905cf4c1368fba08f88d492a54f9d72f52ce39704a81f73efee6e921
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0 OR MIT",

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9369,7 +9369,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "4.6.5",
+      "baseline": "4.6.6",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9369,7 +9369,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "4.6.4",
+      "baseline": "4.6.5",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2dfa6289a462604a3f8288b27bf451d325ce243",
+      "version": "4.6.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "6b3d794faec926fbb2f748cac3f805c17bc820f2",
       "version": "4.6.5",
       "port-version": 0

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b3d794faec926fbb2f748cac3f805c17bc820f2",
+      "version": "4.6.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "35ff70b88182d7816583f981a54cb54d761eef28",
       "version": "4.6.4",
       "port-version": 0

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "6b3d794faec926fbb2f748cac3f805c17bc820f2",
-      "version": "4.6.5",
-      "port-version": 0
-    },
-    {
       "git-tree": "35ff70b88182d7816583f981a54cb54d761eef28",
       "version": "4.6.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/simdjson/simdjson/releases/tag/v4.6.6
