### PR TITLE
[mariadb-connector-cpp] update to 1.1.8

### DIFF
--- a/ports/mariadb-connector-cpp/crt-linkage.diff
+++ b/ports/mariadb-connector-cpp/crt-linkage.diff
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -422,7 +422,6 @@ IF(WIN32)
+         SET(COMPILER_FLAGS "${CMAKE_${COMPILER}_FLAGS_${BUILD_TYPE}}")
+         IF (NOT COMPILER_FLAGS STREQUAL "")
+           IF(NOT WITH_ASAN)
+-            STRING(REPLACE "/MD" "/MT" COMPILER_FLAGS ${COMPILER_FLAGS})
+             STRING(REPLACE "/Zi" "/ZI" COMPILER_FLAGS ${COMPILER_FLAGS})
+           ENDIF(NOT WITH_ASAN)
+           MESSAGE (STATUS "CMAKE_${COMPILER}_FLAGS_${BUILD_TYPE}= ${COMPILER_FLAGS}")

--- a/ports/mariadb-connector-cpp/fix-carray.diff
+++ b/ports/mariadb-connector-cpp/fix-carray.diff
@@ -1,10 +1,10 @@
 diff --git a/include/conncpp/CArray.hpp b/include/conncpp/CArray.hpp
-index f3e4634..e0f62eb 100644
+index 2f48142..1dbac0b 100644
 --- a/include/conncpp/CArray.hpp
 +++ b/include/conncpp/CArray.hpp
-@@ -24,6 +24,7 @@
- #include "buildconf.hpp"
+@@ -25,6 +25,7 @@
  #include <initializer_list>
+ #include <cstdint>
  #include <vector>
 +#include <stdint.h>
  

--- a/ports/mariadb-connector-cpp/portfile.cmake
+++ b/ports/mariadb-connector-cpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO mariadb-corporation/mariadb-connector-cpp
     REF ${VERSION}
     HEAD_REF master
-    SHA512 90ce780e19babda02608134c99e8c0e7601a41ee5531097735beb54ec94c2dd38ecf4f457e9cac04831d7e886fe7c7b7a6d9fe799bf71d52ba168158ec36dc67
+    SHA512 af4659aef378b46eeb7d37388ccbab98d5e1b9d0044325750220dc1a7d1b11d15ab8203768712a359c1126fe753ac0bf893138e92a136f973698338c11cb2ab4
     PATCHES
         fix-carray.diff
         libmariadb.diff

--- a/ports/mariadb-connector-cpp/portfile.cmake
+++ b/ports/mariadb-connector-cpp/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         libmariadb.diff
         mingw.diff
         install.diff
+        crt-linkage.diff
 )
 
 

--- a/ports/mariadb-connector-cpp/vcpkg.json
+++ b/ports/mariadb-connector-cpp/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "mariadb-connector-cpp",
-  "version": "1.1.5",
+  "version": "1.1.8",
   "description": "Connector/c++ for MariaDB.",
-  "homepage": "https://mariadb.com/docs/appdev/connector-cpp/",
+  "homepage": "https://mariadb.com/docs/connectors/mariadb-connector-cpp",
   "license": "LGPL-2.1-or-later",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6449,7 +6449,7 @@
       "port-version": 0
     },
     "mariadb-connector-cpp": {
-      "baseline": "1.1.5",
+      "baseline": "1.1.8",
       "port-version": 0
     },
     "marisa-trie": {

--- a/versions/m-/mariadb-connector-cpp.json
+++ b/versions/m-/mariadb-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a0d951b1e6dc0a2599f1e7acd9b508d871cc4cb",
+      "version": "1.1.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "1983f1fab25432ab561ae4bee2e81243a1af9993",
       "version": "1.1.5",
       "port-version": 0

--- a/versions/m-/mariadb-connector-cpp.json
+++ b/versions/m-/mariadb-connector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a0d951b1e6dc0a2599f1e7acd9b508d871cc4cb",
+      "git-tree": "a91481a6e5a359a8c55db4fd042f6d9239df80c2",
       "version": "1.1.8",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/mariadb-corporation/mariadb-connector-cpp/releases/tag/1.1.8
