### PR TITLE
[icu] Fix use of fallback install-sh

### DIFF
--- a/ports/icu/fix-using-install-sh.diff
+++ b/ports/icu/fix-using-install-sh.diff
@@ -1,0 +1,23 @@
+diff --git a/source/configure b/source/configure
+index a6df219..2e1ebcf 100644
+--- a/source/configure
++++ b/source/configure
+@@ -4935,12 +4935,12 @@ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
+ 
+ 
+ 
+-# make sure install is relative to srcdir - if a script
+-if test "$srcdir" = "."; then
+-  # If srcdir isn't just ., then (srcdir) is already prepended.
+-  if test "${ac_install_sh}" = "${INSTALL}"; then
+-   INSTALL="\\\$(top_srcdir)/${ac_install_sh}"
+-  fi
++# If using the included install-sh, make INSTALL work from any build dir.
++if test "${ac_install_sh}" = "${INSTALL}"; then
++    case "$srcdir" in
++        .|./*|../*)  INSTALL="\\\$(top_builddir)/${ac_install_sh}" ;;
++        *) ;;
++    esac
+ fi
+ 
+ # TODO(ICU-20301): Remove fallback to Python 2.

--- a/ports/icu/fix-using-install-sh.diff
+++ b/ports/icu/fix-using-install-sh.diff
@@ -1,5 +1,21 @@
+diff --git a/source/Makefile.in b/source/Makefile.in
+index 9e15b6a016..53330a3921 100644
+--- a/source/Makefile.in
++++ b/source/Makefile.in
+@@ -189,7 +189,10 @@ install-icu: $(INSTALLED_BUILT_FILES)
+ 	$(INSTALL_SCRIPT) $(top_srcdir)/mkinstalldirs $(DESTDIR)$(pkgdatadir)/mkinstalldirs
+ 	$(INSTALL_SCRIPT) $(top_srcdir)/install-sh $(DESTDIR)$(pkgdatadir)/install-sh
+ 	@$(MKINSTALLDIRS) $(DESTDIR)$(libdir)/pkgconfig
+-	$(INSTALL_DATA) $(ALL_PKGCONFIG_FILES) $(DESTDIR)$(libdir)/pkgconfig/
++	# icu's fallback install-sh does not support multi-file install
++	@for file in $(ALL_PKGCONFIG_FILES); do \
++	  $(INSTALL_DATA) "$${file}" $(DESTDIR)$(libdir)/pkgconfig/ ; \
++	done
+ 	$(INSTALL_DATA) $(top_srcdir)/../LICENSE $(DESTDIR)$(pkgdatadir)/LICENSE
+ ifeq ($(INSTALL_ICU_CONFIG),true)
+ 	$(INSTALL_SCRIPT) $(top_builddir)/config/icu-config $(DESTDIR)$(bindir)/icu-config
 diff --git a/source/configure b/source/configure
-index a6df219..2e1ebcf 100644
+index dfa3a091f8..8ee911d42d 100755
 --- a/source/configure
 +++ b/source/configure
 @@ -4935,12 +4935,12 @@ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         fix_bsd_and_solaris.patch
         fix_parallel_build_on_windows.patch
         fix-python-path-with-spaces.patch
+        fix-using-install-sh.diff
         mh-darwin.patch
         mh-mingw.patch
         mh-msys-msvc.patch

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "78.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3942,7 +3942,7 @@
     },
     "icu": {
       "baseline": "78.3",
-      "port-version": 1
+      "port-version": 2
     },
     "ideep": {
       "baseline": "2026-05-11",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "da9f6dddd34300c1eea72aadde1d774ce2d3f31c",
+      "git-tree": "50a263a104075be2c5647af8e723a18914f6ee13",
       "version": "78.3",
       "port-version": 2
     },

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da9f6dddd34300c1eea72aadde1d774ce2d3f31c",
+      "version": "78.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "931a42f3b3b911ba73dbbaead4c1e0037a158efd",
       "version": "78.3",
       "port-version": 1


### PR DESCRIPTION
icu uses `AC_PROG_INSTALL` which tries to find a fast binary `install` and uses a slow `install-sh` script as fallback.
When the fallback is used, icu prepends `$(top_srcdir)` for (some) in-source builds. But vcpkg builds out-of-source, and the value of `INSTALL` is valid only for the toplevel build dir. 
So this patch prepends `$(top_builddir)` instead in order construct a valid path for every possible case.

In addition, workaround install-sh not handling multiple files in one invocation.

To verify, rename `/usr/bin/install` or similar before installing `icu`. (E.g. apply
~~~
vcpkg_replace_string("${SOURCE_PATH}/source/configure" "DUALCASE=1" "mv /usr/bin/install /usr/bin/install.orig\nDUALCASE=1" IGNORE_UNCHANGED)
~~~
after `vcpkg_extract_source_archive`.)

Alternative to / closes https://github.com/microsoft/vcpkg/pull/52618.  
Fixes https://github.com/microsoft/vcpkg/issues/51759.  
Fixes https://github.com/microsoft/vcpkg/issues/50967.  
Fixes https://github.com/microsoft/vcpkg/issues/48887.
Fixes https://github.com/microsoft/vcpkg/issues/48141.  
Fixes https://github.com/microsoft/vcpkg/issues/46567.  
