### PR TITLE
[opencv4] Fix use of std::cout again

### DIFF
--- a/ports/opencv4/0019-contrib-cout.diff
+++ b/ports/opencv4/0019-contrib-cout.diff
@@ -1,16 +1,20 @@
+diff --git a/modules/viz/src/precomp.hpp b/modules/viz/src/precomp.hpp
+index 4c4bf7c..78933f7 100644
+--- a/modules/viz/src/precomp.hpp
++++ b/modules/viz/src/precomp.hpp
+@@ -51,6 +51,7 @@
+ #include <list>
+ #include <vector>
+ #include <iomanip>
++#include <iostream>
+ #include <limits>
+ 
+ #include <vtkVersionMacros.h>
 diff --git a/modules/viz/src/vtk/vtkVizInteractorStyle.cpp b/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
-index e2d3380..8943cb9 100644
+index e2d3380..26f3ca2 100644
 --- a/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
 +++ b/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
-@@ -44,6 +44,7 @@
- //M*/
- 
- #include "../precomp.hpp"
-+#include <iostream>
- 
- namespace cv { namespace viz
- {
-@@ -96,7 +97,7 @@ void cv::viz::vtkVizInteractorStyle::saveScreenshot(const String &file)
+@@ -96,7 +96,7 @@ void cv::viz::vtkVizInteractorStyle::saveScreenshot(const String &file)
      snapshot_writer->SetFileName(file.c_str());
      snapshot_writer->Write();
  
@@ -19,7 +23,7 @@ index e2d3380..8943cb9 100644
  }
  
  //////////////////////////////////////////////////////////////////////////////////////////////
-@@ -118,7 +119,7 @@ void cv::viz::vtkVizInteractorStyle::exportScene(const String &file)
+@@ -118,7 +118,7 @@ void cv::viz::vtkVizInteractorStyle::exportScene(const String &file)
      exporter->SetInput(Interactor->GetRenderWindow());
      exporter->Write();
  

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.12.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://opencv.org/",
   "documentation": "https://docs.opencv.org/4.12.0/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7442,7 +7442,7 @@
     },
     "opencv4": {
       "baseline": "4.12.0",
-      "port-version": 8
+      "port-version": 9
     },
     "openexr": {
       "baseline": "3.4.13",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2f8fa75770e53767d505264a9748abfc3fdf5db",
+      "version": "4.12.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "f80b6738877e07cf6c0624a40686a4d060adb29e",
       "version": "4.12.0",
       "port-version": 8


### PR DESCRIPTION
Amends #53254. Passed successfully as part of https://github.com/microsoft/vcpkg/pull/52532, but must be split out to limit feature testing.