### PR TITLE
[x265] Update to 4.3

### DIFF
--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -42,6 +42,7 @@ vcpkg_cmake_configure(
         -DENABLE_SHARED=${ENABLE_SHARED}
         -DENABLE_PIC=ON
         -DENABLE_LIBNUMA=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_VLD=ON
         "-DVERSION=${VERSION}"
     OPTIONS_DEBUG
         -DENABLE_CLI=OFF

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -1,8 +1,8 @@
-vcpkg_from_bitbucket(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO multicoreware/x265_git
+    REPO Multicorewareinc/x265
     REF "${VERSION}"
-    SHA512 53fe7b3a1c9f10bfad33f3d794b9ace87973993a5ebfabb2021b2679b1c9c44a0da9d33e9b75347571a14e6bb8224ed55d619d93c9d106d1637dcd28f99a3895
+    SHA512 270d0db180ecebfc5c2f1fe6451be66042fab69273d073428f4af00420fa0f8b792ecdc71ec1a15ee2860e3b6a325c56295143f117e94fa3616f0ccecb2ded75
     HEAD_REF master
     PATCHES
         disable-install-pdb.patch

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "x265",
-  "version": "4.2",
+  "version": "4.3",
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
-  "homepage": "https://bitbucket.org/multicoreware/x265_git/",
+  "homepage": "https://x265.org",
   "license": "GPL-2.0-or-later",
   "supports": "!uwp & !xbox",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11097,7 +11097,7 @@
       "port-version": 2
     },
     "x265": {
-      "baseline": "4.2",
+      "baseline": "4.3",
       "port-version": 0
     },
     "x509cert-banned": {

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d69fb10a09f7b8fc8319377b6e1e2af7c9bfea52",
+      "version": "4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa6e1678926d1d36746150d1c4a6174d6c63956c",
       "version": "4.2",
       "port-version": 0

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d69fb10a09f7b8fc8319377b6e1e2af7c9bfea52",
+      "git-tree": "40433737b9204526edc35ae39d337131b3180251",
       "version": "4.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: They migrated from Bitbucket to GitHub