### PR TITLE
[gumbo] fix sha512

### DIFF
--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://codeberg.org/gumbo-parser/gumbo-parser/archive/${VERSION}.tar.gz"
+    # ON Codeberg the checksums are not guaranteed to be stable, so we use a specific commit instead.
+    # ref. https://codeberg.org/Codeberg/Community/issues/1366#issuecomment-1383136
+    URLS "https://codeberg.org/gumbo-parser/gumbo-parser/archive/322c54c178590ba42b8b04e8c0e4840595a1f717.tar.gz"
     FILENAME "gumbo-${VERSION}.tar.gz"
-    SHA512  1513e88acfc3240081039b30ab63ca6fc23a85b7d1415cb8e90e9c43f9c3d99d37634a7a50d81ef7f6d43a4facac3802feea6959256a2330b26b16523a288568
+    SHA512  9f59965e68ba2e4f5884d52c4126b62cdbefee158816334e317a0d07f10ba927be653490c69fc5b0f52eed1decf0a51715bb726aa84546a2d04cde5805e4a399
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gumbo",
   "version": "0.13.2",
+  "port-version": 1,
   "description": "An HTML5 parsing library in pure C99",
   "homepage": "https://codeberg.org/gumbo-parser/gumbo-parser",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3678,7 +3678,7 @@
     },
     "gumbo": {
       "baseline": "0.13.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-cmake": {
       "baseline": "4.2.1",

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afc4409b80e8df4666c89fb478412cb9186e23b4",
+      "version": "0.13.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf622a1d3b7ad98e86a99b371f3b693a5cce272c",
       "version": "0.13.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Try to fix https://github.com/microsoft/vcpkg/issues/52889.
