### PR TITLE
[yara] Update to 4.5.8

### DIFF
--- a/ports/yara/CMakeLists.txt
+++ b/ports/yara/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(yara C)
 
 if(MSVC)

--- a/ports/yara/CMakeLists.txt
+++ b/ports/yara/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 
 
 find_package(OpenSSL REQUIRED)
-
 include_directories(
   .
   libyara
@@ -179,5 +178,9 @@ if(NOT DISABLE_INSTALL_TOOLS)
 endif()
 
 if(NOT DISABLE_INSTALL_HEADERS)
-  install(DIRECTORY libyara/include/ DESTINATION include)
+  install(
+    DIRECTORY libyara/include/
+    DESTINATION include
+    PATTERN "tlshc" EXCLUDE
+  )
 endif()

--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO VirusTotal/yara
   REF "v${VERSION}"
-  SHA512 e71d6e435cb2ad7b5875ccabcfe3abe42e2f37187a22e778867c5c5762134961369c2cbd4bea8da9193d5381af4569e39a50156d4077dc3a23b9a2240b741b60
+  SHA512 12bbe1bebb6d51f7ae90ad6a725bdb096f3e884b757913e9ba37bfa1557bced32ef56895eb358af5f3165890336be57dc51e9fe2ad672c1e523cb30e00483c86
   HEAD_REF master
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.

--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -31,5 +31,18 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-libyara)
 
-# Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+set(
+    copyright_files
+    "${SOURCE_PATH}/COPYING"
+    "${SOURCE_PATH}/libyara/modules/pe/authenticode-parser/authenticode.c"
+)
+if("dotnet" IN_LIST FEATURES)
+    vcpkg_install_copyright(
+        FILE_LIST
+            ${copyright_files}
+            "${SOURCE_PATH}/libyara/modules/dotnet/dotnet.c"
+        COMMENT "The .NET module is licensed under Apache-2.0; see https://www.apache.org/licenses/LICENSE-2.0."
+    )
+else()
+    vcpkg_install_copyright(FILE_LIST ${copyright_files})
+endif()

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.5.8",
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
-  "license": "BSD-3-Clause",
+  "license": "BSD-3-Clause AND MIT",
   "supports": "!uwp",
   "dependencies": [
     "openssl",
@@ -24,7 +24,8 @@
       ]
     },
     "dotnet": {
-      "description": "The dotnet module allows you to create more fine-grained rules for .NET files by using attributes and features of the .NET file format."
+      "description": "The dotnet module allows you to create more fine-grained rules for .NET files by using attributes and features of the .NET file format.",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yara",
-  "version": "4.5.5",
+  "version": "4.5.8",
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11261,7 +11261,7 @@
       "port-version": 0
     },
     "yara": {
-      "baseline": "4.5.5",
+      "baseline": "4.5.8",
       "port-version": 0
     },
     "yas": {

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e84b7ace8cb8bdacfe2fb5913536dcc28375d2d1",
+      "version": "4.5.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "51f25fc5e840d01388514f0476dfa508a5ed7124",
       "version": "4.5.5",
       "port-version": 0

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e84b7ace8cb8bdacfe2fb5913536dcc28375d2d1",
+      "git-tree": "6e8a08aa1d414b015412001e8166a66c25a04987",
       "version": "4.5.8",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.