### PR TITLE
[libmagic] Update to 5.48

### DIFF
--- a/ports/libmagic/0001-Use-libtre.patch
+++ b/ports/libmagic/0001-Use-libtre.patch
@@ -1,20 +1,9 @@
-From e6e59f41c082be94c4fef007e276b1dffe7dc240 Mon Sep 17 00:00:00 2001
-From: Long Nguyen <nguyen.long.908132@gmail.com>
-Date: Sat, 8 May 2021 19:28:01 +0700
-Subject: [PATCH 01/14] Use libtre
-
----
- configure.ac    | 2 +-
- src/Makefile.am | 2 +-
- src/file.h      | 2 +-
- 3 files changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/configure.ac b/configure.ac
-index 02eac8f..b05c334 100644
+index b44fabdf..c0017be0 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -185,7 +185,7 @@ if test "$enable_libseccomp" != "no"; then
-     AC_CHECK_LIB(seccomp, seccomp_init)
+@@ -238,7 +238,7 @@ if test "$enable_landlock" != "no"; then
+     AC_CHECK_HEADERS(linux/landlock.h)
  fi
  if test "$MINGW" = 1; then
 -  AC_CHECK_LIB(gnurx,regexec,,AC_MSG_ERROR([libgnurx is required to build file(1) with MinGW]))
@@ -23,11 +12,11 @@ index 02eac8f..b05c334 100644
  
  dnl See if we are cross-compiling
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 3f67f2c..34781b9 100644
+index 2d5df53e..09b5be26 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -13,7 +13,7 @@ libmagic_la_SOURCES = buffer.c magic.c apprentice.c softmagic.c ascmagic.c \
- 	file_opts.h elfclass.h mygetopt.h cdf.c cdf_time.c readcdf.c cdf.h
+@@ -14,7 +14,7 @@ libmagic_la_SOURCES = buffer.c magic.c apprentice.c softmagic.c ascmagic.c \
+ 	swap.c swap.h
  libmagic_la_LDFLAGS = -no-undefined -version-info 1:0:0
  if MINGW
 -MINGWLIBS = -lgnurx -lshlwapi
@@ -36,7 +25,7 @@ index 3f67f2c..34781b9 100644
  MINGWLIBS =
  endif
 diff --git a/src/file.h b/src/file.h
-index c548e97..299ac0c 100644
+index 6a39801e..81542659 100644
 --- a/src/file.h
 +++ b/src/file.h
 @@ -79,7 +79,7 @@
@@ -48,6 +37,3 @@ index c548e97..299ac0c 100644
  #include <time.h>
  #include <sys/types.h>
  #ifndef WIN32
--- 
-2.29.2.windows.2
-

--- a/ports/libmagic/fix-public-ssize-t.diff
+++ b/ports/libmagic/fix-public-ssize-t.diff
@@ -1,0 +1,16 @@
+diff --git a/src/magic.h.in b/src/magic.h.in
+index 230fcbd..37d5542 100644
+--- a/src/magic.h.in
++++ b/src/magic.h.in
+@@ -28,6 +28,11 @@
+ 
+ #include <sys/types.h>
+ 
++#ifdef _MSC_VER
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
++
+ #define	MAGIC_NONE		0x0000000 /* No flags */
+ #define	MAGIC_DEBUG		0x0000001 /* Turn on debugging */
+ #define	MAGIC_SYMLINK		0x0000002 /* Follow symlinks */

--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -4,6 +4,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "0001-Use-libtre.patch"
         "0003-Fix-WIN32-macro-checks.patch"
         "0004-Typedef-POSIX-types-on-Windows.patch"
+        "fix-public-ssize-t.diff"
         "0005-Include-dirent.h-for-S_ISREG-and-S_ISDIR.patch"
         "0006-Remove-Wrap-POSIX-headers.patch"
         "0007-Substitute-unistd-macros-for-MSVC.patch"

--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO file/file
     REF "${FILE_REF}"
-    SHA512 9ef8d1efd744115b0f28a7bef1a6b3e25c6feb71f6e37590bc18fe49e77d55adddb712527fd3c4080e0b70f13c5f33cdce3ce932e99a751e6de6a0e8b381c30a
+    SHA512 40568ddef1bd2cedb468f032bf07aaabf1756d20fe8bcba3b4f3fd42be13ed3242768a825db1456b7c0a12c6e549c3e714e1ea182bf5065d1d06e88cdd7a9363
     HEAD_REF master
     PATCHES
         0002-Change-zlib-lib-name-to-match-CMake-output.patch

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmagic",
-  "version": "5.47",
-  "port-version": 1,
+  "version": "5.48",
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5309,8 +5309,8 @@
       "port-version": 4
     },
     "libmagic": {
-      "baseline": "5.47",
-      "port-version": 1
+      "baseline": "5.48",
+      "port-version": 0
     },
     "libmariadb": {
       "baseline": "3.4.8",

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ac08270b235b817a2d91ffbb228513ccec9cb13",
+      "git-tree": "ce1fe445eb57fbbf57dbd48c270f16abe38de5b2",
       "version": "5.48",
       "port-version": 0
     },

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ac08270b235b817a2d91ffbb228513ccec9cb13",
+      "version": "5.48",
+      "port-version": 0
+    },
+    {
       "git-tree": "d9751639c0ab5fcd3c09fcad61f49e3d0574ee43",
       "version": "5.47",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
