### PR TITLE
[pipeql] Add port

### DIFF
--- a/ports/pipeql/portfile.cmake
+++ b/ports/pipeql/portfile.cmake
@@ -1,0 +1,53 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Flaxmbot/PipeQL
+    REF v1.1.4
+    SHA512 5f5327e91eb27afef83ac4d51c4ea6f5b53cb485a240e405c2f6a5a5600b7ad9475746d53ec5002a6894dff0a5a0bd9c9e5886e4060e781d114dea5e5377f53b
+    HEAD_REF master
+)
+
+# Rust toolchain is not shipped with vcpkg - acquire cargo + rustc on demand.
+vcpkg_find_acquire_program(RUSTC)
+vcpkg_find_acquire_program(CARGO)
+
+set(ENV{CARGO_HOME} "${CURRENT_BUILDTREES_DIR}/cargo-home")
+
+vcpkg_execute_required_process(
+    COMMAND "${CARGO}" build --release
+        -p pipeql-cffi
+        --target-dir "${CURRENT_BUILDTREES_DIR}/cargo-target"
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME "cargo-build-${TARGET_TRIPLET}"
+)
+
+set(CARGO_OUT "${CURRENT_BUILDTREES_DIR}/cargo-target/release")
+
+# Header
+file(INSTALL "${SOURCE_PATH}/crates/pipeql-cffi/include/libpipeql.h"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# Shared library + import/static libs (platform specific names)
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL "${CARGO_OUT}/pipeql_cffi.dll"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    if(EXISTS "${CARGO_OUT}/pipeql_cffi.lib")
+        file(INSTALL "${CARGO_OUT}/pipeql_cffi.lib"
+             DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+    if(EXISTS "${CARGO_OUT}/pipeql_cffi.dll.lib")
+        file(INSTALL "${CARGO_OUT}/pipeql_cffi.dll.lib"
+             DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+    if(EXISTS "${CARGO_OUT}/libpipeql_cffi.dll.a")
+        file(INSTALL "${CARGO_OUT}/libpipeql_cffi.dll.a"
+             DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+elseif(VCPKG_TARGET_IS_OSX)
+    file(INSTALL "${CARGO_OUT}/libpipeql_cffi.dylib"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+else()
+    file(INSTALL "${CARGO_OUT}/libpipeql_cffi.so"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/pipeql/vcpkg.json
+++ b/ports/pipeql/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "pipeql",
+  "version": "1.1.4",
+  "description": "Pipelined, injection-safe polyglot query language - C SDK (libpipeql)",
+  "homepage": "https://github.com/Flaxmbot/PipeQL",
+  "license": "MIT",
+  "supports": "!(x86 | arm | arm64 | uwp)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7832,6 +7832,10 @@
       "baseline": "2019-07-11",
       "port-version": 2
     },
+    "pipeql": {
+      "baseline": "1.1.4",
+      "port-version": 0
+    },
     "pipewire": {
       "baseline": "1.6.7",
       "port-version": 0

--- a/versions/p-/pipeql.json
+++ b/versions/p-/pipeql.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b9dfd42db4648fad53bc7f9623c8e0b5b13399c8",
+      "version": "1.1.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Port name:** pipeql
**Version:** 1.1.4

Pipelined, injection-safe polyglot query language — C SDK (`libpipeql`).

The port downloads the `v1.1.4` source tarball from `Flaxmbot/PipeQL`,
builds the Rust `pipeql-cffi` crate with `cargo build --release` (cargo/rustc
acquired via `vcpkg_find_acquire_program`), and installs `libpipeql.h` plus
the platform shared library (`pipeql_cffi.dll` / `libpipeql_cffi.so` /
`libpipeql_cffi.dylib`) and import/static libs.

- `supports` is restricted to `!(x86 | arm | arm64 | uwp)` — the port builds
  with Rust's host toolchain, and cross-compiling to non-host targets
  requires `rustup target add <triple>`, which is out of scope for this
  initial port.
- Verified locally: `cargo build --release -p pipeql-cffi --target-dir ...`
  compiles cleanly and produces the expected artifacts on Windows.

- [x] I've read the [contributing guidelines](https://github.com/microsoft/vcpkg/blob/master/CONTRIBUTING.md)
- [x] `./vcpkg x-add-version pipeql` completed successfully