### PR TITLE
Update imgui to v1.92.9

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -75,6 +75,11 @@ if(IMGUI_BUILD_METAL_BINDING)
     set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.mm PROPERTIES COMPILE_FLAGS -fobjc-weak)
 endif()
 
+if(IMGUI_BUILD_METAL4_BINDING)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal4.mm)
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal4.mm PROPERTIES COMPILE_FLAGS -fobjc-weak)
+endif()
+
 if(IMGUI_BUILD_OPENGL2_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.cpp)
 endif()
@@ -150,6 +155,14 @@ endif()
 
 if(IMGUI_USE_WCHAR32)
     target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_USE_WCHAR32)
+endif()
+
+if(NOT IMGUI_EMBED_DEFAULT_FONT_BITMAP)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE IMGUI_DISABLE_DEFAULT_FONT_BITMAP)
+endif()
+
+if(NOT IMGUI_EMBED_DEFAULT_FONT_VECTOR)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE IMGUI_DISABLE_DEFAULT_FONT_VECTOR)
 endif()
 
 if(IMGUI_TEST_ENGINE)
@@ -235,6 +248,10 @@ if(NOT IMGUI_SKIP_HEADERS)
 
     if(IMGUI_BUILD_METAL_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_METAL4_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal4.h DESTINATION include)
     endif()
 
     if(IMGUI_BUILD_OPENGL2_BINDING)

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -5,7 +5,7 @@ if ("docking-experimental" IN_LIST FEATURES)
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}-docking"
-        SHA512 927ecf72f00a228e0899d5b8008575b44748c49b083b9425b5f2a6b4490a9900eae111afad23f2bf0a1c9c62cf1fea80c903eb3076d7e7ea901a5625f09df78e
+        SHA512 1a5ede24f8358c93a6a012a8961776eccca32dfefe0ea3b88cbbb562a76e6ef6418ab353ed0ec7d59069e5e51918cf2b38b041243cb6edaee0ffd040ccee21c6
         HEAD_REF docking
     )
 else()
@@ -13,7 +13,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}"
-        SHA512 60eb4f8478ae998ae68efa33b2e3c9f331f5e373a1272472f93befd9fd6cab4ed73935bb540e728b5abb154469fbc6c0fd69f7aaf54cd3187eefede6cb145a10
+        SHA512 980acd2d5b8047978e1b858d35cf35bd206ca5c96b6223f0e534db5efe5ec4f7475a51f7ff0455a5904a1f852307f5c548e61cc56925f455cc31e1b9849bb6a6
         HEAD_REF master
     )
 endif()
@@ -32,6 +32,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     glfw-binding                IMGUI_BUILD_GLFW_BINDING
     glut-binding                IMGUI_BUILD_GLUT_BINDING
     metal-binding               IMGUI_BUILD_METAL_BINDING
+    metal4-binding              IMGUI_BUILD_METAL4_BINDING
     opengl2-binding             IMGUI_BUILD_OPENGL2_BINDING
     opengl3-binding             IMGUI_BUILD_OPENGL3_BINDING
     osx-binding                 IMGUI_BUILD_OSX_BINDING
@@ -45,6 +46,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     freetype-svg                IMGUI_FREETYPE_SVG
     wchar32                     IMGUI_USE_WCHAR32
     test-engine                 IMGUI_TEST_ENGINE
+    default-font-bitmap         IMGUI_EMBED_DEFAULT_FONT_BITMAP
+    default-font-vector         IMGUI_EMBED_DEFAULT_FONT_VECTOR
 )
 
 if ("libigl-imgui" IN_LIST FEATURES)
@@ -65,7 +68,7 @@ if ("test-engine" IN_LIST FEATURES)
         OUT_SOURCE_PATH TEST_ENGINE_SOURCE_PATH
         REPO ocornut/imgui_test_engine
         REF "v${VERSION}"
-        SHA512 3a31bd3e1f86679ee60fc765971e96f76e05e530b3c7920aea284818604fd8a3cdf1fc7189e7e825a52a75446217ed6f1b2d7470d317799d381fb9019f14333b
+        SHA512 d622d4d8c9c5fac15d9745f1ce896bea6c04e2f4ed55a9715cd7e119e305b0443c52bc8edbabece6f1a6d301bdce9e78efeaf53fa75858073a48d4872eb5a870
         HEAD_REF master
     )
 

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.92.8",
-  "port-version": 1,
+  "version": "1.92.9",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",
@@ -15,6 +14,10 @@
       "host": true
     }
   ],
+  "default-features": [
+    "default-font-bitmap",
+    "default-font-vector"
+  ],
   "features": {
     "allegro5-binding": {
       "description": "Make available Allegro5 binding",
@@ -25,6 +28,12 @@
     "android-binding": {
       "description": "Make available Android native app support",
       "supports": "android"
+    },
+    "default-font-bitmap": {
+      "description": "Embed ProggyClean font"
+    },
+    "default-font-vector": {
+      "description": "Embed ProggyForever font"
     },
     "docking-experimental": {
       "description": "Build with docking support"
@@ -89,6 +98,10 @@
     "metal-binding": {
       "description": "Make available Metal binding",
       "supports": "osx"
+    },
+    "metal4-binding": {
+      "description": "Make available Metal 4 binding",
+      "supports": "osx & arm64"
     },
     "opengl2-binding": {
       "description": "Make available OpenGL (legacy) binding",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4001,8 +4001,8 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.92.8",
-      "port-version": 1
+      "baseline": "1.92.9",
+      "port-version": 0
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "901e2036e578ecb0d5c22d85ad1aba5f5fbddb02",
+      "version": "1.92.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "911006dffb8054b8817a1d6c2f1e0a9335400e90",
       "version": "1.92.8",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

- Added `metal4` feature that enable Metal 4 backend in macOS.
- Added `default-font-bitmap` and `default-font-vector` features that embed the font data in the library, which are enabled by default.