### PR TITLE
[gtest] Update to 1.18.0

### DIFF
--- a/ports/gtest/fix-main-lib-path.patch
+++ b/ports/gtest/fix-main-lib-path.patch
@@ -1,40 +1,36 @@
 diff --git a/googlemock/CMakeLists.txt b/googlemock/CMakeLists.txt
-index 99b2411f..74610b12 100644
+index 33ec9636..e8bba555 100644
 --- a/googlemock/CMakeLists.txt
 +++ b/googlemock/CMakeLists.txt
-@@ -112,8 +112,9 @@ target_include_directories(gmock_main SYSTEM INTERFACE
- 
+@@ -113,7 +113,8 @@ target_include_directories(gmock_main SYSTEM INTERFACE
  ########################################################################
  #
--# Install rules.
+ # Install rules.
 -install_project(gmock gmock_main)
-+# Install rules
 +install_project(gmock)
 +install_project(gmock_main)
  
  ########################################################################
  #
 diff --git a/googletest/CMakeLists.txt b/googletest/CMakeLists.txt
-index dce6a7c9..d8faf644 100644
+index 64c0510c..84fde724 100644
 --- a/googletest/CMakeLists.txt
 +++ b/googletest/CMakeLists.txt
-@@ -154,8 +154,9 @@ target_link_libraries(gtest_main PUBLIC gtest)
- 
+@@ -152,7 +152,8 @@ target_link_libraries(gtest_main PUBLIC gtest)
  ########################################################################
  #
--# Install rules.
+ # Install rules.
 -install_project(gtest gtest_main)
-+# Install rules
 +install_project(gtest)
 +install_project(gtest_main)
  
  ########################################################################
  #
 diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
-index 580ac1cb..78a5b659 100644
+index 10c55955..ec78cc9a 100644
 --- a/googletest/cmake/internal_utils.cmake
 +++ b/googletest/cmake/internal_utils.cmake
-@@ -302,12 +302,16 @@ function(install_project)
+@@ -324,12 +324,16 @@ function(install_project)
        COMPONENT "${PROJECT_NAME}"
        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
      # Install the project targets.
@@ -53,11 +49,11 @@ index 580ac1cb..78a5b659 100644
      if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
        # Install PDBs.
        foreach(t ${ARGN})
-@@ -317,7 +321,7 @@ function(install_project)
-         install(FILES
-           "${t_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<$<CONFIG:Debug>:${t_pdb_name_debug}>$<$<NOT:$<CONFIG:Debug>>:${t_pdb_name}>.pdb"
+@@ -343,7 +347,7 @@ function(install_project)
+           "$<$<STREQUAL:$<TARGET_PROPERTY:${t},TYPE>,STATIC_LIBRARY>:${t_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<IF:$<CONFIG:Debug>,${t_pdb_name_debug},${t_pdb_name}>.pdb>"
+           "$<$<STREQUAL:$<TARGET_PROPERTY:${t},TYPE>,SHARED_LIBRARY>:${t_shared_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<IF:$<CONFIG:Debug>,${t_shared_pdb_name_debug},${t_shared_pdb_name}>.pdb>"
            COMPONENT "${PROJECT_NAME}"
--          DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-          DESTINATION $<IF:$<STREQUAL:$<TARGET_PROPERTY:${t},TYPE>,STATIC_LIBRARY>,${CMAKE_INSTALL_LIBDIR},${CMAKE_INSTALL_BINDIR}>
 +          DESTINATION ${LIB_INSTALL_DST}
            OPTIONAL)
        endforeach()

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -1,30 +1,23 @@
-vcpkg_download_distfile(CHARACTER_CONVERSION_PATCH
-    URLS "https://github.com/google/googletest/commit/fa8438ae6b70c57010177de47a9f13d7041a6328.patch?full_index=1"
-    FILENAME "googletest-fa8438ae6b70c57010177de47a9f13d7041a6328.patch"
-    SHA512 fe436859fc5cafdc18e7fcb6d12903ea7a4aa37a3a913132d717ab9f8d5495ead9e4ddbbb89d70199f498588ff04e7b47ea988cc3032ef46dabe03eb4110dd5f
-)
-
 if (EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
-    file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/src)
+    file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/src")
 endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
     REF "v${VERSION}"
-    SHA512 0f57e9ef06925e5b7722df1eb92ef5850e8dce79220ea16a8aaff586a71c0b01460ef1713649ee24ffedb2e6ad5a51e9198c5a5ae1b2789e43feb1f494e7d45c
+    SHA512 ba0f5769ccf34acf1bc72d1f7e9ffb8202176d02b64f6f3d9047accfc0cf9026ff5a653d24935e2705fff8709566676452616c93ca0ca6277f1e21d79b58a10a
     HEAD_REF main
     PATCHES
         001-fix-UWP-death-test.patch
         clang-tidy-no-lint.patch
         fix-main-lib-path.patch
-        "${CHARACTER_CONVERSION_PATCH}"
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" GTEST_FORCE_SHARED_CRT)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_GMOCK=ON
         -Dgtest_force_shared_crt=${GTEST_FORCE_SHARED_CRT}
@@ -48,10 +41,10 @@ file(
         "${SOURCE_PATH}/googletest/src/gtest-test-part.cc"
         "${SOURCE_PATH}/googletest/src/gtest-typed-test.cc"
     DESTINATION
-        ${CURRENT_PACKAGES_DIR}/src
+        "${CURRENT_PACKAGES_DIR}/src"
 )
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_fixup_pkgconfig()
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
@@ -64,6 +57,6 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 endif()
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtest",
-  "version-semver": "1.17.0",
-  "port-version": 3,
+  "version-semver": "1.18.0",
   "description": "Google Testing and Mocking Framework",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3633,8 +3633,8 @@
       "port-version": 1
     },
     "gtest": {
-      "baseline": "1.17.0",
-      "port-version": 3
+      "baseline": "1.18.0",
+      "port-version": 0
     },
     "gtk": {
       "baseline": "4.22.4",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17742fd5386949217cc8d3c0c562f25282e7fa0e",
+      "version-semver": "1.18.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "dab84cf3bb50ef2ca3e0b0212c1d55e9e05a75bc",
       "version-semver": "1.17.0",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
