### PR TITLE
[libjuice] Set SOVERSION on shared library target

### DIFF
--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         dependencies.diff
+        soversion.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libjuice/soversion.diff
+++ b/ports/libjuice/soversion.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3b020a9..1f1dd5c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -97,7 +97,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads REQUIRED)
+ 
+ add_library(juice ${LIBJUICE_SOURCES})
+-set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION})
++set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+ target_include_directories(juice PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+     $<INSTALL_INTERFACE:include>)

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 1,
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
-  "license": "LGPL-2.1-only",
+  "license": "MPL-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libjuice",
   "version": "1.7.2",
+  "port-version": 1,
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5234,7 +5234,7 @@
     },
     "libjuice": {
       "baseline": "1.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libjxl": {
       "baseline": "0.11.2",

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a1874c615ce1eb77f2426249fdf66c9093286df",
+      "version": "1.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "82db1377df8a430ee955ff2994c29bd342da2f1b",
       "version": "1.7.2",
       "port-version": 0

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2a1874c615ce1eb77f2426249fdf66c9093286df",
+      "git-tree": "59feec3870fce9408e58b9f5a5c51bbb95b00a22",
       "version": "1.7.2",
       "port-version": 1
     },


### PR DESCRIPTION
libjuice's CMake sets `VERSION` but not `SOVERSION` on the shared target, so the soname/install_name is derived from the full version (`libjuice.so.1.7.2`, `@rpath/libjuice.1.7.2.dylib`) and no major-version symlink is produced. Dependents such as libdatachannel then link the full-version name, which changes on every patch release. This patch sets `SOVERSION` to the major version so the library advertises `libjuice.so.1` / `@rpath/libjuice.1.dylib`.

Submitted upstream: https://github.com/paullouisageneau/libjuice/pull/349

- [x] `port-version` bumped (`1.7.2#1`), `x-add-version` run
- [x] Patch accompanied by the upstream PR linked above
