### PR TITLE
[opengl-registry] Update to 2026-08-03

### DIFF
--- a/ports/opengl-registry/portfile.cmake
+++ b/ports/opengl-registry/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO KhronosGroup/OpenGL-Registry
-  REF 0b449b97cdf1043eef5e1f0e235cbbab6ec10c86
-  SHA512 148e1bfe4cc199bcc2c23b22d0b3e4988a29389d7f510ba4a6340672dbb7ab99bb836d2c08587499484df704d51a1adf4f0dc3a30d5ad8977ee0ad339163b17e
-  HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/OpenGL-Registry
+    REF e8f7cd0e35ac8d6f5667a021ff83d04b1fec41ef
+    SHA512 7b2eab04e54aa77294887f897f3091c07ecad38acc1dfb1e9d1efc3954d347a0b8c2666f3ceaf074dd17a3d97305f3d99494fe80c4b2f17d052183dfab1927c5
+    HEAD_REF main
 )
 
 file(COPY "${SOURCE_PATH}/api/GL" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
@@ -15,8 +15,8 @@ file(COPY "${SOURCE_PATH}/api/GLSC2" DESTINATION "${CURRENT_PACKAGES_DIR}/includ
 
 file(GLOB reg_files "${SOURCE_PATH}/xml/*.xml" "${SOURCE_PATH}/xml/readme.pdf" "${SOURCE_PATH}/xml/*.rnc" "${SOURCE_PATH}/xml/reg.py")
 file(COPY
-  ${reg_files}
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/opengl"
+    ${reg_files}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/opengl"
 )
 
 vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/copyright")

--- a/ports/opengl-registry/portfile.cmake
+++ b/ports/opengl-registry/portfile.cmake
@@ -1,7 +1,9 @@
+set(REF e8f7cd0e35ac8d6f5667a021ff83d04b1fec41ef)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/OpenGL-Registry
-    REF e8f7cd0e35ac8d6f5667a021ff83d04b1fec41ef
+    REF "${REF}"
     SHA512 7b2eab04e54aa77294887f897f3091c07ecad38acc1dfb1e9d1efc3954d347a0b8c2666f3ceaf074dd17a3d97305f3d99494fe80c4b2f17d052183dfab1927c5
     HEAD_REF main
 )
@@ -22,11 +24,13 @@ file(COPY
 vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/copyright")
 
 # pc layout from cygwin (consumed in xserver!)
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/pkgconfig/khronos-opengl-registry.pc" [=[
+set(pc_file [=[
 prefix=${pcfiledir}/../..
 datadir=${prefix}/share
 specdir=${datadir}/opengl
 Name: khronos-opengl-registry
 Description: Khronos OpenGL registry
-Version: git3530768138c5ba3dfbb2c43c830493f632f7ea33
+Version: git@REF@
 ]=])
+string(CONFIGURE "${pc_file}" pc_file @ONLY)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/pkgconfig/khronos-opengl-registry.pc" "${pc_file}")

--- a/ports/opengl-registry/vcpkg.json
+++ b/ports/opengl-registry/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opengl-registry",
-  "version-date": "2026-01-26",
+  "version-date": "2026-08-03",
   "description": "OpenGL, OpenGL ES, and OpenGL ES-SC API and Extension Registry",
   "homepage": "https://github.com/KhronosGroup/OpenGL-Registry",
   "supports": "!xbox",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7461,7 +7461,7 @@
       "port-version": 3
     },
     "opengl-registry": {
-      "baseline": "2026-01-26",
+      "baseline": "2026-08-03",
       "port-version": 0
     },
     "openh264": {

--- a/versions/o-/opengl-registry.json
+++ b/versions/o-/opengl-registry.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "897f77a5d54d017da026ffc61a67b7d94e99a5b5",
+      "git-tree": "afb3b830710697505bc6d59cb1fbed9ca29c7e99",
       "version-date": "2026-08-03",
       "port-version": 0
     },

--- a/versions/o-/opengl-registry.json
+++ b/versions/o-/opengl-registry.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "897f77a5d54d017da026ffc61a67b7d94e99a5b5",
+      "version-date": "2026-08-03",
+      "port-version": 0
+    },
+    {
       "git-tree": "0cd17c3b57221250d5ba174580f0a2993853ce34",
       "version-date": "2026-01-26",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
