### PR TITLE
[sentil] add new port 0.3.0

### DIFF
--- a/ports/sentil/portfile.cmake
+++ b/ports/sentil/portfile.cmake
@@ -1,0 +1,122 @@
+set(SENTIL_VERSION 0.3.0)
+set(SENTIL_RELEASE "https://github.com/sedislab/SENTIL/releases/download/v${SENTIL_VERSION}")
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+if(VCPKG_TARGET_IS_LINUX)
+    if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        message(FATAL_ERROR "sentil ships a prebuilt bundle for linux-x86_64 only.")
+    endif()
+    set(SENTIL_PLATFORM "linux-x86_64")
+    set(SENTIL_SHA512 "42ad31693badb2cf1660dca250be3e6f490fbb6bf93e1d9ede0408db8c11e20d8e316445a74b6c318d6d5f3f85e237fa0405d629492056d954d566486788a0fa")
+    set(SENTIL_SHARED "libsentil.so")
+    set(SENTIL_STATIC "libsentil.a")
+elseif(VCPKG_TARGET_IS_OSX)
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(SENTIL_PLATFORM "macos-x86_64")
+        set(SENTIL_SHA512 "2328dd5c1c31a3c5f355122723ccbb293c02010f58ac3019e11687191269e73cfa1fc747544e50ccdb22bf104f5ab0c38a01bc3456a30fc26532cc038daabb8b")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(SENTIL_PLATFORM "macos-arm64")
+        set(SENTIL_SHA512 "464f1e56348e2fb25cc30dd70470ca8551810027e827c6c52d4bd94ea766616515d16e2efe5176e3eb6145a23d44f462b18780acf8456b3d376c373a8a8eeb87")
+    else()
+        message(FATAL_ERROR "sentil ships a prebuilt bundle for macos x86_64 and arm64 only.")
+    endif()
+    set(SENTIL_SHARED "libsentil.dylib")
+    set(SENTIL_STATIC "libsentil.a")
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        message(FATAL_ERROR "sentil ships a prebuilt bundle for windows-x86_64 only.")
+    endif()
+    set(SENTIL_PLATFORM "windows-x86_64")
+    set(SENTIL_SHA512 "f0e2ef0edd5793d53b4b405269e22e1b711f367febe35df0ea0b65ae56f76f41d7490ce6d8ffdcbf87c09ff9a253d497d985e2767eee5fc7562b635222475907")
+    set(SENTIL_SHARED "sentil.dll")
+    set(SENTIL_IMPORT_LIB "sentil.dll.lib")
+else()
+    message(FATAL_ERROR "sentil has no prebuilt bundle for this platform.")
+endif()
+
+set(SENTIL_BUNDLE "sentil-${SENTIL_VERSION}-${SENTIL_PLATFORM}")
+
+vcpkg_download_distfile(SENTIL_ARCHIVE
+    URLS "${SENTIL_RELEASE}/${SENTIL_BUNDLE}.tar.gz"
+    FILENAME "${SENTIL_BUNDLE}.tar.gz"
+    SHA512 "${SENTIL_SHA512}"
+)
+
+vcpkg_extract_source_archive(SENTIL_SRC
+    ARCHIVE "${SENTIL_ARCHIVE}"
+    SOURCE_BASE "${SENTIL_BUNDLE}"
+)
+
+file(INSTALL "${SENTIL_SRC}/include/sentil.h"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SENTIL_SRC}/include/sentil"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_IMPORT_LIB}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_IMPORT_LIB}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+else()
+    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    if(EXISTS "${SENTIL_SRC}/lib/${SENTIL_STATIC}")
+        file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_STATIC}"
+            DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+        file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_STATIC}"
+            DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    endif()
+endif()
+
+if(EXISTS "${SENTIL_SRC}/lib/pkgconfig/sentil.pc")
+    file(READ "${SENTIL_SRC}/lib/pkgconfig/sentil.pc" SENTIL_PC)
+    string(REGEX REPLACE "prefix=[^\n]*" "prefix=\${pcfiledir}/../.." SENTIL_PC_REL "${SENTIL_PC}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sentil.pc" "${SENTIL_PC_REL}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sentil.pc" "${SENTIL_PC_REL}")
+    vcpkg_fixup_pkgconfig()
+endif()
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/SentilConfig.cmake"
+"set(SENTIL_VERSION ${SENTIL_VERSION})
+
+get_filename_component(SENTIL_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}/../..\" ABSOLUTE)
+set(SENTIL_INCLUDE_DIR \"\${SENTIL_PREFIX}/include\")
+set(SENTIL_LIBRARY \"\${SENTIL_PREFIX}/lib/\${CMAKE_SHARED_LIBRARY_PREFIX}sentil\${CMAKE_SHARED_LIBRARY_SUFFIX}\")
+
+if(NOT TARGET Sentil::sentil)
+    add_library(Sentil::sentil SHARED IMPORTED)
+    set_target_properties(Sentil::sentil PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES \"\${SENTIL_INCLUDE_DIR}\")
+    if(WIN32)
+        set_target_properties(Sentil::sentil PROPERTIES
+            IMPORTED_LOCATION \"\${SENTIL_PREFIX}/bin/sentil.dll\"
+            IMPORTED_IMPLIB \"\${SENTIL_PREFIX}/lib/sentil.dll.lib\")
+    else()
+        set_target_properties(Sentil::sentil PROPERTIES
+            IMPORTED_LOCATION \"\${SENTIL_LIBRARY}\")
+    endif()
+endif()
+"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_download_distfile(SENTIL_LICENSE_MIT
+    URLS "https://raw.githubusercontent.com/sedislab/SENTIL/v${SENTIL_VERSION}/LICENSE-MIT"
+    FILENAME "sentil-${SENTIL_VERSION}-LICENSE-MIT"
+    SHA512 "fca06c4f0b5d87bacb8180552cd78fcff29920cb8c916bc4407904cd61dcda956fc2a77225cc2df61a88048a29d4e5ba6e782a7f87070134dd318dadd92f5fd4"
+)
+vcpkg_download_distfile(SENTIL_LICENSE_APACHE
+    URLS "https://raw.githubusercontent.com/sedislab/SENTIL/v${SENTIL_VERSION}/LICENSE-APACHE"
+    FILENAME "sentil-${SENTIL_VERSION}-LICENSE-APACHE"
+    SHA512 "1893a8f4251653e1b0a62983d0c1b049e0e178dc493d74bd035bccf0286be35d57db437a7c011eabe44ba166730f1801a8c761c9ab560651dd5f258a264dddd7"
+)
+vcpkg_install_copyright(FILE_LIST "${SENTIL_LICENSE_MIT}" "${SENTIL_LICENSE_APACHE}")

--- a/ports/sentil/portfile.cmake
+++ b/ports/sentil/portfile.cmake
@@ -1,122 +1,142 @@
-set(SENTIL_VERSION 0.3.0)
-set(SENTIL_RELEASE "https://github.com/sedislab/SENTIL/releases/download/v${SENTIL_VERSION}")
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sedislab/SENTIL
+    REF "v${VERSION}"
+    SHA512 0df1ba3e3867124dd4d4adebcc3311d156ed8e63e9a1ae2ceff2a038a69b23fc37b922b92b063d2a0d0399cf5f7b1d6797f71a1dff3ce2e38239de317f2cd0e8
+    HEAD_REF main
+)
+
+# The core is a Rust cdylib, so the release distfile will produce that binary but the cpp will be built from source
+if(VCPKG_TARGET_IS_LINUX)
+    set(core_bundle "sentil-${VERSION}-linux-x86_64")
+    set(core_sha512 42ad31693badb2cf1660dca250be3e6f490fbb6bf93e1d9ede0408db8c11e20d8e316445a74b6c318d6d5f3f85e237fa0405d629492056d954d566486788a0fa)
+    set(core_binary "libsentil.so")
+elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(core_bundle "sentil-${VERSION}-macos-arm64")
+    set(core_sha512 464f1e56348e2fb25cc30dd70470ca8551810027e827c6c52d4bd94ea766616515d16e2efe5176e3eb6145a23d44f462b18780acf8456b3d376c373a8a8eeb87)
+    set(core_binary "libsentil.dylib")
+elseif(VCPKG_TARGET_IS_OSX)
+    set(core_bundle "sentil-${VERSION}-macos-x86_64")
+    set(core_sha512 2328dd5c1c31a3c5f355122723ccbb293c02010f58ac3019e11687191269e73cfa1fc747544e50ccdb22bf104f5ab0c38a01bc3456a30fc26532cc038daabb8b)
+    set(core_binary "libsentil.dylib")
+else()
+    set(core_bundle "sentil-${VERSION}-windows-x86_64")
+    set(core_sha512 f0e2ef0edd5793d53b4b405269e22e1b711f367febe35df0ea0b65ae56f76f41d7490ce6d8ffdcbf87c09ff9a253d497d985e2767eee5fc7562b635222475907)
+    set(core_binary "sentil.dll")
+    # Pushed by upstream and linked
+    set(VCPKG_POLICY_SKIP_CRT_LINKAGE_CHECK enabled)
+endif()
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+vcpkg_download_distfile(CORE_ARCHIVE
+    URLS "https://github.com/sedislab/SENTIL/releases/download/v${VERSION}/${core_bundle}.tar.gz"
+    FILENAME "${core_bundle}.tar.gz"
+    SHA512 "${core_sha512}"
+)
+
+vcpkg_extract_source_archive(CORE_PATH
+    ARCHIVE "${CORE_ARCHIVE}"
+    SOURCE_BASE "${core_bundle}"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/sentil-cpp"
+    OPTIONS
+        -DSENTIL_CPP_BUILD_CORE=OFF
+        -DSENTIL_CPP_BUILD_TESTS=OFF
+        -DSENTIL_CPP_BUILD_EXAMPLES=OFF
+        "-DSENTIL_INCLUDE_DIR=${CORE_PATH}/include"
+        "-DSENTIL_LIB_DIR=${CORE_PATH}/lib"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME sentilcpp CONFIG_PATH lib/cmake/SentilCpp)
+
+file(INSTALL "${SOURCE_PATH}/sentil-ffi/include/sentil.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
 if(VCPKG_TARGET_IS_LINUX)
-    if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-        message(FATAL_ERROR "sentil ships a prebuilt bundle for linux-x86_64 only.")
-    endif()
-    set(SENTIL_PLATFORM "linux-x86_64")
-    set(SENTIL_SHA512 "42ad31693badb2cf1660dca250be3e6f490fbb6bf93e1d9ede0408db8c11e20d8e316445a74b6c318d6d5f3f85e237fa0405d629492056d954d566486788a0fa")
-    set(SENTIL_SHARED "libsentil.so")
-    set(SENTIL_STATIC "libsentil.a")
+    vcpkg_find_acquire_program(PATCHELF)
+    set(core_id_command "${PATCHELF}" --set-soname "${core_binary}")
 elseif(VCPKG_TARGET_IS_OSX)
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-        set(SENTIL_PLATFORM "macos-x86_64")
-        set(SENTIL_SHA512 "2328dd5c1c31a3c5f355122723ccbb293c02010f58ac3019e11687191269e73cfa1fc747544e50ccdb22bf104f5ab0c38a01bc3456a30fc26532cc038daabb8b")
-    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        set(SENTIL_PLATFORM "macos-arm64")
-        set(SENTIL_SHA512 "464f1e56348e2fb25cc30dd70470ca8551810027e827c6c52d4bd94ea766616515d16e2efe5176e3eb6145a23d44f462b18780acf8456b3d376c373a8a8eeb87")
+    set(core_id_command install_name_tool -id "@rpath/${core_binary}")
+endif()
+
+set(core_configs release debug)
+if(VCPKG_BUILD_TYPE)
+    set(core_configs "${VCPKG_BUILD_TYPE}")
+endif()
+
+foreach(config IN LISTS core_configs)
+    set(prefix "${CURRENT_PACKAGES_DIR}")
+    if(config STREQUAL "debug")
+        string(APPEND prefix "/debug")
+    endif()
+    if(VCPKG_TARGET_IS_WINDOWS)
+        file(INSTALL "${CORE_PATH}/lib/${core_binary}" DESTINATION "${prefix}/bin")
+        file(INSTALL "${CORE_PATH}/lib/sentil.dll.lib" DESTINATION "${prefix}/lib")
     else()
-        message(FATAL_ERROR "sentil ships a prebuilt bundle for macos x86_64 and arm64 only.")
+        file(INSTALL "${CORE_PATH}/lib/${core_binary}" DESTINATION "${prefix}/lib" USE_SOURCE_PERMISSIONS)
+        vcpkg_execute_required_process(
+            COMMAND ${core_id_command} "${prefix}/lib/${core_binary}"
+            WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}"
+            LOGNAME "library-id-${config}-${TARGET_TRIPLET}"
+        )
     endif()
-    set(SENTIL_SHARED "libsentil.dylib")
-    set(SENTIL_STATIC "libsentil.a")
-elseif(VCPKG_TARGET_IS_WINDOWS)
-    if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-        message(FATAL_ERROR "sentil ships a prebuilt bundle for windows-x86_64 only.")
-    endif()
-    set(SENTIL_PLATFORM "windows-x86_64")
-    set(SENTIL_SHA512 "f0e2ef0edd5793d53b4b405269e22e1b711f367febe35df0ea0b65ae56f76f41d7490ce6d8ffdcbf87c09ff9a253d497d985e2767eee5fc7562b635222475907")
-    set(SENTIL_SHARED "sentil.dll")
-    set(SENTIL_IMPORT_LIB "sentil.dll.lib")
+    file(INSTALL "${CORE_PATH}/lib/pkgconfig/sentil.pc" DESTINATION "${prefix}/lib/pkgconfig")
+endforeach()
+
+vcpkg_fixup_pkgconfig()
+
+if("release" IN_LIST core_configs)
+    set(default_config "Release")
 else()
-    message(FATAL_ERROR "sentil has no prebuilt bundle for this platform.")
+    set(default_config "Debug")
+endif()
+set(mapped_configs MINSIZEREL RELWITHDEBINFO NOCONFIG)
+if(NOT "debug" IN_LIST core_configs)
+    list(APPEND mapped_configs DEBUG)
+elseif(NOT "release" IN_LIST core_configs)
+    list(APPEND mapped_configs RELEASE)
 endif()
 
-set(SENTIL_BUNDLE "sentil-${SENTIL_VERSION}-${SENTIL_PLATFORM}")
-
-vcpkg_download_distfile(SENTIL_ARCHIVE
-    URLS "${SENTIL_RELEASE}/${SENTIL_BUNDLE}.tar.gz"
-    FILENAME "${SENTIL_BUNDLE}.tar.gz"
-    SHA512 "${SENTIL_SHA512}"
-)
-
-vcpkg_extract_source_archive(SENTIL_SRC
-    ARCHIVE "${SENTIL_ARCHIVE}"
-    SOURCE_BASE "${SENTIL_BUNDLE}"
-)
-
-file(INSTALL "${SENTIL_SRC}/include/sentil.h"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-file(INSTALL "${SENTIL_SRC}/include/sentil"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-
-if(VCPKG_TARGET_IS_WINDOWS)
-    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_IMPORT_LIB}"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_IMPORT_LIB}"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-else()
-    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-    file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_SHARED}"
-        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-    if(EXISTS "${SENTIL_SRC}/lib/${SENTIL_STATIC}")
-        file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_STATIC}"
-            DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-        file(INSTALL "${SENTIL_SRC}/lib/${SENTIL_STATIC}"
-            DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
-    endif()
-endif()
-
-if(EXISTS "${SENTIL_SRC}/lib/pkgconfig/sentil.pc")
-    file(READ "${SENTIL_SRC}/lib/pkgconfig/sentil.pc" SENTIL_PC)
-    string(REGEX REPLACE "prefix=[^\n]*" "prefix=\${pcfiledir}/../.." SENTIL_PC_REL "${SENTIL_PC}")
-    file(WRITE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sentil.pc" "${SENTIL_PC_REL}")
-    file(WRITE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sentil.pc" "${SENTIL_PC_REL}")
-    vcpkg_fixup_pkgconfig()
-endif()
-
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/SentilConfig.cmake"
-"set(SENTIL_VERSION ${SENTIL_VERSION})
-
-get_filename_component(SENTIL_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}/../..\" ABSOLUTE)
-set(SENTIL_INCLUDE_DIR \"\${SENTIL_PREFIX}/include\")
-set(SENTIL_LIBRARY \"\${SENTIL_PREFIX}/lib/\${CMAKE_SHARED_LIBRARY_PREFIX}sentil\${CMAKE_SHARED_LIBRARY_SUFFIX}\")
+set(sentil_config "${CURRENT_PACKAGES_DIR}/share/${PORT}/SentilConfig.cmake")
+file(WRITE "${sentil_config}" "set(SENTIL_VERSION ${VERSION})\n")
+file(APPEND "${sentil_config}" [[
+get_filename_component(SENTIL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(SENTIL_INCLUDE_DIR "${SENTIL_PREFIX}/include")
 
 if(NOT TARGET Sentil::sentil)
     add_library(Sentil::sentil SHARED IMPORTED)
-    set_target_properties(Sentil::sentil PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES \"\${SENTIL_INCLUDE_DIR}\")
-    if(WIN32)
-        set_target_properties(Sentil::sentil PROPERTIES
-            IMPORTED_LOCATION \"\${SENTIL_PREFIX}/bin/sentil.dll\"
-            IMPORTED_IMPLIB \"\${SENTIL_PREFIX}/lib/sentil.dll.lib\")
-    else()
-        set_target_properties(Sentil::sentil PROPERTIES
-            IMPORTED_LOCATION \"\${SENTIL_LIBRARY}\")
+    set_property(TARGET Sentil::sentil PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SENTIL_INCLUDE_DIR}")
+]])
+foreach(mapped IN LISTS mapped_configs)
+    file(APPEND "${sentil_config}"
+        "    set_property(TARGET Sentil::sentil PROPERTY MAP_IMPORTED_CONFIG_${mapped} ${default_config})\n")
+endforeach()
+foreach(config IN LISTS core_configs)
+    string(TOUPPER "${config}" config_id)
+    set(config_prefix [[${SENTIL_PREFIX}]])
+    if(config STREQUAL "debug")
+        string(APPEND config_prefix "/debug")
     endif()
-endif()
-"
-)
+    file(APPEND "${sentil_config}"
+        "    set_property(TARGET Sentil::sentil APPEND PROPERTY IMPORTED_CONFIGURATIONS ${config_id})\n")
+    if(VCPKG_TARGET_IS_WINDOWS)
+        file(APPEND "${sentil_config}"
+            "    set_target_properties(Sentil::sentil PROPERTIES\n"
+            "        IMPORTED_LOCATION_${config_id} \"${config_prefix}/bin/${core_binary}\"\n"
+            "        IMPORTED_IMPLIB_${config_id} \"${config_prefix}/lib/sentil.dll.lib\")\n")
+    else()
+        file(APPEND "${sentil_config}"
+            "    set_property(TARGET Sentil::sentil PROPERTY IMPORTED_LOCATION_${config_id} \"${config_prefix}/lib/${core_binary}\")\n")
+    endif()
+endforeach()
+file(APPEND "${sentil_config}" "endif()\n")
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-vcpkg_download_distfile(SENTIL_LICENSE_MIT
-    URLS "https://raw.githubusercontent.com/sedislab/SENTIL/v${SENTIL_VERSION}/LICENSE-MIT"
-    FILENAME "sentil-${SENTIL_VERSION}-LICENSE-MIT"
-    SHA512 "fca06c4f0b5d87bacb8180552cd78fcff29920cb8c916bc4407904cd61dcda956fc2a77225cc2df61a88048a29d4e5ba6e782a7f87070134dd318dadd92f5fd4"
-)
-vcpkg_download_distfile(SENTIL_LICENSE_APACHE
-    URLS "https://raw.githubusercontent.com/sedislab/SENTIL/v${SENTIL_VERSION}/LICENSE-APACHE"
-    FILENAME "sentil-${SENTIL_VERSION}-LICENSE-APACHE"
-    SHA512 "1893a8f4251653e1b0a62983d0c1b049e0e178dc493d74bd035bccf0286be35d57db437a7c011eabe44ba166730f1801a8c761c9ab560651dd5f258a264dddd7"
-)
-vcpkg_install_copyright(FILE_LIST "${SENTIL_LICENSE_MIT}" "${SENTIL_LICENSE_APACHE}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-MIT" "${SOURCE_PATH}/LICENSE-APACHE")

--- a/ports/sentil/usage
+++ b/ports/sentil/usage
@@ -1,0 +1,12 @@
+sentil provides CMake and pkg-config integration.
+
+    find_package(Sentil CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Sentil::sentil)
+
+With pkg-config:
+
+    pkg-config --cflags --libs sentil
+
+The header is included as:
+
+    #include <sentil.h>

--- a/ports/sentil/usage
+++ b/ports/sentil/usage
@@ -1,12 +1,13 @@
-sentil provides CMake and pkg-config integration.
+sentil provides CMake targets:
+
+    find_package(SentilCpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Sentil::cpp)
+
+To use the C API on its own:
 
     find_package(Sentil CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Sentil::sentil)
 
-With pkg-config:
+sentil provides pkg-config modules:
 
-    pkg-config --cflags --libs sentil
-
-The header is included as:
-
-    #include <sentil.h>
+    sentil

--- a/ports/sentil/vcpkg.json
+++ b/ports/sentil/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "sentil",
+  "version": "0.3.0",
+  "description": "Runtime verification for Signal Temporal Logic and its probabilistic extension PrSTL. This port installs the prebuilt SENTIL C ABI: the sentil.h header, the shared and static libraries, the pkg-config file, and a CMake package config exposing the Sentil::sentil target.",
+  "homepage": "https://github.com/sedislab/SENTIL",
+  "license": "MIT OR Apache-2.0",
+  "supports": "(linux & x64) | (osx & (x64 | arm64)) | (windows & x64)"
+}

--- a/ports/sentil/vcpkg.json
+++ b/ports/sentil/vcpkg.json
@@ -1,8 +1,19 @@
 {
   "name": "sentil",
   "version": "0.3.0",
-  "description": "Runtime verification for Signal Temporal Logic and its probabilistic extension PrSTL. This port installs the prebuilt SENTIL C ABI: the sentil.h header, the shared and static libraries, the pkg-config file, and a CMake package config exposing the Sentil::sentil target.",
+  "description": "Runtime verification for Signal Temporal Logic and its probabilistic extension PrSTL. Provides offline and streaming monitors, statistical model checking, and controller synthesis behind a C ABI with a C++17 header interface.",
   "homepage": "https://github.com/sedislab/SENTIL",
+  "documentation": "https://sentil.pages.dev",
   "license": "MIT OR Apache-2.0",
-  "supports": "(linux & x64) | (osx & (x64 | arm64)) | (windows & x64)"
+  "supports": "(linux & x64) | (osx & (x64 | arm64)) | (windows & x64 & !uwp & !mingw)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9248,6 +9248,10 @@
       "baseline": "0.2.1",
       "port-version": 0
     },
+    "sentil": {
+      "baseline": "0.3.0",
+      "port-version": 0
+    },
     "sentry-native": {
       "baseline": "0.16.1",
       "port-version": 0

--- a/versions/s-/sentil.json
+++ b/versions/s-/sentil.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c1ad7838873637f05db3f46e885e5c1c6b0826c0",
+      "version": "0.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds the `sentil` port at 0.3.0. And regarding the question from the previous submission, this is consumed as a C and C++ library. This port has a C-ABI header over a Rust core and it's used as any regular C or C++ library.