### PR TITLE
[attr] update to 2.6.0

### DIFF
--- a/ports/attr/portfile.cmake
+++ b/ports/attr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://download.savannah.nongnu.org/releases/attr/attr-${VERSION}.tar.xz"
          "https://www.mirrorservice.org/sites/download.savannah.gnu.org/releases/attr/attr-${VERSION}.tar.xz"
     FILENAME "attr-${VERSION}.tar.xz"
-    SHA512 f587ea544effb7cfed63b3027bf14baba2c2dbe3a9b6c0c45fc559f7e8cb477b3e9a4a826eae30f929409468c50d11f3e7dc6d2500f41e1af8662a7e96a30ef3
+    SHA512 870d0c34fbaa7520aad058ecd6509fe8eddd17430781a16d1e80484d4947307a7c641f0449183cbac1da611a85f82c9bee2d2d7bff76170fc2195b123100d22e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/attr/vcpkg.json
+++ b/ports/attr/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "attr",
-  "version-semver": "2.5.2",
-  "port-version": 1,
+  "version-semver": "2.6.0",
   "description": "Commands for Manipulating Filesystem Extended Attributes",
   "homepage": "http://savannah.nongnu.org/projects/attr",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/attr.json
+++ b/versions/a-/attr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c0c09a0c70713c02eb59e481214ec362928fdb5",
+      "version-semver": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9469e87c26e686294ae881a7ef4fbf1d18d34057",
       "version-semver": "2.5.2",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -397,8 +397,8 @@
       "port-version": 0
     },
     "attr": {
-      "baseline": "2.5.2",
-      "port-version": 1
+      "baseline": "2.6.0",
+      "port-version": 0
     },
     "aubio": {
       "baseline": "2024-01-03",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://cgit.git.savannah.nongnu.org/cgit/attr.git/tag/?h=v2.6.0
