### PR TITLE
[wt] update to 4.13.4

### DIFF
--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -66,6 +66,7 @@ vcpkg_cmake_configure(
         -DENABLE_FIREBIRD=OFF
         -DENABLE_QT4=OFF
         -DENABLE_QT5=OFF
+        -DENABLE_QT6=OFF
         -DENABLE_LIBWTTEST=ON
         -DENABLE_OPENGL=ON
 
@@ -98,5 +99,10 @@ file(READ "${CURRENT_PACKAGES_DIR}/include/Wt/WConfig.h" W_CONFIG_H)
 string(REGEX REPLACE "([\r\n])#define RUNDIR[^\r\n]+" "\\1// RUNDIR intentionally unset by vcpkg" W_CONFIG_H "${W_CONFIG_H}")
 file(WRITE "${CURRENT_PACKAGES_DIR}/include/Wt/WConfig.h" "${W_CONFIG_H}")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/src/thirdparty/qrcodegen/license.txt"
+        "${SOURCE_PATH}/src/thirdparty/rapidxml/license.txt"
+)
 vcpkg_copy_pdbs()

--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emweb/wt
     REF "${VERSION}"
-    SHA512 0ae5c2448404fca2583da5567dfa73db9fe7580fc17b6ae27e74b2cdeacfe37082b417847cf77a0b26c8efecca3ef3adc7f37e09f7eb2a67c84d2aab2a600566
+    SHA512 1200a6623cd37df2db46220b5b36e7a760f5675cb6a7e8c79fea7cad3a58f57bbfe761311bb8f67928107b477b4cd618ba917517013bf219d702302843d3cc09
     HEAD_REF master
     PATCHES
         0005-XML_file_path.patch

--- a/ports/wt/vcpkg.json
+++ b/ports/wt/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.13.4",
   "description": "Wt is a C++ library for developing web applications",
   "homepage": "https://github.com/emweb/wt",
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-only AND MIT AND (BSL-1.0 OR MIT)",
   "supports": "!xbox",
   "dependencies": [
     "boost-algorithm",

--- a/ports/wt/vcpkg.json
+++ b/ports/wt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wt",
-  "version": "4.13.3",
+  "version": "4.13.4",
   "description": "Wt is a C++ library for developing web applications",
   "homepage": "https://github.com/emweb/wt",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11073,7 +11073,7 @@
       "port-version": 0
     },
     "wt": {
-      "baseline": "4.13.3",
+      "baseline": "4.13.4",
       "port-version": 0
     },
     "wtl": {

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad9c3a92bda7300ee5879220c08ab29ce8d089f9",
+      "version": "4.13.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6d185fe13a7a37e16498a0c442ecd38223477dd",
       "version": "4.13.3",
       "port-version": 0

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad9c3a92bda7300ee5879220c08ab29ce8d089f9",
+      "git-tree": "f2b140f14cd255d64c45823a71b55694042f3370",
       "version": "4.13.4",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/emweb/wt/releases/tag/4.13.4
