### PR TITLE
[opencv3] Fix use of std::cout again

### DIFF
--- a/ports/opencv3/0023-cout.diff
+++ b/ports/opencv3/0023-cout.diff
@@ -1,16 +1,20 @@
+diff --git a/modules/viz/src/precomp.hpp b/modules/viz/src/precomp.hpp
+index 4c4bf7c..78933f7 100644
+--- a/modules/viz/src/precomp.hpp
++++ b/modules/viz/src/precomp.hpp
+@@ -51,6 +51,7 @@
+ #include <list>
+ #include <vector>
+ #include <iomanip>
++#include <iostream>
+ #include <limits>
+ 
+ #include <vtkVersionMacros.h>
 diff --git a/modules/viz/src/vtk/vtkVizInteractorStyle.cpp b/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
-index e2d3380..8943cb9 100644
+index e2d3380..26f3ca2 100644
 --- a/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
 +++ b/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
-@@ -44,6 +44,7 @@
- //M*/
- 
- #include "../precomp.hpp"
-+#include <iostream>
- 
- namespace cv { namespace viz
- {
-@@ -96,7 +97,7 @@ void cv::viz::vtkVizInteractorStyle::saveScreenshot(const String &file)
+@@ -96,7 +96,7 @@ void cv::viz::vtkVizInteractorStyle::saveScreenshot(const String &file)
      snapshot_writer->SetFileName(file.c_str());
      snapshot_writer->Write();
  
@@ -19,7 +23,7 @@ index e2d3380..8943cb9 100644
  }
  
  //////////////////////////////////////////////////////////////////////////////////////////////
-@@ -118,7 +119,7 @@ void cv::viz::vtkVizInteractorStyle::exportScene(const String &file)
+@@ -118,7 +118,7 @@ void cv::viz::vtkVizInteractorStyle::exportScene(const String &file)
      exporter->SetInput(Interactor->GetRenderWindow());
      exporter->Write();
  

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.20",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7438,7 +7438,7 @@
     },
     "opencv3": {
       "baseline": "3.4.20",
-      "port-version": 3
+      "port-version": 4
     },
     "opencv4": {
       "baseline": "4.12.0",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9030617c2247119b547d23c7c0cd7cd3785c953d",
+      "version": "3.4.20",
+      "port-version": 4
+    },
+    {
       "git-tree": "d856d027d756d99e8c293873ba039bc9c1349dd6",
       "version": "3.4.20",
       "port-version": 3


### PR DESCRIPTION
Amends #53036. Passed successfully as part of #52532, but must be split out to limit feature testing.