### PR TITLE
[gif-load]: add new port

### DIFF
--- a/ports/gif-load/portfile.cmake
+++ b/ports/gif-load/portfile.cmake
@@ -10,26 +10,4 @@ file(INSTALL "${SOURCE_PATH}/gif_load.h" DESTINATION "${CURRENT_PACKAGES_DIR}/in
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-gif-load-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-gif-load")
 
-file(WRITE "${SOURCE_PATH}/UNLICENSE" [[This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-]])
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/UNLICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/gif_load.h")

--- a/ports/gif-load/portfile.cmake
+++ b/ports/gif-load/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hidefromkgb/gif_load
+    REF 74b674de2704bc1b20fc3bf482a5ee3e774b67c5
+    SHA512 f58b02ad62c0898865bb0c933711f52eb203c3e49b832847613a1de32330192636ddd31aacba2cefe7a7acde7c9be3c5edeea262b905b9a49bf05f4bbafddc21
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/gif_load.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-gif-load-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-gif-load")
+
+file(WRITE "${SOURCE_PATH}/UNLICENSE" [[This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+]])
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/UNLICENSE")

--- a/ports/gif-load/unofficial-gif-load-config.cmake
+++ b/ports/gif-load/unofficial-gif-load-config.cmake
@@ -1,0 +1,5 @@
+if(NOT TARGET unofficial::gif-load::gif-load)
+    add_library(unofficial::gif-load::gif-load INTERFACE IMPORTED)
+    set_target_properties(unofficial::gif-load::gif-load PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include")
+endif()

--- a/ports/gif-load/vcpkg.json
+++ b/ports/gif-load/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "gif-load",
+  "version-date": "2019-01-06",
+  "description": "A slim, fast and header-only GIF loader written in C",
+  "homepage": "https://github.com/hidefromkgb/gif_load",
+  "license": "Unlicense"
+}

--- a/scripts/test_ports/vcpkg-ci-gif-load/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-gif-load/portfile.cmake
@@ -1,0 +1,5 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-gif-load/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-gif-load/project/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.22)
+project(gif-load-test LANGUAGES C)
+find_package(unofficial-gif-load CONFIG REQUIRED)
+add_executable(main main.c)
+target_link_libraries(main PRIVATE unofficial::gif-load::gif-load)

--- a/scripts/test_ports/vcpkg-ci-gif-load/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-gif-load/project/main.c
@@ -1,13 +1,15 @@
 #include <gif_load.h>
+#include <stdbool.h>
 
 static const unsigned char gif_data[] = { 0x47 };
 static void frame_writer(void *anim, struct GIF_WHDR *whdr)
 {
-    (void)anim; (void)whdr;
+    (void)anim;
+    (void)whdr;
 }
 
 int main(void)
 {
-    bool success = GIF_Load((void *)gif_data, (long)sizeof(gif_data), frame_writer, 0, 0, 0) == 1 ? 0 : 1;
+    const bool success = GIF_Load((void *)gif_data, (long)sizeof(gif_data), frame_writer, 0, 0, 0) == 1;
     return 0;
 }

--- a/scripts/test_ports/vcpkg-ci-gif-load/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-gif-load/project/main.c
@@ -1,0 +1,13 @@
+#include <gif_load.h>
+
+static const unsigned char gif_data[] = { 0x47 };
+static void frame_writer(void *anim, struct GIF_WHDR *whdr)
+{
+    (void)anim; (void)whdr;
+}
+
+int main(void)
+{
+    bool success = GIF_Load((void *)gif_data, (long)sizeof(gif_data), frame_writer, 0, 0, 0) == 1 ? 0 : 1;
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-gif-load/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-gif-load/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-gif-load",
+  "version-string": "ci",
+  "description": "Validates gif-load",
+  "dependencies": [
+    "gif-load",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3432,6 +3432,10 @@
       "baseline": "2019-10-07",
       "port-version": 3
     },
+    "gif-load": {
+      "baseline": "2019-01-06",
+      "port-version": 0
+    },
     "giflib": {
       "baseline": "6.1.3",
       "port-version": 0

--- a/versions/g-/gif-load.json
+++ b/versions/g-/gif-load.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b119d655f3d50a42fc103a2a97cdd830cf7ec678",
+      "version-date": "2019-01-06",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/g-/gif-load.json
+++ b/versions/g-/gif-load.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b119d655f3d50a42fc103a2a97cdd830cf7ec678",
+      "git-tree": "935cba3a1773d4c9f46d5a676ad4170bfa4cc132",
       "version-date": "2019-01-06",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="1906" height="1024" alt="image" src="https://github.com/user-attachments/assets/ae3079fb-0917-428f-a708-7c1479f5f8eb" />

