### PR TITLE
[crashcatch] Update to 1.5.0

### DIFF
--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO keithpotz/CrashCatch
     REF "v${VERSION}"
-    SHA512 ba3f431b1c1da9f8ead4038ff8073df3010394ce84a6976ba6b9e9f50842a3aacb367b443a92fef75317ee49cf08384a39d76b944bf1e2735d3e2a3647c63f01
+    SHA512 1f7b8a75673abf74ee417fbc679bb293a04dc48f1c4a17fd69db0b7e260a30575564c4f406d98ab37478a9515b46cdc7b044e3050462a1b1384c0f95019b40da
     HEAD_REF main
     PATCHES
         fix-disable-examples-tests.patch

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "crashcatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A cross-platform, single-header C++ crash-reporting library for modern C++ applications.",
   "homepage": "https://github.com/keithpotz/CrashCatch",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2189,7 +2189,7 @@
       "port-version": 0
     },
     "crashcatch": {
-      "baseline": "1.4.0",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "crashpad": {

--- a/versions/c-/crashcatch.json
+++ b/versions/c-/crashcatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a0779fe5f20fe776242df639fdd7607e8a41a6d",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d2d98d530427d030b94cf84bd19eb81f2e113dab",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 1.5.0