### PR TITLE
[stlab-copy-on-write] update to 1.1.1

### DIFF
--- a/ports/stlab-copy-on-write/disable-cpm.patch
+++ b/ports/stlab-copy-on-write/disable-cpm.patch
@@ -1,15 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6452b57..6e4e9d4 100644
+index 086a9da..8bf9ecf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,11 +1,8 @@
+@@ -1,15 +1,12 @@
  cmake_minimum_required(VERSION 3.24)
  
 -include(cmake/CPM.cmake)
 -
  # Fetch cpp-library before project()
- # Check https://github.com/stlab/cpp-library/releases for the latest version
--CPMAddPackage("gh:stlab/cpp-library@5.0.0")
+ # [DEPENDENCY] https://github.com/stlab/cpp-library/releases for the latest version
+ # CPMAddPackage(
+ #     NAME cpp-library
+ #     SOURCE_DIR "${CMAKE_SOURCE_DIR}/../cpp-library"
+ # )
+-CPMAddPackage("gh:stlab/cpp-library@5.4.1")
 -include(${cpp-library_SOURCE_DIR}/cpp-library.cmake)
 +include(cmake/cpp-library/cpp-library.cmake)
  

--- a/ports/stlab-copy-on-write/portfile.cmake
+++ b/ports/stlab-copy-on-write/portfile.cmake
@@ -13,8 +13,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
     REPO stlab/cpp-library
-    REF "v5.0.0"
-    SHA512 5e158dbdcabe698f7ddaff460a68c490978a7f91af8cb90f19430456acc1ca0f115973f149303b07d5ed0fbb3b43cd857b133c46bc6b4e8cc96c1ee25b0e87a9
+    REF "v5.4.1"
+    SHA512 68e6bdb76627e5019b4dbe49cd7450c38011d1e721f9e93b3ffaf2d807a01883e243b069292e3b44e7dc8142a0e235facccaa877607ab1a5c4a4db2764d5382e
     HEAD_REF master
 )
 file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/cpp-library")
@@ -25,6 +25,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DCPP_LIBRARY_VERSION=${VERSION}
 )
 
 vcpkg_cmake_install()

--- a/ports/stlab-copy-on-write/portfile.cmake
+++ b/ports/stlab-copy-on-write/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stlab/copy-on-write
     REF "v${VERSION}"
-    SHA512 4f480b35a232abd94f70bcd37b93099196e8d09f40678f87afc367af7b11c5799ffaa81ee134e6c1b85f7a5d6765f0a25c305d6dd09685bb1b4bbc3948ecbd3e
+    SHA512 c7e9036862aafb1cc651eb8785edb09c11b36245731fb0213d6cc72c7cf521cd5954e6fd40aa5349148e103f847e62c0736ea943e5f097b46e96c5ba0a125151
     HEAD_REF main
     PATCHES
         disable-cpm.patch

--- a/ports/stlab-copy-on-write/vcpkg.json
+++ b/ports/stlab-copy-on-write/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stlab-copy-on-write",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "stlab copy-on-write library",
   "homepage": "https://github.com/stlab/copy-on-write",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9817,7 +9817,7 @@
       "port-version": 0
     },
     "stlab-copy-on-write": {
-      "baseline": "1.1.0",
+      "baseline": "1.1.1",
       "port-version": 0
     },
     "stlab-enum-ops": {

--- a/versions/s-/stlab-copy-on-write.json
+++ b/versions/s-/stlab-copy-on-write.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49c4295e294a8f87bc4fa06a0cb3baafe7a7ebe3",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "413d8e2a4f721eac97e22f67622f274dc06a6595",
       "version": "1.1.0",
       "port-version": 0

--- a/versions/s-/stlab-copy-on-write.json
+++ b/versions/s-/stlab-copy-on-write.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "49c4295e294a8f87bc4fa06a0cb3baafe7a7ebe3",
+      "git-tree": "b5309f762e85a9c5eaf44c759e3212682d215186",
       "version": "1.1.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/stlab/stlab-copy-on-write/releases/tag/v1.1.1
