### PR TITLE
[sail] Bump to 1.1.0

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 63ad4ee0cee6d5511e069f2203947c6ae0e9c0b64b3423d1f03f50f059b768d62fe658ae4631c1b7a3fdeb375f26f22ed5439ee30a480c5c3ccf2357a717ac6d
+    SHA512 34adaf10d8a4b69740acc6ac9db9564483cbe6e3226a2adec3692b0b8432aa086a5158bae1eafd1a621f1566f462eb1352bc323672f93eacb8d26ee2f03052d4
     HEAD_REF master
     PATCHES
         fix-always-nanosvg.diff

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "1.0.3",
+  "version-semver": "1.1.0",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9061,7 +9061,7 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "1.0.3",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "sajson": {

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43b4065d889d90c199278f32f4d1ebc0f08d9b2d",
+      "version-semver": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f40b6a8cd312e6e8e98ae334aa6b8908e1eeb3d",
       "version-semver": "1.0.3",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
