### PR TITLE
[fluidsynth] Update to 2.5.7

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
     REF "v${VERSION}"
-    SHA512 0e0f78933c5cc119abc25f91f51df467e9a8efe7bca87b0439d13da42046e5b331bc800bdcba6b82c33fdfd32f821550d1f0d7262fdb15f525a219212ed3b5f2
+    SHA512 673edd454c912e2fb2b0848c4ab8c47b068f06d611df7e2bcb73d66f1457078024a474c1f45bac4ea2c63921131eea58ceb1efe3340e643895dc8979fb44da32
     HEAD_REF master
     PATCHES
         fix-gcem.patch

--- a/ports/fluidsynth/usage
+++ b/ports/fluidsynth/usage
@@ -2,7 +2,7 @@ fluidsynth provides CMake targets:
 
   find_package(FluidSynth CONFIG REQUIRED)
   target_link_libraries(main PRIVATE FluidSynth::libfluidsynth)
-  add_custom_command(OUTPUT result COMMAND FluidSynth::q ARGS ...)
+  add_custom_command(OUTPUT result COMMAND FluidSynth::fluidsynth ARGS ...)
 
 fluidsynth provides pkg-config modules:
 

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidsynth",
-  "version": "2.5.5",
+  "version": "2.5.7",
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3149,7 +3149,7 @@
       "port-version": 0
     },
     "fluidsynth": {
-      "baseline": "2.5.5",
+      "baseline": "2.5.7",
       "port-version": 0
     },
     "flux": {

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1134350590718794ff0b869247108c21edddd417",
+      "version": "2.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "cfdb9ecf76c6f7691d931394a340dbd6fc129f96",
       "version": "2.5.5",
       "port-version": 0

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1134350590718794ff0b869247108c21edddd417",
+      "git-tree": "4a4e214cae592c79d4b515e99674d63ee7213de5",
       "version": "2.5.7",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
