### PR TITLE
[exyokioffice] Add port: ExyokiOffice version 1.0.0

### DIFF
--- a/ports/exyokioffice/portfile.cmake
+++ b/ports/exyokioffice/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO JakubMelka/ExyokiOffice
     REF "v${VERSION}"
-    SHA512 0
+    SHA512 079d90326e104d4ba4a3e4449b7fcea5cd972bc79b1dd661ec25d51e5d5af7cea601bec4b44c87628971f74a1e12adb2241c1c6937411a38ef69c1c7a100c4fc
     HEAD_REF master
 )
 

--- a/ports/exyokioffice/portfile.cmake
+++ b/ports/exyokioffice/portfile.cmake
@@ -1,0 +1,99 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO JakubMelka/ExyokiOffice
+    REF "v${VERSION}"
+    SHA512 0
+    HEAD_REF master
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools   EXYOKIOFFICE_BUILD_TOOL
+        mcp     EXYOKIOFFICE_BUILD_MCP
+)
+
+# EXYOKIOFFICE_RUN_GENERATOR reruns the OpenXML source generator and writes the
+# result back into the source tree. The generated sources are committed upstream,
+# so a package build takes them as they are: it keeps the extracted source clean
+# and it is what makes cross compilation possible, since the generator would
+# otherwise be built for the target and then run on the host.
+#
+# BUILD_SHARED_LIBS is supplied by vcpkg_cmake_configure from the triplet.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DEXYOKIOFFICE_RUN_GENERATOR=OFF
+        -DEXYOKIOFFICE_WARNINGS_AS_ERRORS=OFF
+        -DEXYOKIOFFICE_BUILD_UNIT_TESTS=OFF
+        -DEXYOKIOFFICE_BUILD_MCP_PYTHON_TESTS=OFF
+        -DEXYOKIOFFICE_BUILD_FUZZERS=OFF
+        -DEXYOKIOFFICE_DUMP_EXPORTS=OFF
+        -DEXYOKIOFFICE_BUILD_EXAMPLE_WORD=OFF
+        -DEXYOKIOFFICE_BUILD_EXAMPLE_WORD_EDITOR=OFF
+        -DEXYOKIOFFICE_BUILD_EXAMPLE_WORD_EDIT=OFF
+        -DEXYOKIOFFICE_BUILD_EXAMPLE_EXCEL_EDITOR=OFF
+        -DEXYOKIOFFICE_BUILD_EXAMPLE_POWERPOINT_EDITOR=OFF
+)
+
+vcpkg_cmake_install()
+
+# The package name stays lowercase so that the config files land in the same
+# share/exyokioffice as the copyright and usage files; find_package matches the
+# directory case-insensitively, so ExyokiOfficeConfig.cmake is still found.
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ExyokiOffice)
+vcpkg_copy_pdbs()
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES exyoki AUTO_CLEAN)
+endif()
+
+if("mcp" IN_LIST FEATURES)
+    vcpkg_copy_tools(
+        TOOL_NAMES
+            exyoki-mcp-word
+            exyoki-mcp-excel
+            exyoki-mcp-power-point
+        AUTO_CLEAN
+    )
+endif()
+
+# The upstream install ships its manual, changelog and contributor documentation
+# under share/doc; vcpkg carries none of that.
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+# Every third-party component compiled into the installed binaries, under the
+# name upstream's THIRD-PARTY-LICENSES.md gives it. They are all called LICENSE
+# in the source tree, so they are staged under distinct names first. doctest is
+# absent on purpose: it reaches the test executables only, and none are installed.
+set(license_staging "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-licenses")
+file(REMOVE_RECURSE "${license_staging}")
+configure_file("${SOURCE_PATH}/3rdparty/CLI11/LICENSE" "${license_staging}/CLI11" COPYONLY)
+configure_file("${SOURCE_PATH}/3rdparty/nlohmann/LICENSE.MIT" "${license_staging}/nlohmann-json" COPYONLY)
+configure_file("${SOURCE_PATH}/3rdparty/json-schema-validator/LICENSE" "${license_staging}/json-schema-validator" COPYONLY)
+configure_file("${SOURCE_PATH}/sources/pugixml/LICENSE" "${license_staging}/pugixml" COPYONLY)
+configure_file("${SOURCE_PATH}/sources/zip/LICENSE" "${license_staging}/zip-miniz" COPYONLY)
+configure_file("${SOURCE_PATH}/data/LICENSE" "${license_staging}/Open-XML-SDK-data" COPYONLY)
+
+vcpkg_install_copyright(
+    COMMENT "ExyokiOffice is distributed under the MIT license. It embeds the third-party components listed below."
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${license_staging}/CLI11"
+        "${license_staging}/nlohmann-json"
+        "${license_staging}/json-schema-validator"
+        "${license_staging}/pugixml"
+        "${license_staging}/zip-miniz"
+        "${license_staging}/Open-XML-SDK-data"
+)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/exyokioffice/usage
+++ b/ports/exyokioffice/usage
@@ -1,0 +1,7 @@
+exyokioffice provides CMake targets:
+
+    find_package(ExyokiOffice 1.0 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE ExyokiOffice::ExyokiOffice)
+
+The tools and mcp features install exyoki and the MCP servers into
+tools/exyokioffice.

--- a/ports/exyokioffice/vcpkg.json
+++ b/ports/exyokioffice/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "exyokioffice",
+  "version": "1.0.0",
+  "description": [
+    "C++20 library for reading, writing and editing Office Open XML documents",
+    "ExyokiOffice reads and writes Word, Excel and PowerPoint packages through a generated, typed OOXML DOM, high-level document editors, an OPC packaging layer, package and DOM validation, digital signatures, and format conversion. It has no external dependencies."
+  ],
+  "homepage": "https://github.com/JakubMelka/ExyokiOffice",
+  "documentation": "https://github.com/JakubMelka/ExyokiOffice/blob/master/docs/README.md",
+  "license": "MIT",
+  "supports": "!uwp & !android & !ios & !emscripten",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "mcp": {
+      "description": "Build the exyoki Word, Excel and PowerPoint MCP servers"
+    },
+    "tools": {
+      "description": "Build the exyoki command-line utility"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2908,6 +2908,10 @@
       "baseline": "0.0.3",
       "port-version": 0
     },
+    "exyokioffice": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "ez8-co-yapi": {
       "baseline": "2022-08-10",
       "port-version": 0

--- a/versions/e-/exyokioffice.json
+++ b/versions/e-/exyokioffice.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a04630b993cdf17f020d3f0bfbf3f3506612bbe7",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/exyokioffice.json
+++ b/versions/e-/exyokioffice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a04630b993cdf17f020d3f0bfbf3f3506612bbe7",
+      "git-tree": "51db375726a56050931d97fcdb1736c8f0d574a6",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [x] Some other reason (please explain): I have developed it from November 2025, but then squashed the commits and released the library. The library is tested via various paths (unit tests, tools, demonstration project).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

