### PR TITLE
[enchantum] fix cmake config path

### DIFF
--- a/ports/enchantum/portfile.cmake
+++ b/ports/enchantum/portfile.cmake
@@ -13,5 +13,12 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "cmake")
+
+# upstream installs enchantumConfig.cmake into <prefix>/cmake but enchantumTargets.cmake
+# into <prefix>/share/enchantum/cmake; merge them so the config's include() resolves
+file(RENAME "${CURRENT_PACKAGES_DIR}/cmake/enchantumConfig.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/cmake/enchantumConfig.cmake")
+file(RENAME "${CURRENT_PACKAGES_DIR}/cmake/enchantumConfigVersion.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/cmake/enchantumConfigVersion.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cmake")
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/${PORT}/cmake")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/enchantum/vcpkg.json
+++ b/ports/enchantum/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "enchantum",
   "version": "0.4.0",
+  "port-version": 1,
   "description": "Header-only C++20 fast compile time enum reflection library.",
   "homepage": "https://github.com/ZXShady/enchantum",
   "license": "MIT",

--- a/ports/enchantum/vcpkg.json
+++ b/ports/enchantum/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "enchantum",
   "version": "0.4.0",
   "port-version": 1,
-  "description": "Header-only C++20 fast compile time enum reflection library.",
+  "description": "Header-only C++17 fast compile time enum reflection library.",
   "homepage": "https://github.com/ZXShady/enchantum",
   "license": "MIT",
   "dependencies": [

--- a/scripts/test_ports/vcpkg-ci-enchantum/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-enchantum/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-enchantum/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-enchantum/project/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20)
+project(vcpkg_ci_enchantum LANGUAGES CXX)
+
+find_package(enchantum CONFIG REQUIRED)
+
+add_executable(vcpkg_ci_enchantum main.cpp)
+target_link_libraries(vcpkg_ci_enchantum PRIVATE enchantum::enchantum)

--- a/scripts/test_ports/vcpkg-ci-enchantum/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-enchantum/project/main.cpp
@@ -1,0 +1,15 @@
+#include <enchantum/enchantum.hpp>
+
+#include <string_view>
+
+enum class color
+{
+    red,
+    green,
+    blue
+};
+
+int main()
+{
+    return enchantum::to_string(color::green) == std::string_view{"green"} ? 0 : 1;
+}

--- a/scripts/test_ports/vcpkg-ci-enchantum/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-enchantum/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-enchantum",
+  "version-string": "ci",
+  "description": "Validates enchantum CMake integration",
+  "dependencies": [
+    "enchantum",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2842,7 +2842,7 @@
     },
     "enchantum": {
       "baseline": "0.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "enet": {
       "baseline": "1.3.18",

--- a/versions/e-/enchantum.json
+++ b/versions/e-/enchantum.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a4da5cd54484cf6ca2df733ea55c30b3d7e623cd",
+      "git-tree": "af0dbe6760759ad1a3a04b1f6f90657c0cb70ea5",
       "version": "0.4.0",
       "port-version": 1
     },

--- a/versions/e-/enchantum.json
+++ b/versions/e-/enchantum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4da5cd54484cf6ca2df733ea55c30b3d7e623cd",
+      "version": "0.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9e632360b3bc5934e84c78c8382c9645af4a089a",
       "version": "0.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

**Problem**

Upstream installs the CMake package files into two different locations:

- `enchantumConfig.cmake` / `enchantumConfigVersion.cmake` → `<prefix>/cmake/`
- `enchantumTargets.cmake` → `<prefix>/share/enchantum/cmake/`

The portfile called `vcpkg_cmake_config_fixup(CONFIG_PATH "cmake")`, which moves
only the config files into `share/enchantum/`, leaving the targets file behind in
`share/enchantum/cmake/`. Since `enchantumConfig.cmake` does
`include("${CMAKE_CURRENT_LIST_DIR}/enchantumTargets.cmake")`, any consumer using
`find_package(enchantum CONFIG REQUIRED)` fails with:

    include could not find requested file:
      .../share/enchantum/enchantumTargets.cmake

**Fix**

Before running `vcpkg_cmake_config_fixup`, move the config files into
`share/enchantum/cmake/` next to the targets file, then run the fixup with
`CONFIG_PATH "share/${PORT}/cmake"`. The fixup then relocates all three files
together into `share/enchantum/` and corrects the `PACKAGE_PREFIX_DIR`
computation.
