### PR TITLE
[libvips] update to 8.18.5

### DIFF
--- a/ports/libvips/portfile.cmake
+++ b/ports/libvips/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libvips/libvips
     REF v${VERSION}
-    SHA512 6861bc7a65137817613448c2e5e44def7845e5537d68e43d245bf3b45eb0fad7ea297bc3864905ae4e33dbf11bc21ec6f76626ff92d15ee1aac6959768fbd256
+    SHA512 c7bb3a331dce1b2961c71134cac307111d77d17f4ff4d0a952b01ae5e83204b4fd59f01b98047fa4cb5bbf9917f0eb5441ada7d0b9afc5f56e6dc1ea05d7c440
     HEAD_REF master
 )
 
@@ -72,7 +72,7 @@ vcpkg_install_meson()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-## tools are built by default, uncomment this for next libvips version where 
+## tools are built by default, uncomment this for next libvips version where
 ## there's a tools option in the FEATURES and MESON OPTIONS file.
 ## Also, the tools feature should be added in the vcpkg.json file:
 ##   ,

--- a/ports/libvips/vcpkg.json
+++ b/ports/libvips/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libvips",
-  "version": "8.18.2",
+  "version": "8.18.5",
   "description": "libvips is a demand-driven, horizontally threaded image processing library.",
   "homepage": "https://github.com/libvips/libvips",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5929,7 +5929,7 @@
       "port-version": 0
     },
     "libvips": {
-      "baseline": "8.18.2",
+      "baseline": "8.18.5",
       "port-version": 0
     },
     "libvmaf": {

--- a/versions/l-/libvips.json
+++ b/versions/l-/libvips.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e08d536bcbec5f4b2239891c1a5d4035347f0a2c",
+      "version": "8.18.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "6d864e37a2fae385859acfc96bd2e0c05d6b8504",
       "version": "8.18.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libvips/libvips/releases/tag/v8.18.5
