### PR TITLE
[sdl3] Update to version 3.4.14

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -8,12 +8,6 @@ vcpkg_from_github(
         fix-freebsd.patch
 )
 
-vcpkg_download_distfile(APACHE_2_LICENSE
-    URLS "https://www.apache.org/licenses/LICENSE-2.0.txt"
-    FILENAME "apache-license-2.0.txt"
-    SHA512 98f6b79b778f7b0a15415bd750c3a8a097d650511cb4ec8115188e115c47053fe700f578895c097051c9bc3dfb6197c2b13a15de203273e1a3218884f86e90e8
-)
-
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
@@ -120,5 +114,5 @@ vcpkg_install_copyright(
         "${SOURCE_PATH}/src/video/yuv2rgb/LICENSE"
         "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2.h"
         "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2platform.h"
-        "${APACHE_2_LICENSE}"
+    COMMENT "SDL_opengles2_gl2platform.h is licensed under Apache-2.0; see https://www.apache.org/licenses/LICENSE-2.0."
 )

--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -8,6 +8,12 @@ vcpkg_from_github(
         fix-freebsd.patch
 )
 
+vcpkg_download_distfile(APACHE_2_LICENSE
+    URLS "https://www.apache.org/licenses/LICENSE-2.0.txt"
+    FILENAME "apache-license-2.0.txt"
+    SHA512 98f6b79b778f7b0a15415bd750c3a8a097d650511cb4ec8115188e115c47053fe700f578895c097051c9bc3dfb6197c2b13a15de203273e1a3218884f86e90e8
+)
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
@@ -114,4 +120,5 @@ vcpkg_install_copyright(
         "${SOURCE_PATH}/src/video/yuv2rgb/LICENSE"
         "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2.h"
         "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2platform.h"
+        "${APACHE_2_LICENSE}"
 )

--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -72,11 +72,21 @@ vcpkg_cmake_configure(
         -DSDL_LIBURING=OFF
         -DSDL_PIPEWIRE=OFF
         -DSDL_PULSEAUDIO=OFF
+        -DSDL_ROCKCHIP=OFF
+        -DSDL_RPI=OFF
         -DSDL_SNDIO=OFF
         -DSDL_WAYLAND_LIBDECOR=OFF
         -DSDL_TEST_LIBRARY=OFF
         -DSDL_TESTS=OFF
+        -DSDL_X11_XCURSOR=OFF
+        -DSDL_X11_XDBE=OFF
+        -DSDL_X11_XFIXES=OFF
+        -DSDL_X11_XINPUT=OFF
+        -DSDL_X11_XRANDR=OFF
+        -DSDL_X11_XSHAPE=OFF
         -DSDL_X11_XSCRNSAVER=OFF
+        -DSDL_X11_XSYNC=OFF
+        -DSDL_X11_XTEST=OFF
         -DSDL_INSTALL_CMAKEDIR_ROOT=share/${PORT}
         # Specifying the revision skips the need to use git to determine a version
         -DSDL_REVISION=vcpkg
@@ -99,6 +109,9 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_D
 vcpkg_install_copyright(
     FILE_LIST
         "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/src/hidapi/LICENSE-bsd.txt"
+        "${SOURCE_PATH}/src/video/stb_image.h"
         "${SOURCE_PATH}/src/video/yuv2rgb/LICENSE"
-    COMMENT "Some configurations may use code licensed under the MIT and Apache-2.0 licenses."
+        "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2.h"
+        "${SOURCE_PATH}/include/SDL3/SDL_opengles2_gl2platform.h"
 )

--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
     REF "release-${VERSION}"
-    SHA512 fc0a55ca01c32f613b9cd8c6cffad17ee0855ee542f03fa455632043c99a0a259599557a46c7c636032444260e64476867d9af43a1da689837f99c22942cd863
+    SHA512 6e6f91cde7dffec527af8a9b0162e9fb7997ec2b6770d3002c662cd75e5cd01afd2fb5f5cadfa2496c86e67ed22e876d99ebdf60b9ea7431a3a3caf5686d0f8f
     HEAD_REF main
     PATCHES
         fix-freebsd.patch

--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -63,6 +63,17 @@ vcpkg_cmake_configure(
         -DSDL_SHARED=${SDL_SHARED}
         -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DSDL_LIBC=ON
+        # Prevent host-installed Unix libraries from silently changing SDL's capabilities.
+        -DSDL_FRIBIDI=OFF
+        -DSDL_JACK=OFF
+        -DSDL_KMSDRM=OFF
+        -DSDL_LIBTHAI=OFF
+        -DSDL_LIBUDEV=OFF
+        -DSDL_LIBURING=OFF
+        -DSDL_PIPEWIRE=OFF
+        -DSDL_PULSEAUDIO=OFF
+        -DSDL_SNDIO=OFF
+        -DSDL_WAYLAND_LIBDECOR=OFF
         -DSDL_TEST_LIBRARY=OFF
         -DSDL_TESTS=OFF
         -DSDL_X11_XSCRNSAVER=OFF
@@ -85,6 +96,9 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt"
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/src/video/yuv2rgb/LICENSE"
     COMMENT "Some configurations may use code licensed under the MIT and Apache-2.0 licenses."
 )

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3",
-  "version": "3.4.12",
+  "version": "3.4.14",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0",

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.4.14",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
-  "license": "Zlib AND MIT AND Apache-2.0",
+  "license": "Zlib AND MIT AND Apache-2.0 AND BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9189,7 +9189,7 @@
       "port-version": 0
     },
     "sdl3": {
-      "baseline": "3.4.12",
+      "baseline": "3.4.14",
       "port-version": 0
     },
     "sdl3-image": {

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9688f9d27a5a5c0a1e3cfcc1dab6db4a238cef14",
+      "git-tree": "4bfe77f2b6125d39b3060199aa88de88c1c620be",
       "version": "3.4.14",
       "port-version": 0
     },

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e1a88561046e086d40223d6c317a94303b710fa",
+      "git-tree": "9688f9d27a5a5c0a1e3cfcc1dab6db4a238cef14",
       "version": "3.4.14",
       "port-version": 0
     },

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bfe77f2b6125d39b3060199aa88de88c1c620be",
+      "git-tree": "60d73b127885c8a9fdd1055996490cbfb9b2be18",
       "version": "3.4.14",
       "port-version": 0
     },

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "604588f5e400ef704dd40e6854192f13c2ab9758",
+      "version": "3.4.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "472bce2f9b7f539cf1be0e021e3f389e56f2a300",
       "version": "3.4.12",
       "port-version": 0

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "604588f5e400ef704dd40e6854192f13c2ab9758",
+      "git-tree": "5e1a88561046e086d40223d6c317a94303b710fa",
       "version": "3.4.14",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.