### PR TITLE
[librats] Add new librats 2.0.12

### DIFF
--- a/ports/librats/portfile.cmake
+++ b/ports/librats/portfile.cmake
@@ -1,0 +1,64 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO librats/librats
+    REF "${VERSION}"
+    SHA512 09c330972ffaeec5621d63b1a43598fbe40bb497b21eff0252392551943d7d7512fdd76d8da983eea80e487a8665cfc79f0d05248e5b63f9ce733349ed5d6079
+    HEAD_REF master
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        bindings         RATS_BINDINGS
+        search-features  RATS_SEARCH_FEATURES
+        storage          RATS_STORAGE
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" RATS_SHARED)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RATS_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DRATS_SHARED_LIBRARY=${RATS_SHARED}
+        -DRATS_STATIC_LIBRARY=${RATS_STATIC}
+        -DRATS_BUILD_TESTS=OFF
+        -DRATS_BUILD_CLIENT=OFF
+        -DRATS_BUILD_EXAMPLES=OFF
+        -DRATS_INSTALL=ON
+        -DRATS_VERSION_OVERRIDE=${VERSION}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME rats CONFIG_PATH lib/cmake/rats)
+
+# Headers only — drop debug copy and any binaries that landed under share/.
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+# librats is MIT, but it embeds adapted single-primitive crypto sources and, for
+# Android API < 24, a getifaddrs() shim. Each keeps its own notice; see
+# THIRD_PARTY_NOTICES.md upstream for provenance and the list of modifications.
+vcpkg_install_copyright(
+    COMMENT [[
+librats is licensed under the MIT license. It additionally embeds adapted
+third-party sources that carry their own notices, reproduced below:
+
+  * src/librats/crypto/curve25519.*  curve25519-donna     BSD-3-Clause
+  * src/librats/crypto/poly1305.*    poly1305-donna       MIT
+  * src/librats/crypto/{chacha,sha256,sha512,blake2*}.*
+                                   noise-c                MIT
+  * 3rdparty/android/ifaddrs-*     ifaddrs-android        BSD-2-Clause AND
+                                   (Android API < 24)     BSD-1-Clause
+]]
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/licenses/curve25519-donna.LICENSE"
+        "${SOURCE_PATH}/licenses/poly1305-donna.LICENSE"
+        "${SOURCE_PATH}/licenses/noise-c.LICENSE"
+        "${SOURCE_PATH}/licenses/ifaddrs-android.LICENSE"
+)

--- a/ports/librats/vcpkg.json
+++ b/ports/librats/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "librats",
+  "version": "2.0.12",
+  "description": "C++17 peer-to-peer networking library: encrypted P2P (Noise XX), DHT/mDNS discovery, NAT traversal (STUN/UPnP/NAT-PMP), GossipSub pub/sub, file transfer, optional BitTorrent.",
+  "homepage": "https://github.com/librats/librats",
+  "license": "MIT AND BSD-3-Clause AND BSD-2-Clause AND BSD-1-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "bindings": {
+      "description": "Build the C API used by Node.js / Python / Java bindings"
+    },
+    "search-features": {
+      "description": "Enable BitTorrent client (bt_*, tracker, disk_io, info_hash spider)"
+    },
+    "storage": {
+      "description": "Enable distributed key-value storage module"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5592,6 +5592,10 @@
       "baseline": "0.11.0",
       "port-version": 0
     },
+    "librats": {
+      "baseline": "2.0.12",
+      "port-version": 0
+    },
     "libraw": {
       "baseline": "0.22.1",
       "port-version": 0

--- a/versions/l-/librats.json
+++ b/versions/l-/librats.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2e04d8f8355d7a4ccd61e9faaf369981ee00e645",
+      "version": "2.0.12",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
  Adds a new port for [librats](https://github.com/librats/librats) — an MIT-licensed C++17 peer-to-peer networking library: encrypted transport (Noise_XX), peer discovery (Kademlia DHT, mDNS), NAT traversal (STUN/UPnP/NAT-PMP), GossipSub pub/sub, file transfer, and an optional BitTorrent stack. It has no external dependencies beyond platform sockets and threads.

  - [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
  - [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
      - [x] Has a release at least 6 months old or 6 months of demonstrated public development
      - [ ] Is an official component of something else meeting that criteria
      - [ ] Some other reason (please explain)
  - [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
      - [ ] The project is in Repology: https://repology.org/project/librats/versions
      - [x] The project is amongst the first web search results for "librats" or "librats C++". Include a screenshot of the search engine results in the PR.
      - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
  - [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
  - [x] The versioning scheme in `vcpkg.json` matches what upstream says.
  - [x] The license declaration in `vcpkg.json` matches what upstream says.
  - [x] The installed as the "copyright" file matches what upstream says.
  - [x] The source code of the component installed comes from an authoritative source.
  - [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
  - [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
  - [x] Exactly one version is added in each modified versions file.

<img width="890" height="720" alt="image" src="https://github.com/user-attachments/assets/98b1f7ad-9d21-4d03-b642-95b18111ea84" />
