### PR TITLE
[suitesparse] Update to 7.13.0

### DIFF
--- a/ports/suitesparse-amd/portfile.cmake
+++ b/ports/suitesparse-amd/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-amd/vcpkg.json
+++ b/ports/suitesparse-amd/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-amd",
   "version-semver": "3.3.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "AMD: Routines for permuting sparse matrices prior to factorization in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "BSD-3-Clause",

--- a/ports/suitesparse-btf/portfile.cmake
+++ b/ports/suitesparse-btf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-btf/vcpkg.json
+++ b/ports/suitesparse-btf/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-btf",
   "version-semver": "2.3.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "BTF: Software package for permuting a matrix into block upper triangular form in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "LGPL-2.1-or-later",

--- a/ports/suitesparse-camd/portfile.cmake
+++ b/ports/suitesparse-camd/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-camd/vcpkg.json
+++ b/ports/suitesparse-camd/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-camd",
   "version-semver": "3.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "AMD: Routines for permuting sparse matrices prior to factorization in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "BSD-3-Clause",

--- a/ports/suitesparse-ccolamd/portfile.cmake
+++ b/ports/suitesparse-ccolamd/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-ccolamd/vcpkg.json
+++ b/ports/suitesparse-ccolamd/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-ccolamd",
   "version-semver": "3.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "CCOLAMD: Routines for constrained column approximate minimum degree ordering algorithm in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "BSD-3-Clause",

--- a/ports/suitesparse-cholmod/portfile.cmake
+++ b/ports/suitesparse-cholmod/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
     PATCHES
         001-dont-override-cuda-architectures.patch

--- a/ports/suitesparse-cholmod/vcpkg.json
+++ b/ports/suitesparse-cholmod/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-cholmod",
   "version-semver": "5.3.5",
+  "port-version": 1,
   "description": "CHOLMOD: Routines for factorizing sparse symmetric positive definite matrices in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "LGPL-2.1-or-later AND Apache-2.0",

--- a/ports/suitesparse-colamd/portfile.cmake
+++ b/ports/suitesparse-colamd/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-colamd/vcpkg.json
+++ b/ports/suitesparse-colamd/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-colamd",
   "version-semver": "3.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "COLAMD: Routines for column approximate minimum degree ordering algorithm in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "BSD-3-Clause",

--- a/ports/suitesparse-config/portfile.cmake
+++ b/ports/suitesparse-config/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-config/vcpkg.json
+++ b/ports/suitesparse-config/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-config",
-  "version-semver": "7.12.3",
+  "version-semver": "7.13.0",
   "description": "Configuration for SuiteSparse libraries",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "BSD-3-Clause",

--- a/ports/suitesparse-cxsparse/portfile.cmake
+++ b/ports/suitesparse-cxsparse/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
     PATCHES
         001-detect-complex-support.patch

--- a/ports/suitesparse-cxsparse/vcpkg.json
+++ b/ports/suitesparse-cxsparse/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-cxsparse",
   "version-semver": "4.4.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "CXSparse: Software package for permuting a matrix into block upper triangular form in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "LGPL-2.1-or-later",

--- a/ports/suitesparse-graphblas/portfile.cmake
+++ b/ports/suitesparse-graphblas/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/GraphBLAS
-    REF v10.3.2
-    SHA512 7d33a8cbf451ea9251e6490f7b4abe37990d557db88705d3eca577b94452048edbcda92f4cd9aee9e9a1069544b744fce0aa4c625e6b82476e3342aa386756d8
+    REF v10.4.1
+    SHA512 ba9338c14b89bf211428abc08bdde1ebd567d01bf54f8f99c680e742f6ed7f820272a1833348a668f4938c84f429d848aec608f011d3e93999c4fa3473ab83bd
     HEAD_REF stable
     PATCHES
         crossbuild.diff

--- a/ports/suitesparse-graphblas/vcpkg.json
+++ b/ports/suitesparse-graphblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-graphblas",
-  "version-semver": "10.3.2",
+  "version-semver": "10.4.1",
   "description": "SuiteSparse:GraphBLAS: graph algorithms in the language of linear algebra",
   "homepage": "https://people.engr.tamu.edu/davis/GraphBLAS.html",
   "license": null,

