### PR TITLE
[openjph] update to 0.31.0

### DIFF
--- a/ports/openjph/fix-pkgconfig-library-name.patch
+++ b/ports/openjph/fix-pkgconfig-library-name.patch
@@ -1,0 +1,34 @@
+diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
+index f6eb01b..25b23c8 100644
+--- a/src/core/CMakeLists.txt
++++ b/src/core/CMakeLists.txt
+@@ -192,6 +192,18 @@ else()
+       VERSION "${OPENJPH_VERSION}")
+ endif()
+ 
++if(CMAKE_BUILD_TYPE STREQUAL "Debug")
++  set(OJPH_PKG_CONFIG_DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
++else()
++  set(OJPH_PKG_CONFIG_DEBUG_POSTFIX "")
++endif()
++
++if(MSVC)
++  set(OJPH_PKG_CONFIG_LIB_NAME "${OJPH_LIB_NAME_STRING}${OJPH_PKG_CONFIG_DEBUG_POSTFIX}" PARENT_SCOPE)
++else()
++  set(OJPH_PKG_CONFIG_LIB_NAME "openjph${OJPH_PKG_CONFIG_DEBUG_POSTFIX}" PARENT_SCOPE)
++endif()
++
+ install(TARGETS openjph
+   EXPORT openjph-targets
+ )
+diff --git a/src/openjph.pc.in b/src/openjph.pc.in
+index 94ea3ab..06d8c2f 100644
+--- a/src/openjph.pc.in
++++ b/src/openjph.pc.in
+@@ -6,5 +6,5 @@ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@
+ Version: @PROJECT_VERSION@
+ Requires: @PKG_CONFIG_REQUIRES@
+-Libs: -L${libdir} -lopenjph
++Libs: -L${libdir} -l@OJPH_PKG_CONFIG_LIB_NAME@
+ Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64

--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         xsi-strerror_r.patch
+        fix-pkgconfig-library-name.patch
 )
 
 vcpkg_check_features(
@@ -28,17 +29,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/openjph)
-
-# OpenJPH sets CMAKE_DEBUG_POSTFIX ("d" for MSVC, "_d" for others) but the
-# generated .pc file always references -lopenjph. Fix the debug .pc to match
-# the actual library name on disk.
-if(NOT VCPKG_BUILD_TYPE)
-    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/openjph.pc" "-lopenjph" "-lopenjphd")
-    else()
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/openjph.pc" "-lopenjph" "-lopenjph_d")
-    endif()
-endif()
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aous72/OpenJPH
     REF "${VERSION}"
-    SHA512 3c572a21eb57861ef7621d020aea08b4e50ee2feb432f26ccada2978a89e2c10813025e2f1a219474bdd56b2ca846760bc6b0c0c538f5fc5d8bf79425bafe542
+    SHA512 2dfafe3db360ac177014c4b65ea0b62ea14ccf61714d80dbaa0c01ab2dbc2153f6d26df3d7af5e6b74e298eb72670a7670fca626a37d2fe7e4c224a3256af35a
     HEAD_REF master
     PATCHES
         xsi-strerror_r.patch

--- a/ports/openjph/vcpkg.json
+++ b/ports/openjph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openjph",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Open-source implementation of JPEG2000 Part-15 (or JPH or HTJ2K)",
   "homepage": "https://github.com/aous72/OpenJPH",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7473,7 +7473,7 @@
       "port-version": 0
     },
     "openjph": {
-      "baseline": "0.30.1",
+      "baseline": "0.31.0",
       "port-version": 0
     },
     "openldap": {

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b8dc1ec7a801f4aa12f67befd24b99963d16bf2b",
+      "git-tree": "ad25bd553f9d4644ed6a978f8a6fc5d6387a923b",
       "version": "0.31.0",
       "port-version": 0
     },

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8dc1ec7a801f4aa12f67befd24b99963d16bf2b",
+      "version": "0.31.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "34500e97bf648674133fa7055a0dbf4ae23592a9",
       "version": "0.30.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/aous72/OpenJPH/releases/tag/0.31.0
