### PR TITLE
[jsonfusion] Update to 1.1.1

### DIFF
--- a/ports/jsonfusion/portfile.cmake
+++ b/ports/jsonfusion/portfile.cmake
@@ -2,15 +2,39 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tucher/JsonFusion
     REF "v${VERSION}"
-    SHA512 fe8cb3068fc5ce7f5bacb708eb4c9947fa241b7cf29d50b1d285f5df243a164e063701de9bf1e486d6a38be0c9d0677d0ed0450b70e3878cdad1dbbae363bc36
+    SHA512 7b131bb92b067378eef81b454303393b83019e0a04bc06c91ab0c9646d7d5bb0b6eaef49a7f77d2f1886107b58ccb581de5eac5a81da3fc1801903dd38cdaf57
     HEAD_REF master
 )
 
-# Install JsonFusion headers, excluding experimental 3party directory
-# (3party is only used with JSONFUSION_FP_BACKEND=1, default is 0 with in-house implementation)
+# Header-only. Install everything except the experimental 3party directory
+# (only used with JSONFUSION_FP_BACKEND=1).
 file(INSTALL "${SOURCE_PATH}/include/JsonFusion"
      DESTINATION "${CURRENT_PACKAGES_DIR}/include"
      PATTERN "3party" EXCLUDE)
 
-# Install license
+# The optional backend headers guard their dependency with "#if __has_include(<...>)"
+# upstream. Per the vcpkg maintainer guide, a port's dependencies must be controlled
+# by its features, not by whatever headers happen to be on the include path, so we
+# rewrite those guards to a fixed value rather than leaving them ambient.
+
+# rapidyaml is not provided by this port: disable the YAML backend outright.
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/JsonFusion/yaml.hpp"
+    "#if __has_include(<rapidyaml.hpp>)"
+    "#if 0 // rapidyaml is not provided by the vcpkg port")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/JsonFusion/yaml.hpp"
+    "#endif // __has_include(<rapidyaml.hpp>)" "#endif")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/JsonFusion/yyjson.hpp"
+    "#endif // __has_include(<yyjson.h>)" "#endif")
+
+# yyjson backend: enabled strictly by the "yyjson" feature.
+if("yyjson" IN_LIST FEATURES)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/JsonFusion/yyjson.hpp"
+        "#if __has_include(<yyjson.h>)"
+        "#if 1 // provided by the 'yyjson' feature")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/JsonFusion/yyjson.hpp"
+        "#if __has_include(<yyjson.h>)"
+        "#if 0 // enable the 'yyjson' feature to use this backend")
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/jsonfusion/vcpkg.json
+++ b/ports/jsonfusion/vcpkg.json
@@ -1,10 +1,19 @@
 {
   "name": "jsonfusion",
-  "version": "0.710.0",
+  "version": "1.1.1",
   "description": "Type-driven JSON/CBOR parser with declarative validation. Header-only C++23 library.",
   "homepage": "https://github.com/tucher/JsonFusion",
   "license": "MIT",
+  "supports": "!windows",
   "dependencies": [
     "boost-pfr"
-  ]
+  ],
+  "features": {
+    "yyjson": {
+      "description": "High-performance JSON backend (JsonFusion/yyjson.hpp) built on yyjson",
+      "dependencies": [
+        "yyjson"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4237,7 +4237,7 @@
       "port-version": 0
     },
     "jsonfusion": {
-      "baseline": "0.710.0",
+      "baseline": "1.1.1",
       "port-version": 0
     },
     "jsonifier": {

--- a/versions/j-/jsonfusion.json
+++ b/versions/j-/jsonfusion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b567b343276c4eaf9f50a9e412a377e3f5646e7a",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2aa8233f622d88be661160cca7166053b371b181",
       "version": "0.710.0",
       "port-version": 0


### PR DESCRIPTION
Updates the `jsonfusion` port to 1.1.1, which also addresses the review feedback on the earlier revision.

**Review fixes**
- **MSVC**: upstream supports only GCC 14+ / Clang 20+, so added `"supports": "!windows"` (the `__attribute__((noinline))` etc. do not compile with MSVC).
- **`yyjson.hpp` undeclared dependency**: the optional backend headers are now `#if __has_include(<...>)`-guarded upstream (v1.1.1), so they are self-contained — installing/including them no longer requires the backend to be present; they compile to nothing without it. A `yyjson` feature pulls the `yyjson` dependency to activate `JsonFusion/yyjson.hpp`.
- **`yaml.hpp` includes nonexistent `rapidyaml.hpp`**: same `__has_include` guard, so the installed header is safe (no-ops without rapidyaml). It is intentionally left unfeatured: the vcpkg `ryml` port ships a different include layout (`<ryml/ryml.hpp>`), so it can't satisfy this header cleanly.

**Validation (arm64-osx)**
- `format-manifest` — no changes.
- `./vcpkg install jsonfusion` — SHA512 verified for `v1.1.1`; installed headers (including the guarded `yaml.hpp` / `yyjson.hpp`) compile standalone with no backend deps present.
- `./vcpkg install jsonfusion[yyjson]` — pulls `yyjson@0.12.0`; `JsonFusion/yyjson.hpp` compiles against it.

Header-only; `boost-pfr` dependency unchanged.

- [x] Changes comply with the maintainer guide.
- [x] SHA512s are updated for each downloaded file.
- [x] The version database is updated (`x-add-version`).
- [x] The installed package builds and can be used.