--- a/ports/suitesparse-klu/portfile.cmake
+++ b/ports/suitesparse-klu/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-klu/vcpkg.json
+++ b/ports/suitesparse-klu/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-klu",
   "version-semver": "2.3.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "KLU: Routines for solving sparse linear systems of equations in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "LGPL-2.1-or-later",

--- a/ports/suitesparse-lagraph/portfile.cmake
+++ b/ports/suitesparse-lagraph/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-lagraph/vcpkg.json
+++ b/ports/suitesparse-lagraph/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-lagraph",
   "version-semver": "1.2.2",
+  "port-version": 1,
   "description": "LAGraph: Library plus test harness for collecting algorithms that use GraphBLAS",
   "homepage": "https://lagraph.readthedocs.io/en/latest/",
   "license": "BSD-2-Clause",

--- a/ports/suitesparse-ldl/portfile.cmake
+++ b/ports/suitesparse-ldl/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-ldl/vcpkg.json
+++ b/ports/suitesparse-ldl/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-ldl",
   "version-semver": "3.3.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LDL: A sparse LDL' factorization and solve package in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "LGPL-2.1-or-later",

--- a/ports/suitesparse-mongoose/portfile.cmake
+++ b/ports/suitesparse-mongoose/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-mongoose/vcpkg.json
+++ b/ports/suitesparse-mongoose/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-mongoose",
   "version-semver": "3.3.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mongoose: Graph partitioning library in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "GPL-3.0-only",

--- a/ports/suitesparse-paru/portfile.cmake
+++ b/ports/suitesparse-paru/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-paru/vcpkg.json
+++ b/ports/suitesparse-paru/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-paru",
-  "version-semver": "1.1.1",
+  "version-semver": "1.1.2",
   "description": "ParU: Routines for solving sparse linear system via parallel multifrontal LU factorization algorithms in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "GPL-3.0-or-later",

--- a/ports/suitesparse-rbio/portfile.cmake
+++ b/ports/suitesparse-rbio/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-rbio/vcpkg.json
+++ b/ports/suitesparse-rbio/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-rbio",
   "version-semver": "4.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "RBio: routines for reading/writing sparse matrices in Rutherford/Boeing format in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "GPL-2.0-or-later",

--- a/ports/suitesparse-spex/portfile.cmake
+++ b/ports/suitesparse-spex/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-spex/vcpkg.json
+++ b/ports/suitesparse-spex/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-spex",
   "version-semver": "3.2.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SPEX: Software package for SParse EXact algebra in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "GPL-2.0-or-later OR LGPL-3.0-or-later",

--- a/ports/suitesparse-spqr/portfile.cmake
+++ b/ports/suitesparse-spqr/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
     PATCHES
         001-dont-override-cuda-architectures.patch

--- a/ports/suitesparse-spqr/vcpkg.json
+++ b/ports/suitesparse-spqr/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-spqr",
   "version-semver": "4.3.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SPQR: Multithreaded, multifrontal, rank-revealing sparse QR factorization method in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "GPL-2.0-or-later",

--- a/ports/suitesparse-umfpack/portfile.cmake
+++ b/ports/suitesparse-umfpack/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DrTimothyAldenDavis/SuiteSparse
-    REF v7.12.3
-    SHA512 e6f8cba51459a345fbb8f2de3470c07f128790eaecf2faba06bf6b0a02e90ea4fdc87fe4cf6e444b8a458bdb8d83552033292eb64d5763b96e268657e9b9a048
+    REF v7.13.0
+    SHA512 62319607ddd06bdb160d1308233bccec2bafb8a4909d4f5123df1b1d1088d2df9290b21984f7963ec87c2502ee9c4d5e687b23bf9dcd13e2ff076a416b4e0eef
     HEAD_REF dev
 )
 

--- a/ports/suitesparse-umfpack/vcpkg.json
+++ b/ports/suitesparse-umfpack/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse-umfpack",
   "version-semver": "6.3.8",
+  "port-version": 1,
   "description": "UMFPACK: Routines solving sparse linear systems via LU factorization in SuiteSparse",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": "GPL-2.0-or-later",

