### PR TITLE
[wxwidgets] Update to 3.3.3

### DIFF
--- a/ports/wxwidgets/install-layout.patch
+++ b/ports/wxwidgets/install-layout.patch
@@ -1,9 +1,8 @@
 diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
-index f044d22d4d..a78b9aa1e9 100644
 --- a/build/cmake/init.cmake
 +++ b/build/cmake/init.cmake
-@@ -200,12 +200,12 @@ endif()
- 
+@@ -201,11 +201,11 @@ endif()
+ wx_get_install_dir(include)
  if(WIN32_MSVC_NAMING)
      if(wxBUILD_SHARED)
 -        set(lib_suffix "_dll")
@@ -12,35 +11,8 @@ index f044d22d4d..a78b9aa1e9 100644
 -        set(lib_suffix "_lib")
 +        # set(lib_suffix "_lib")
      endif()
- 
 -    set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
 +    # set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
- 
-     # Generator expression to not create different Debug and Release directories
-     set(GEN_EXPR_DIR "$<1:/>")
-diff --git a/build/cmake/install.cmake b/build/cmake/install.cmake
-index a373983043..2e1ace7bf9 100644
---- a/build/cmake/install.cmake
-+++ b/build/cmake/install.cmake
-@@ -63,7 +63,7 @@ else()
- 
-     install(DIRECTORY DESTINATION "bin")
-     install(CODE "execute_process( \
--        COMMAND ${CMAKE_COMMAND} -E create_symlink \
-+        COMMAND ${CMAKE_COMMAND} -E copy \
-         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
-         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
-         )"
-diff --git a/build/cmake/utils/CMakeLists.txt b/build/cmake/utils/CMakeLists.txt
-index 15f4339ef9..f93849e025 100644
---- a/build/cmake/utils/CMakeLists.txt
-+++ b/build/cmake/utils/CMakeLists.txt
-@@ -39,7 +39,7 @@ if(wxUSE_XRC)
- 
-         # Don't use wx_install() here to preserve escaping.
-         install(CODE "execute_process( \
--            COMMAND ${CMAKE_COMMAND} -E create_symlink \
-+            COMMAND ${CMAKE_COMMAND} -E copy \
-             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX}\" \
-             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX}\" \
-             )"
+     set(wxINSTALL_INCLUDE_DIR "${include_dir}")
+ else()
+     wx_get_flavour(lib_flavour "-")

--- a/ports/wxwidgets/libsecret-link-dirs.patch
+++ b/ports/wxwidgets/libsecret-link-dirs.patch
@@ -1,0 +1,15 @@
+diff --git a/build/cmake/lib/base/CMakeLists.txt b/build/cmake/lib/base/CMakeLists.txt
+index 6eed902..ffd095a 100644
+--- a/build/cmake/lib/base/CMakeLists.txt
++++ b/build/cmake/lib/base/CMakeLists.txt
+@@ -46,6 +46,10 @@ if(UNIX AND wxUSE_SECRETSTORE)
+     # requiring it being installed on the target system.
+     list(REMOVE_ITEM LIBSECRET_LIBRARIES secret-1)
+     wx_lib_link_libraries(wxbase PRIVATE ${LIBSECRET_LIBRARIES})
++    # LIBSECRET_LIBRARIES may include transitive deps (gcrypt, gpg-error) that
++    # aren't in the default linker search path; propagate the -L dirs
++    # pkg-config reported so downstream links (wxrc etc.) can find them.
++    wx_lib_link_directories(wxbase PUBLIC ${LIBSECRET_LIBRARY_DIRS})
+ endif()
+ if(wxUSE_LIBICONV)
+     wx_lib_include_directories(wxbase ${ICONV_INCLUDE_DIR})

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
     REF "v${VERSION}"
-    SHA512 8ad17582c4ba721ffe76ada4bb8bd7bc4b050491220aca335fd0506a51354fb789d5bc3d965f0f459dc81784d6427c88272e2acc2099cddf73730231b5a16f62
+    SHA512 c497d6642d6f9fb7f190ab725e3c5ee0e67e96c883eebbe2d7fa7e0b3dec9847871010e53e23c5d46b9158b8a045f162592d0c25f524daedeaca8c1caa555a5a
     HEAD_REF master
     PATCHES
         install-layout.patch
@@ -18,8 +18,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH lexilla_SOURCE_PATH
     REPO wxWidgets/lexilla
-    REF "27c20a6ae5eebf418debeac0166052ed6fb653bc"
-    SHA512 7e5de7f664509473b691af8261fca34c2687772faca7260eeba5f2984516e6f8edf88c27192e056c9dda996e2ad2c20f6d1dff1c4bd2f3c0d74852cb50ca424a
+    REF "bf6ad20062b98808ffa21419263942a427c150a9"
+    SHA512 08360fcd29e6c021857928375509ea48b9c8a02407bcb3c01865f57734c449fc6ff24afbe011f218b7145116e1805f8c9b4a2e3ec26f4a6298dca9453f610887
     HEAD_REF wx
 )
 file(COPY "${lexilla_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/src/stc/lexilla")
