### PR TITLE
[rego-cpp] update to 1.5.2

### DIFF
--- a/ports/rego-cpp/portfile.cmake
+++ b/ports/rego-cpp/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/rego-cpp
@@ -45,7 +47,11 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME regocpp CONFIG_PATH share/regocpp/cmake)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/src/builtins/base64/base64.cpp"
+)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/rego-cpp/portfile.cmake
+++ b/ports/rego-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/rego-cpp
     REF "v${VERSION}"
-    SHA512 a9e7b6202fdc7b7168433227c7bc67492d52bdf10c5d9b2c0954aa66a9eb5a16a9b4de7eb7385a335c6685111393aad6840c171ab12b3e6b2fd493b5bffea21c
+    SHA512 41c9a9ef4f531b872c5fc5a4ba4a1ac1a393a907e48e9dc22abf069098ce71045c294503a24f28c177058bbe3e148e6be0f49a73fbc46c64547c249f70f6fcd7
     HEAD_REF main
     PATCHES
       add-bigobj.diff # src\rego_to_bundle.cc : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

--- a/ports/rego-cpp/vcpkg.json
+++ b/ports/rego-cpp/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.5.2",
   "description": "A C++ interpreter for the OPA Rego policy language",
   "homepage": "https://github.com/microsoft/rego-cpp",
-  "license": "MIT",
+  "license": "MIT AND Zlib",
   "supports": "!x86",
   "dependencies": [
     {

--- a/ports/rego-cpp/vcpkg.json
+++ b/ports/rego-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rego-cpp",
-  "version": "1.4.1",
-  "port-version": 1,
+  "version": "1.5.2",
   "description": "A C++ interpreter for the OPA Rego policy language",
   "homepage": "https://github.com/microsoft/rego-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8821,8 +8821,8 @@
       "port-version": 0
     },
     "rego-cpp": {
-      "baseline": "1.4.1",
-      "port-version": 1
+      "baseline": "1.5.2",
+      "port-version": 0
     },
     "rendergraph": {
       "baseline": "2.1.0",

--- a/versions/r-/rego-cpp.json
+++ b/versions/r-/rego-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a714b7fce7061e8fff0cfe70370331e4ed2db6d0",
+      "git-tree": "75459f8f58ecba0d9934b5cf39c7a18dd1931771",
       "version": "1.5.2",
       "port-version": 0
     },

--- a/versions/r-/rego-cpp.json
+++ b/versions/r-/rego-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a714b7fce7061e8fff0cfe70370331e4ed2db6d0",
+      "version": "1.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4eba4aa2840ed4827eec9fa1da81228400300bcb",
       "version": "1.4.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/microsoft/rego-cpp/releases/tag/v1.5.2
