### PR TITLE
[libnsgif]: fix check_required_components

### DIFF
--- a/ports/libnsgif/unofficial-libnsgif-config.cmake.in
+++ b/ports/libnsgif/unofficial-libnsgif-config.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
 include("${CMAKE_CURRENT_LIST_DIR}/unofficial-libnsgif-targets.cmake")
-check_required_components("nsgif")
+check_required_components("unofficial-libnsgif")

--- a/ports/libnsgif/vcpkg.json
+++ b/ports/libnsgif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libnsgif",
   "version": "1.0.0",
+  "port-version": 1,
   "description": "GIF image decompression library written in C",
   "homepage": "https://www.netsurf-browser.org/projects/libnsgif/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5430,7 +5430,7 @@
     },
     "libnsgif": {
       "baseline": "1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libobfuscate": {
       "baseline": "2024-07-10",

--- a/versions/l-/libnsgif.json
+++ b/versions/l-/libnsgif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d03a93117e40690050e63fcb0c00207e216e239",
+      "version": "1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e4f72b099011b39e92fc6162483745b54ac293bd",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