@@ -64,6 +64,11 @@ if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX)
 else()
     list(APPEND OPTIONS -DwxUSE_WEBREQUEST_CURL=ON)
 endif()
+
+# Prefer copies over symlinks for the wx-config / wxrc install artifacts.
+# On Windows symlinks require admin; on any platform vcpkg expects real files
+# in its install tree so downstream relocation works.
+list(APPEND OPTIONS -DwxBUILD_INSTALL_USE_SYMLINK=OFF)
 
 if(VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
@@ -127,7 +132,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wxWidgets)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wxWidgets-3.3)
 
 # The CMake export is not ready for use: It lacks a config file.
 file(REMOVE_RECURSE

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -210,6 +210,24 @@ foreach(config IN LISTS configs)
     vcpkg_replace_string("${config}" "${CURRENT_INSTALLED_DIR}/debug" [[${prefix}]])
 endforeach()
 
+# wxWidgets 3.3.3's wx_get_dependencies (build/cmake/config.cmake) leaks raw
+# CMake target names into wx-config's LIBS for imported deps that lack an
+# IMPORTED_LOCATION (i.e. vcpkg's header-only NanoSVG), producing entries like
+# "-lNanoSVG::nanosvg" that later trip target_link_libraries in downstream
+# projects. Strip those; vcpkg-cmake-wrapper.cmake re-adds the real
+# NanoSVG::nanosvg{,rast} targets for static builds. Fix targeted for wx 3.3.4
+# (see wxwidgets/wxWidgets#23373).
+file(GLOB all_configs LIST_DIRECTORIES false
+    "${CURRENT_PACKAGES_DIR}/lib/wx/config/*"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/wx/config/*"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wx-config"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/wx-config")
+foreach(config IN LISTS all_configs)
+    file(READ "${config}" _cfg)
+    string(REGEX REPLACE "-l[A-Za-z0-9_+.-]+::[A-Za-z0-9_+.-]+ *" "" _cfg "${_cfg}")
+    file(WRITE "${config}" "${_cfg}")
+endforeach()
+
 # For CMake multi-config in connection with wrapper
 if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
     file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h"

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-pcre2.patch
         gtk3-link-libraries.patch
         sdl2.patch
+        libsecret-link-dirs.patch
 )
 
 # Submodule dependencies

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -263,4 +263,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/build")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/docs/licence.txt")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/docs/licence.txt"
+        "${lexilla_SOURCE_PATH}/License.txt"
+        "${scintilla_SOURCE_PATH}/License.txt"
+)

--- a/ports/wxwidgets/sdl2.patch
+++ b/ports/wxwidgets/sdl2.patch
@@ -1,10 +1,9 @@
 diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
-index 5447d33..f5440b4 100644
 --- a/build/cmake/init.cmake
 +++ b/build/cmake/init.cmake
-@@ -530,7 +530,9 @@ if(wxUSE_GUI)
+@@ -691,7 +691,9 @@ if(wxUSE_GUI)
      endif()
- 
+
      if(wxUSE_SOUND AND wxUSE_LIBSDL AND UNIX AND NOT APPLE)
 -        find_package(SDL2)
 +        find_package(SDL2 CONFIG REQUIRED)
@@ -12,18 +11,17 @@ index 5447d33..f5440b4 100644
 +        set(SDL2_LIBRARY SDL2::SDL2 CACHE INTERNAL "")
          if(NOT SDL2_FOUND)
              find_package(SDL)
-         endif()
+             mark_as_advanced(SDL_INCLUDE_DIR SDLMAIN_LIBRARY)
 diff --git a/build/cmake/wxWidgetsConfig.cmake.in b/build/cmake/wxWidgetsConfig.cmake.in
-index 60cf762..202a8c3 100644
 --- a/build/cmake/wxWidgetsConfig.cmake.in
 +++ b/build/cmake/wxWidgetsConfig.cmake.in
 @@ -2,6 +2,9 @@
- 
+
  include(CMakeFindDependencyMacro)
  find_dependency(NanoSVG CONFIG)
 +if("@wxUSE_LIBSDL@")
 +    find_dependency(SDL2 CONFIG)
 +endif()
- 
+
  cmake_policy(PUSH)
  # Set policies to prevent warnings

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wxwidgets",
-  "version": "3.3.1",
-  "port-version": 1,
+  "version": "3.3.3",
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -7,7 +7,7 @@
     "Set WXWIDGETS_USE_STD_CONTAINERS in a custom triplet to build with the wxUSE_STD_CONTAINERS build option."
   ],
   "homepage": "https://github.com/wxWidgets/wxWidgets",
-  "license": "LGPL-2.0-or-later WITH WxWindows-exception-3.1",
+  "license": "LGPL-2.0-or-later WITH WxWindows-exception-3.1 AND HPND",
   "supports": "!uwp & !xbox",
   "dependencies": [
     {

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -87,7 +87,13 @@
       ]
     },
     "secretstore": {
-      "description": "Use wxSecretStore class"
+      "description": "Use wxSecretStore class",
+      "dependencies": [
+        {
+          "name": "libsecret",
+          "platform": "!windows & !osx & !ios"
+        }
+      ]
     },
     "sound": {
       "description": "Build wxSound support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11085,8 +11085,8 @@
       "port-version": 0
     },
     "wxwidgets": {
-      "baseline": "3.3.1",
-      "port-version": 1
+      "baseline": "3.3.3",
+      "port-version": 0
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "931dbcf8d395d296a7bb82015d8c3835a2b9748e",
+      "git-tree": "14a905e5675628dd78990da8b0eee0c146542e4f",
       "version": "3.3.3",
       "port-version": 0
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bffc8514924bda9f4dbd12b780731934addc289",
+      "git-tree": "931dbcf8d395d296a7bb82015d8c3835a2b9748e",
       "version": "3.3.3",
       "port-version": 0
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed1890683a006519e4873a32922157eb5d11c08c",
+      "version": "3.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "c3b7a128822dda9b567ad7efaa48fbcdf889e7d0",
       "version": "3.3.1",
       "port-version": 1

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14a905e5675628dd78990da8b0eee0c146542e4f",
+      "git-tree": "eeb427e462674b9df707dc3412bd88f9a49aa9a2",
       "version": "3.3.3",
       "port-version": 0
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ed1890683a006519e4873a32922157eb5d11c08c",
+      "git-tree": "4bffc8514924bda9f4dbd12b780731934addc289",
       "version": "3.3.3",
       "port-version": 0
     },


### PR DESCRIPTION
Update wxwidgets from 3.3.1 to 3.3.3. Patches are refreshed against the new line context. Two hunks of install-layout.patch (`create_symlink` -> `copy` in `install.cmake` and `utils/CMakeLists.txt`) are dropped in favor of the new upstream option `wxBUILD_INSTALL_USE_SYMLINK=OFF`, which the port now sets. Lexilla submodule is bumped to the sha paired with 3.3.3, and `vcpkg_cmake_config_fixup(CONFIG_PATH ...)` moves to `lib/cmake/wxWidgets-3.3` to match the versioned install layout wxWidgets 3.3 now emits.

Verified locally with a full `vcpkg install wxwidgets:x64-windows` build (15 min, dbg + rel, post-build validation passed).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.