### PR TITLE
[sentry-native] update to 0.16.2

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 1e959348630e8de323390a44bb465c7326f8d393235a4ac7a04631d2b6f324294c0ef7359adb4662ceb4150a2fe8b0cf46e3e288eea1176374601a193484b876
+    SHA512 6f98fa3ab389a8d33535f3a9edeac1d0c2a8edaa822bc069d216f233d48805d8e9949a2aaeb462b530401e4e7b024bb8dff3cc7ed559a6c146c583d5e002f4cc
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT AND Apache-2.0 AND BSD-3-Clause AND ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9249,7 +9249,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.16.1",
+      "baseline": "0.16.2",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53dae28ea8c49da902c5fb9cebcd55e6c2d312ff",
+      "version": "0.16.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b61424d075c0718f649439e7ce16986b25e098b",
       "version": "0.16.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
