### PR TITLE
[picobench] update to 2.10.0

### DIFF
--- a/ports/picobench/portfile.cmake
+++ b/ports/picobench/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO iboB/picobench
     REF "v${VERSION}"
-    SHA512 b09de960f88c6acf0257bc0276afa783b475f42c75c8429f32554df0c100a7dcfeb0f6d8f7a98fc1f10eaab3bcd04b38e382dce5cc05630fdf9ecfc1bcda449b
+    SHA512 d45160c4c15b9b1f90c2263e76b51aa9d675d7f782b7c41c00725a3faf45d2105624594dd149e85c74e6d9d37a358d92dc26841a813fa7ef43990afdbb8c2b8c
     HEAD_REF main
 )
 

--- a/ports/picobench/vcpkg.json
+++ b/ports/picobench/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "picobench",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "A micro microbenchmarking library for C++11 in a single header file",
   "homepage": "https://github.com/iboB/picobench",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7813,7 +7813,7 @@
       "port-version": 1
     },
     "picobench": {
-      "baseline": "2.9.0",
+      "baseline": "2.10.0",
       "port-version": 0
     },
     "picohttpparser": {

--- a/versions/p-/picobench.json
+++ b/versions/p-/picobench.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cd35a3d22772abd8ec76242cf56e94ad65ea818",
+      "version": "2.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "68c647744104d454e4b4b0aa85a197ca03241982",
       "version": "2.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/iboB/picobench/releases/tag/v2.10.0
