### PR TITLE
[babl] Update to 0.1.128

### DIFF
--- a/ports/babl/gir-header-only-on-windows.patch
+++ b/ports/babl/gir-header-only-on-windows.patch
@@ -1,15 +1,15 @@
 diff --git a/babl/meson.build b/babl/meson.build
-index e3129d3..35562f6 100644
+index 9a77cdf..80e3a52 100644
 --- a/babl/meson.build
 +++ b/babl/meson.build
-@@ -166,6 +166,10 @@ if build_gir
-       '--identifier-filter-cmd=@0@ @1@'.format(python.full_path(), 
-       '"' + meson.current_source_dir() / 'identfilter.py' + '"'),
-       '-DBABL_IS_BEING_COMPILED',
-+      # Windows DLL resolution for the temporary GIR helper executable is
-+      # unreliable in vcpkg builds. Babl does not expose GObject runtime
-+      # types, so a header-only scan is sufficient here.
-+      platform_win32 ? '--header-only' : '',
-       '--quiet',
-     ],
-     namespace: 'Babl',
+@@ -177,6 +177,10 @@ if build_gir
+         '--identifier-filter-cmd=@0@ @1@'.format(python.full_path(), 
+         '"' + meson.current_source_dir() / 'identfilter.py' + '"'),
+         '-DBABL_IS_BEING_COMPILED',
++        # Windows DLL resolution for the temporary GIR helper executable is
++        # unreliable in vcpkg builds. Babl does not expose GObject runtime
++        # types, so a header-only scan is sufficient here.
++        platform_win32 ? '--header-only' : '',
+         '--quiet',
+       ],
+       namespace: 'Babl',

--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 953037386e1763b28385f0f1802a657e2b918b5db3932cc62e75aa32c36b36b0513258f1b5548dfebedb51fb6de47412503ea8f8aff4ce79c314e33a28d27166
+    SHA512 ce295226f9a0c98c22e1564306741e0588235dd3f420899978469949b3ddfd107c3c009e85279aed82055ece1689de7ded0a0f04974de89cff0ed585007b6290
 )
 
 vcpkg_extract_source_archive(

--- a/ports/babl/remove-consistency-check.patch
+++ b/ports/babl/remove-consistency-check.patch
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index 5f5299a..269dc17 100644
+index e8b4d39..e613b48 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -581,7 +581,7 @@ if build_docs
+@@ -611,7 +611,7 @@ if build_docs or build_gi_docgen
  endif
  subdir('bin')
  
--if not platform_osx and host_cpu_family != 'x86'
+-if host_machine.system() != 'emscripten'
 +if false
    nm = find_program('nm', required: false)
  
-   # Verify .def files for Windows linking.
+   # Verify .def files for Windows linking (and for macOS too when -Wl,-exported_symbols_list is used).

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.126",
-  "port-version": 2,
+  "version": "0.1.128",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8ffcd8d3110207416b86ddc1578cdf6b3cbd6c7",
+      "version": "0.1.128",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c5b72c20889d10e66a77defdb8f554e972988dc",
       "version": "0.1.126",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -625,8 +625,8 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.126",
-      "port-version": 2
+      "baseline": "0.1.128",
+      "port-version": 0
     },
     "backward-cpp": {
       "baseline": "2023-11-24",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

@BillyONeal You may review #53323 first (in case GPT complains the gobject-introspection code of the port ;)).