### PR TITLE
[babl] Avoid STATUS_STACK_BUFFER_OVERRUN

### DIFF
--- a/ports/babl/gir-header-only-on-windows.patch
+++ b/ports/babl/gir-header-only-on-windows.patch
@@ -1,14 +1,8 @@
 diff --git a/babl/meson.build b/babl/meson.build
-index f6dd81c..ec42f68 100644
+index e3129d3..35562f6 100644
 --- a/babl/meson.build
 +++ b/babl/meson.build
-@@ -159,15 +159,19 @@ if build_gir
-   # identity filter, so GIR doesn't choke on the Babl type
-   # (since it has the same name as the Babl namespace)
-   babl_gir = gnome.generate_gir(
-     babl,
-     sources: babl_headers,
-     extra_args: [
+@@ -166,6 +166,10 @@ if build_gir
        '--identifier-filter-cmd=@0@ @1@'.format(python.full_path(), 
        '"' + meson.current_source_dir() / 'identfilter.py' + '"'),
        '-DBABL_IS_BEING_COMPILED',
@@ -19,8 +13,3 @@ index f6dd81c..ec42f68 100644
        '--quiet',
      ],
      namespace: 'Babl',
-     nsversion: api_version,
-     header: 'babl.h',
-     export_packages: 'babl-0.1',
-     install: true,
-   )

--- a/ports/babl/remove-consistency-check.patch
+++ b/ports/babl/remove-consistency-check.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 08332a0571..bd4e31c55f 100644
+index 5f5299a..269dc17 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -580,7 +580,7 @@ if build_docs
+@@ -581,7 +581,7 @@ if build_docs
  endif
  subdir('bin')
  

--- a/ports/babl/support-plugins.patch
+++ b/ports/babl/support-plugins.patch
@@ -1,4 +1,5 @@
 diff --git a/babl/babl.c b/babl/babl.c
+index 6803538..45a43c6 100644
 --- a/babl/babl.c
 +++ b/babl/babl.c
 @@ -101,7 +101,7 @@ babl_dir_list (void)
@@ -10,7 +11,12 @@ diff --git a/babl/babl.c b/babl/babl.c
         * Otherwise, use the directory where the DLL is.
         */
  
-@@ -121,7 +121,7 @@ babl_dir_list (void)
+@@ -117,11 +117,11 @@ babl_dir_list (void)
+               size_t tmp_size;
+ 
+               *(++sep2) = '\0';
+-              tmp_size = strlen (filename) + strlen (BABL_DIR_SEPARATOR BABL_LIBRARY) + 4;
++              tmp_size = strlen (filename) + strlen ("plugins" BABL_DIR_SEPARATOR BABL_LIBRARY) + 1;
                filename_tmp = babl_malloc (sizeof (char) * tmp_size);
                strcpy_s (filename_tmp, tmp_size, filename);
                babl_free (filename);
@@ -20,6 +26,7 @@ diff --git a/babl/babl.c b/babl/babl.c
              }
          }
 diff --git a/extensions/meson.build b/extensions/meson.build
+index 395be57..1d37c30 100644
 --- a/extensions/meson.build
 +++ b/extensions/meson.build
 @@ -85,7 +85,7 @@ foreach ext : extensions
@@ -68,6 +75,7 @@ diff --git a/extensions/meson.build b/extensions/meson.build
    endforeach
  
 diff --git a/meson.build b/meson.build
+index 08332a0..5f5299a 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -29,6 +29,7 @@ buildtype = get_option('buildtype')

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "babl",
   "version": "0.1.126",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c5b72c20889d10e66a77defdb8f554e972988dc",
+      "version": "0.1.126",
+      "port-version": 2
+    },
+    {
       "git-tree": "9bf6eefd4f512c818e8cb0a3c99325a827898ae1",
       "version": "0.1.126",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -626,7 +626,7 @@
     },
     "babl": {
       "baseline": "0.1.126",
-      "port-version": 1
+      "port-version": 2
     },
     "backward-cpp": {
       "baseline": "2023-11-24",


### PR DESCRIPTION
Related: https://github.com/microsoft/vcpkg/pull/53323
Related: https://github.com/microsoft/vcpkg/pull/53342

While reviewing the above PRs GPT 5.6 Sol reports:

>- [`support-plugins.patch`](https://github.com/microsoft/vcpkg/blob/ea1a7396b05637a53bf23c078647ecc0edee4b80/ports/babl/support-plugins.patch#L1-L18) appends `plugins` while allocating only `+ 4` bytes—sufficient for `lib` plus NUL. An installed x64-windows Release pkg-config consumer terminates with `0xc0000409`; Debug does not complete. Setting `BABL_PATH` to the plugins directory makes both pass.

See also https://github.com/GNOME/babl/blob/8307f8d3347f5fececca88e264632d49df9bcb85/babl/babl.c#L116-L125

Regenerates the patches with git diff --output.

(Despite that GPT 5.6 Sol found the problem it did not write this change)