### PR TITLE
[fastdds] Update to 3.6.2

### DIFF
--- a/ports/fastdds/disable-autolink.patch
+++ b/ports/fastdds/disable-autolink.patch
@@ -1,0 +1,15 @@
+diff --git a/include/fastdds/fastdds_dll.hpp b/include/fastdds/fastdds_dll.hpp
+index ec2e54882..5b0e6d77e 100644
+--- a/include/fastdds/fastdds_dll.hpp
++++ b/include/fastdds/fastdds_dll.hpp
+@@ -18,6 +18,10 @@
+ 
+ #include <fastdds/config.hpp>
+ 
++#if defined(_WIN32) && !defined(FASTDDS_NO_LIB)
++#define FASTDDS_NO_LIB
++#endif
++
+ // normalize macros
+ #if !defined(FASTDDS_DYN_LINK) && !defined(FASTDDS_STATIC_LINK) \
+     && !defined(EPROSIMA_ALL_DYN_LINK) && !defined(EPROSIMA_ALL_STATIC_LINK)

--- a/ports/fastdds/fix-deps.patch
+++ b/ports/fastdds/fix-deps.patch
@@ -41,3 +41,15 @@ index 070597df6..c0b2d6b64 100644
      $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto$<$<BOOL:${WIN32}>:$<SEMICOLON>crypt32.lib>>
      $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
      ${THIRDPARTY_BOOST_LINK_LIBS}
+diff --git a/cmake/packaging/Config.cmake.in b/cmake/packaging/Config.cmake.in
+index 0fe3d9589..26134720c 100644
+--- a/cmake/packaging/Config.cmake.in
++++ b/cmake/packaging/Config.cmake.in
+@@ -24,6 +24,7 @@ include(CMakeFindDependencyMacro)
+ 
+ find_dependency(fastcdr REQUIRED)
+ find_dependency(foonathan_memory REQUIRED)
++find_dependency(nlohmann_json CONFIG)
+ 
+ set(fastdds_known_comps static shared)
+ set(fastdds_comp_static NO)

--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-DDS
     REF "v${VERSION}"
-    SHA512 c5758001b73624e9bfc2684e1c01b6f8f90c785ea23e67d1a554fc45b061fb59cc5865fb4784953fe527c8158e158326bc3503bcadbb38a6f3da1affb6062a9e
+    SHA512 f9cba9b881b5b34ad496e2123dd1f3303936eab2a0b985207f470e6b5a91a99e8a0d96fa5596bc2ff4babc348e2f2f91a90e612fa9b7c1de2424e036b8d2366a
     HEAD_REF master
     PATCHES
         fix-deps.patch

--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-deps.patch
+        disable-autolink.patch
         pdb-file.patch
         disable-test.patch
         disable-werror.patch
@@ -34,14 +35,19 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/fastdds/cmake)
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    # copy tools from "bin" to "tools" folder
-    foreach(TOOL "fast-discovery-server-1.0.1.exe" "fastdds.bat" "ros-discovery.bat")
+    vcpkg_copy_tools(TOOL_NAMES "fast-discovery-server-1.0.1" AUTO_CLEAN)
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/tools/${PORT}/fast-discovery-server-1.0.1.exe"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
+        RENAME "fast-discovery-server.exe"
+    )
+
+    foreach(TOOL "fastdds.bat" "ros-discovery.bat")
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${TOOL}")
     endforeach()
 
-    # remove tools from debug builds
-    foreach(TOOL "fast-discovery-serverd-1.0.1.exe" "fastdds.bat" "ros-discovery.bat")
+    foreach(TOOL "fast-discovery-server.exe" "fast-discovery-serverd-1.0.1.exe" "fastdds.bat" "ros-discovery.bat")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${TOOL}")
         if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
             file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
         endif()
@@ -51,7 +57,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fastdds.bat" "%dir%\\..\\tools\\fastdds\\fastdds.py" "%dir%\\..\\fastdds\\fastdds.py")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/ros-discovery.bat" "%dir%\\..\\tools\\fastdds\\fastdds.py" "%dir%\\..\\fastdds\\fastdds.py")
 
-    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 elseif(VCPKG_TARGET_IS_LINUX)
     # copy tools from "bin" to "tools" folder
     foreach(TOOL "fast-discovery-server-1.0.1" "fast-discovery-server" "fastdds" "ros-discovery")
@@ -85,4 +90,13 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/thirdparty/boost/LICENSE.TXT"
+        "${SOURCE_PATH}/thirdparty/filewatch/LICENSE"
+        "${SOURCE_PATH}/thirdparty/optionparser/optionparser.hpp"
+        "${SOURCE_PATH}/thirdparty/optionparser/optionparser/optionparser.h"
+        "${SOURCE_PATH}/thirdparty/taocpp-pegtl/pegtl.hpp"
+        "${SOURCE_PATH}/src/cpp/rtps/persistence/sqlite3.h"
+)

--- a/ports/fastdds/usage
+++ b/ports/fastdds/usage
@@ -2,4 +2,3 @@ fastdds provides CMake targets:
 
   find_package(fastdds CONFIG REQUIRED)
   target_link_libraries(main PRIVATE fastdds)
-    

--- a/ports/fastdds/vcpkg.json
+++ b/ports/fastdds/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastdds",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/ports/fastdds/vcpkg.json
+++ b/ports/fastdds/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.6.2",
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0 AND BSL-1.0 AND MIT AND blessing",
   "supports": "!uwp",
   "dependencies": [
     "asio",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2985,7 +2985,7 @@
       "port-version": 1
     },
     "fastdds": {
-      "baseline": "3.6.1",
+      "baseline": "3.6.2",
       "port-version": 0
     },
     "fastfeat": {

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "897728b21882fca8e8ab2ce2f96f67629b753061",
+      "version": "3.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1805d932aaba59225ad287347906a3e62220da47",
       "version": "3.6.1",
       "port-version": 0

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "897728b21882fca8e8ab2ce2f96f67629b753061",
+      "git-tree": "fb2b53f00db6d3ba62b8bde1cca52a7a26710a66",
       "version": "3.6.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.