--- a/ports/suitesparse/vcpkg.json
+++ b/ports/suitesparse/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Use scripts/update_suitesparse.py to update all SuiteSparse ports",
   "name": "suitesparse",
-  "version-semver": "7.12.3",
+  "version-semver": "7.13.0",
   "description": "A suite of sparse matrix algorithms",
   "homepage": "https://people.engr.tamu.edu/davis/suitesparse.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9881,80 +9881,80 @@
       "port-version": 1
     },
     "suitesparse": {
-      "baseline": "7.12.3",
+      "baseline": "7.13.0",
       "port-version": 0
     },
     "suitesparse-amd": {
       "baseline": "3.3.4",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-btf": {
       "baseline": "2.3.3",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-camd": {
       "baseline": "3.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-ccolamd": {
       "baseline": "3.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-cholmod": {
       "baseline": "5.3.5",
-      "port-version": 0
+      "port-version": 1
     },
     "suitesparse-colamd": {
       "baseline": "3.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-config": {
-      "baseline": "7.12.3",
+      "baseline": "7.13.0",
       "port-version": 0
     },
     "suitesparse-cxsparse": {
       "baseline": "4.4.2",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-graphblas": {
-      "baseline": "10.3.2",
+      "baseline": "10.4.1",
       "port-version": 0
     },
     "suitesparse-klu": {
       "baseline": "2.3.6",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-lagraph": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "suitesparse-ldl": {
       "baseline": "3.3.3",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-mongoose": {
       "baseline": "3.3.6",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-paru": {
-      "baseline": "1.1.1",
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "suitesparse-rbio": {
       "baseline": "4.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-spex": {
       "baseline": "3.2.4",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-spqr": {
       "baseline": "4.3.6",
-      "port-version": 1
+      "port-version": 2
     },
     "suitesparse-umfpack": {
       "baseline": "6.3.8",
-      "port-version": 0
+      "port-version": 1
     },
     "sundials": {
       "baseline": "7.8.0",

--- a/versions/s-/suitesparse-amd.json
+++ b/versions/s-/suitesparse-amd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "addaec24a529ae57b89bf4768867cc1f29450459",
+      "version-semver": "3.3.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "72a34410f6399d10eaafba14a363f2fde5eaa14d",
       "version-semver": "3.3.4",
       "port-version": 1

--- a/versions/s-/suitesparse-btf.json
+++ b/versions/s-/suitesparse-btf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6e7aee25b9264d3abd6a5daa15d06d2b87d5d5c",
+      "version-semver": "2.3.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "c27ab64452e2b795c779eec716fdd7f9172a6bf0",
       "version-semver": "2.3.3",
       "port-version": 1

--- a/versions/s-/suitesparse-camd.json
+++ b/versions/s-/suitesparse-camd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0339fd78390cfdce5137f32f6ad20aaf5791e0af",
+      "version-semver": "3.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "c786b0de51a6db39f3a5e25f53bf13b88256a5d4",
       "version-semver": "3.3.5",
       "port-version": 1

--- a/versions/s-/suitesparse-ccolamd.json
+++ b/versions/s-/suitesparse-ccolamd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c04ff246ecbfbc96fa6838662cc58b8f066a7c0",
+      "version-semver": "3.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "db94ddef0f4e6fdd21821df30cca3d08d38e5b8c",
       "version-semver": "3.3.5",
       "port-version": 1

--- a/versions/s-/suitesparse-cholmod.json
+++ b/versions/s-/suitesparse-cholmod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15d802ff584e1e43f47bbb9c1afc4b2c29929b27",
+      "version-semver": "5.3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "54489f5bb750a0585d04f044104a083f3eb95e7d",
       "version-semver": "5.3.5",
       "port-version": 0

--- a/versions/s-/suitesparse-colamd.json
+++ b/versions/s-/suitesparse-colamd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6445f5612571a68567a4535db7610d47908b64eb",
+      "version-semver": "3.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "f4a9d817f09dcd577dfb282085447cdd4bd3b74b",
       "version-semver": "3.3.5",
       "port-version": 1

--- a/versions/s-/suitesparse-config.json
+++ b/versions/s-/suitesparse-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8a528cb21b011bf9f6dd4b5b79f54734fd375f7",
+      "version-semver": "7.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "924c0c1f50b6473c9be44317a5bf13d9afaca0e1",
       "version-semver": "7.12.3",
       "port-version": 0

--- a/versions/s-/suitesparse-cxsparse.json
+++ b/versions/s-/suitesparse-cxsparse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8e74156cf42a26c44bff80fd7be7ed77c6eb8b5",
+      "version-semver": "4.4.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "87cf1a5d6f07e1a0244472eddc8d13e1baa29d3f",
       "version-semver": "4.4.2",
       "port-version": 1

--- a/versions/s-/suitesparse-graphblas.json
+++ b/versions/s-/suitesparse-graphblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f89aae365eb0d7f40c770355eb1bedbcf5cb6ed6",
+      "version-semver": "10.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3666a19c72ab75c90029f11a29c5c0914214a6e0",
       "version-semver": "10.3.2",
       "port-version": 0

--- a/versions/s-/suitesparse-klu.json
+++ b/versions/s-/suitesparse-klu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18e8f5d49a6f297b45f5202155aa220186e4d748",
+      "version-semver": "2.3.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "92fd97ac36858e77f3d7ebb6c12da2150677b7eb",
       "version-semver": "2.3.6",
       "port-version": 1

--- a/versions/s-/suitesparse-lagraph.json
+++ b/versions/s-/suitesparse-lagraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02058ef7bfa9b3a992811997a88980ea46e0747b",
+      "version-semver": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "958217f5aacdcf31854e8713c03e0fb3172af8a2",
       "version-semver": "1.2.2",
       "port-version": 0

--- a/versions/s-/suitesparse-ldl.json
+++ b/versions/s-/suitesparse-ldl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0497238f7472198d3cb4f1414dcbc57aa89c8dae",
+      "version-semver": "3.3.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "620e983c6ef5dcdf86f3981557c4f65aa78a0c67",
       "version-semver": "3.3.3",
       "port-version": 1

--- a/versions/s-/suitesparse-mongoose.json
+++ b/versions/s-/suitesparse-mongoose.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90d4fdc3db07b5de8f779a3570cd30e04b5f2623",
+      "version-semver": "3.3.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "91a926b23dd531dd991a5b7602a3c559bffcb988",
       "version-semver": "3.3.6",
       "port-version": 1

--- a/versions/s-/suitesparse-paru.json
+++ b/versions/s-/suitesparse-paru.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f252a08e1d814cbf78a19e4bb391184ed00e1035",
+      "version-semver": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "05e282f51a869733f47186ec94d5b24d41ca2560",
       "version-semver": "1.1.1",
       "port-version": 0

--- a/versions/s-/suitesparse-rbio.json
+++ b/versions/s-/suitesparse-rbio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a55df709aedb2c7cea2fe130f8923817f98d49e",
+      "version-semver": "4.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "5cb67117c6666c10fd0e47cccb8441db04c79490",
       "version-semver": "4.3.5",
       "port-version": 1

--- a/versions/s-/suitesparse-spex.json
+++ b/versions/s-/suitesparse-spex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "048db27e58d59fd01eab71902048d1c527750d05",
+      "version-semver": "3.2.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "a138352ef46026bf453924f9ccdcadc127832c6c",
       "version-semver": "3.2.4",
       "port-version": 1

--- a/versions/s-/suitesparse-spqr.json
+++ b/versions/s-/suitesparse-spqr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "513ffa6c47c6a02f7ea0e1b2bafca10a8447bb51",
+      "version-semver": "4.3.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "16f116279537bb1b19308c786edb4c0e1d695ac1",
       "version-semver": "4.3.6",
       "port-version": 1

--- a/versions/s-/suitesparse-umfpack.json
+++ b/versions/s-/suitesparse-umfpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c21d0cf910655e793e4280cb04f3173eb437f13",
+      "version-semver": "6.3.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "ba4db7a0a33a155ec8b1126842ae79c113b57072",
       "version-semver": "6.3.8",
       "port-version": 0

--- a/versions/s-/suitesparse.json
+++ b/versions/s-/suitesparse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "566a996b8be38d8a028525d0a979318f38e4b6a6",
+      "version-semver": "7.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "04547c369892ecd647d7a5e8735b023ad25a7f8a",
       "version-semver": "7.12.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
