### PR TITLE
[ms-gdk] Update port to April 2026 Update 3

### DIFF
--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,4 +1,4 @@
-set(GDK_EDITION_NUMBER 260402)
+set(GDK_EDITION_NUMBER 260403)
 
 # The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
@@ -6,13 +6,13 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE_CORE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.Core/${VERSION}"
     FILENAME "ms-gdk-core.${VERSION}.zip"
-    SHA512 72c7fc4b15c652b616c2372ee4ebd94d7205161c2d383dd773ab2f5a10dcb593311ccceecb66127e4f645176eb2a2d2d3a6d7eecb2a66b40173647013d819541
+    SHA512 9c607f4bed88a53aafde4f56c89fc02f0b7bfd7006f793aeeea77aceb0ccefbe7dbf4874b6414ead4e26c78599236476c3432150eed78576b684e6219e075fd7
 )
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.Windows/${VERSION}"
     FILENAME "ms-gdk-windows.${VERSION}.zip"
-    SHA512 69ae9e33d259cf742fcf30c5cffa528ef018d89dc1a6d0446170656c789277fbf823c956886cc65c971c277df2878355da995c518b93d4f4ffae2c50967fa9f0
+    SHA512 bd6951bc05c2010f35a2f2565bb42a4306c9962309810bfa82379d689d5095f483e11f590c226e7bf8847fa1b868d8f44b75abf707feee00944dc9db5b98113c
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-gdk",
-  "version": "2604.2.7849",
+  "version": "2604.3.7874",
   "description": "Microsoft Game Development Kit (GDK)",
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6805,7 +6805,7 @@
       "port-version": 0
     },
     "ms-gdk": {
-      "baseline": "2604.2.7849",
+      "baseline": "2604.3.7874",
       "port-version": 0
     },
     "ms-gdkx": {

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d6b2b8d16f040ba6be0269ec54768124906d57b",
+      "version": "2604.3.7874",
+      "port-version": 0
+    },
+    {
       "git-tree": "0cf362eaf6f6ad0fb2bb1edcec1972f7247537c5",
       "version": "2604.2.7849",
       "port-version": 0


### PR DESCRIPTION
Updates the `ms-gdk` port to the **Microsoft GDK April 2026 Update 3** release (`2604.3.7874`), published to nuget.org on 2026-08-05.

- `GDK_EDITION_NUMBER` moves from `260402` to `260403`.
- SHA512s updated for both `Microsoft.GDK.Core` and `Microsoft.GDK.Windows`.

No other port changes were required — the package layout is unchanged from Update 2, and every file referenced by the portfile is present for both `x64` and `arm64`.

### Validation

Built locally against the new packages, both supported triplets, with the optional `playfab` feature enabled:

- `ms-gdk[core,playfab]:x64-windows` — installed successfully, post-build validation passed
- `ms-gdk[core,playfab]:arm64-windows` — installed successfully, post-build validation passed

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
