### PR TITLE
[curve-coco] Update to 4.7.2

### DIFF
--- a/ports/curve-coco/portfile.cmake
+++ b/ports/curve-coco/portfile.cmake
@@ -1,9 +1,8 @@
-set(VCPKG_BUILD_TYPE release) # Header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/coco
     REF "v${VERSION}"
-    SHA512 7c011553834dba0030ad01d45fcdd3b092ca1b30ccb6f500bbc3e53ed5ee3c0eb57a581347f9879e5b3746cdc3e3214d41329a6ef04988c64c9f55350d8948a3
+    SHA512 b2ed5eaddbbec115d61fc044c6ac56cfef67e871bd44e4717cd64c998a2038195a5caa70e3351efc2c04ccbc69834ffd2e6bbe15331521a1cd33b19155534c7b
     HEAD_REF master
     PATCHES
         remove-cpm.patch
@@ -22,8 +21,8 @@ file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco-${VERSION}" PACKAGE_NAME "coco")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco-4.7.1" PACKAGE_NAME "coco") # 4.7.2 was released with wrong version
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")  # from CMake config
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/curve-coco/portfile.cmake
+++ b/ports/curve-coco/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/coco
@@ -21,7 +23,7 @@ file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco-4.7.1" PACKAGE_NAME "coco") # 4.7.2 was released with wrong version
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco" PACKAGE_NAME "coco")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/curve-coco/remove-cpm.patch
+++ b/ports/curve-coco/remove-cpm.patch
@@ -1,7 +1,14 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 387fc02..8ba9eb7 100644
+index 387fc02..a16af04 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ cmake_minimum_required(VERSION 3.25)
+-project(coco LANGUAGES CXX VERSION 4.7.1)
++project(coco LANGUAGES CXX VERSION 4.7.2)
+ 
+ # +-------------------------------------------------------------------------------------------------------+
+ # | Library Options                                                                                       |
 @@ -14,7 +14,6 @@ option(coco_exceptions "Enable exception support (Respects -fno-exceptions even
  # +-------------------------------------------------------------------------------------------------------+
  
@@ -10,6 +17,15 @@ index 387fc02..8ba9eb7 100644
  
  target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
  set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED ON)
+@@ -33,7 +32,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE "include/coco")
+ 
+ target_include_directories(
+   ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+-                         $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
++                         $<INSTALL_INTERFACE:include>
+ )
+ 
+ # +-------------------------------------------------------------------------------------------------------+
 @@ -55,13 +54,7 @@ if (NOT coco_install)
    return()
  endif()
@@ -25,3 +41,12 @@ index 387fc02..8ba9eb7 100644
  
  packageProject(
    NAMESPACE cr
+@@ -69,5 +62,7 @@ packageProject(
+   VERSION ${PROJECT_VERSION}
+   BINARY_DIR ${PROJECT_BINARY_DIR}
+   INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
+-  INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
++  INCLUDE_DESTINATION include
++  DISABLE_VERSION_SUFFIX YES
++  RUNTIME_DESTINATION "."
+ )

--- a/ports/curve-coco/remove-cpm.patch
+++ b/ports/curve-coco/remove-cpm.patch
@@ -1,18 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3a2434c..ae2b342 100644
+index 387fc02..8ba9eb7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -13,7 +13,6 @@ option(coco_exceptions "Enable exception support (Respects -fno-exceptions even
+@@ -14,7 +14,6 @@ option(coco_exceptions "Enable exception support (Respects -fno-exceptions even
  # +-------------------------------------------------------------------------------------------------------+
  
- add_library(${PROJECT_NAME} STATIC "src/latch.cpp" "src/stray.cpp")
+ add_library(${PROJECT_NAME} STATIC "src/latch.cpp" "src/stray.cpp" "src/courier.cpp")
 -add_library(cr::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
  
  target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
  set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED ON)
-@@ -50,13 +49,7 @@ endif()
- # | Package Config                                                                                        |
- # +-------------------------------------------------------------------------------------------------------+
+@@ -55,13 +54,7 @@ if (NOT coco_install)
+   return()
+ endif()
  
 -include("cmake/cpm.cmake")
 -

--- a/ports/curve-coco/vcpkg.json
+++ b/ports/curve-coco/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "curve-coco",
-  "version": "4.3.0",
+  "version": "4.7.2",
   "description": "a C++20 coroutine library that aims to be convenient and simple to use.",
   "homepage": "https://github.com/Curve/coco",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2309,7 +2309,7 @@
       "port-version": 11
     },
     "curve-coco": {
-      "baseline": "4.3.0",
+      "baseline": "4.7.2",
       "port-version": 0
     },
     "curve-eraser": {

--- a/versions/c-/curve-coco.json
+++ b/versions/c-/curve-coco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f24fe41079a13fb0ea880a981debbfbacae0d1e3",
+      "version": "4.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "428adea8bb4f40ac5b13d1331ea8e5a6a7d9abb9",
       "version": "4.3.0",
       "port-version": 0

--- a/versions/c-/curve-coco.json
+++ b/versions/c-/curve-coco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f24fe41079a13fb0ea880a981debbfbacae0d1e3",
+      "git-tree": "0a975a04c90f04e3e54aa07e9d3304e625cbf675",
       "version": "4.7.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
