### PR TITLE
[opus] update to 1.6.1

### DIFF
--- a/ports/opus/fix-arm64-windows-compile.diff
+++ b/ports/opus/fix-arm64-windows-compile.diff
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -563,7 +563,9 @@
+         target_compile_definitions(opus PRIVATE OPUS_HAVE_RTCD)
+         add_sources_group(opus celt ${celt_sources_arm_rtcd})
+         add_sources_group(opus silk ${silk_sources_arm_rtcd})
+-        add_sources_group(opus lpcnet ${dnn_sources_arm_rtcd})
++        if (OPUS_DNN)
++          add_sources_group(opus lpcnet ${dnn_sources_arm_rtcd})
++        endif()
+       else()
+         message(ERROR "Runtime cpu capability detection needed for MAY_HAVE_NEON")
+       endif()

--- a/ports/opus/portfile.cmake
+++ b/ports/opus/portfile.cmake
@@ -2,9 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiph/opus
     REF "v${VERSION}"
-    SHA512 4ffefd9c035671024f9720c5129bfe395dea04f0d6b730041c2804e89b1db6e4d19633ad1ae58855afc355034233537361e707f26dc53adac916554830038fab
+    SHA512 b9a504f8576c977df57caee808412ab95e7424e9a64e3dd4045f05616c3ed58706bc3549195b61e25721e299547509d15206d246d96f1a307b82562b703b412c
     HEAD_REF main
-    PATCHES fix-pkgconfig-version.patch
+    PATCHES
+        fix-pkgconfig-version.patch
+        fix-arm64-windows-compile.diff # https://github.com/xiph/opus/pull/471
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/opus/vcpkg.json
+++ b/ports/opus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "opus",
-  "version": "1.5.2",
-  "port-version": 1,
+  "version": "1.6.1",
   "description": "Totally open, royalty-free, highly versatile audio codec",
   "homepage": "https://github.com/xiph/opus",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7577,8 +7577,8 @@
       "port-version": 0
     },
     "opus": {
-      "baseline": "1.5.2",
-      "port-version": 1
+      "baseline": "1.6.1",
+      "port-version": 0
     },
     "opusfile": {
       "baseline": "0.12+20221121",

--- a/versions/o-/opus.json
+++ b/versions/o-/opus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63d615e768adfa3b03dc58d1f1fe3712b90de5f6",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2235818841e936376b19642c7a94fc7f17b2c2c2",
       "version": "1.5.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #49593.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
