### PR TITLE
[gumbo] update Codeberg archive SHA512 (port-version 1)

### DIFF
--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -3,7 +3,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://codeberg.org/gumbo-parser/gumbo-parser/archive/${VERSION}.tar.gz"
     FILENAME "gumbo-${VERSION}.tar.gz"
-    SHA512  1513e88acfc3240081039b30ab63ca6fc23a85b7d1415cb8e90e9c43f9c3d99d37634a7a50d81ef7f6d43a4facac3802feea6959256a2330b26b16523a288568
+    # Codeberg re-packs the same tag without changing the version string; refresh
+    # the hash when download fails with "hash mismatch" (observed 2026-08-02).
+    SHA512 9f59965e68ba2e4f5884d52c4126b62cdbefee158816334e317a0d07f10ba927be653490c69fc5b0f52eed1decf0a51715bb726aa84546a2d04cde5805e4a399
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gumbo",
   "version": "0.13.2",
+  "port-version": 1,
   "description": "An HTML5 parsing library in pure C99",
   "homepage": "https://codeberg.org/gumbo-parser/gumbo-parser",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3678,7 +3678,7 @@
     },
     "gumbo": {
       "baseline": "0.13.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-cmake": {
       "baseline": "4.2.1",

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b7030795a1f65570f41612dcbfae98b91224149",
+      "version": "0.13.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf622a1d3b7ad98e86a99b371f3b693a5cce272c",
       "version": "0.13.2",
       "port-version": 0


### PR DESCRIPTION
## Description
Codeberg re-packs tagged source archives without changing the version string. The live `0.13.2` tarball no longer matches the SHA512 recorded in the port, so `vcpkg_download_distfile` fails with a hash mismatch.

Refresh SHA512 from the live archive (verified 2026-08-02) and bump `port-version` to 1.

## Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512 verified by installing `gumbo:x64-windows` successfully with the new hash
- [x] Version database updated (`versions/g-/gumbo.json`, baseline `port-version`)

## Tested
```
vcpkg install gumbo:x64-windows
# Successfully downloaded gumbo-0.13.2.tar.gz
# All requested installations completed successfully
```