### PR TITLE
[ls-qpack] Update to 2.7.0

### DIFF
--- a/ports/ls-qpack/portfile.cmake
+++ b/ports/ls-qpack/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO litespeedtech/ls-qpack
     REF "v${VERSION}"
-    SHA512 c660f9b815fe609211bb12e32efd306551b3a933d5c0baff7f01f6a67684e6bdc4b77b48917b169f3025efac5bcf4ea18c52c24e7d76427dc8dd186ffb54e58f
+    SHA512 2f2596486bb505feb3899ec20a94c52c1ee4b2bcda28f506f6ba5302dd3997fd18150a78428a3fd1944a5ba5ab17cc9b0c73ede9e90d3cf9dddf7bc2ab708438
     HEAD_REF master
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/deps")

--- a/ports/ls-qpack/vcpkg.json
+++ b/ports/ls-qpack/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ls-qpack",
-  "version": "2.6.6",
+  "version": "2.7.0",
   "description": "QPACK compression library for use with HTTP/3",
   "homepage": "https://github.com/litespeedtech/ls-qpack",
   "license": "MIT AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6253,7 +6253,7 @@
       "port-version": 1
     },
     "ls-qpack": {
-      "baseline": "2.6.6",
+      "baseline": "2.7.0",
       "port-version": 0
     },
     "ltla-aarand": {

--- a/versions/l-/ls-qpack.json
+++ b/versions/l-/ls-qpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c02af0c834fa2ba8794342ab5dd8d3c95ebc4a2f",
+      "version": "2.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "635c936753c4f90f1d6b45b89eee5ca528dbde44",
       "version": "2.6.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update to 2.7.0