### PR TITLE
[crcpp] Update to 1.2.2.0

### DIFF
--- a/ports/crcpp/install_fixes.patch
+++ b/ports/crcpp/install_fixes.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e5d902..185039c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ cmake_minimum_required (VERSION 3.5)
+ 
+-project(CRCpp VERSION 1.2.1.0)
++project(CRCpp VERSION 1.2.2.0)
+ 
+ include(CMakePackageConfigHelpers)
+ include(GNUInstallDirs)
+@@ -32,14 +32,15 @@ configure_file(
+ configure_package_config_file(
+     cmake/CRCppConfig.cmake.in
+     "${CMAKE_CURRENT_BINARY_DIR}/CRCppConfig.cmake"
+-    INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/crcpp")
++    INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/crcpp"
++    PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+ write_basic_package_version_file(CRCppConfigVersion.cmake
+                                  VERSION ${PACKAGE_VERSION}
+                                  COMPATIBILITY SameMajorVersion
+                                  ARCH_INDEPENDENT)
+ 
+ # Installation
+-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION ${CMAKE_INSTALL_INCLUDE_DIR})
++install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(FILES
+           ${CMAKE_CURRENT_BINARY_DIR}/CRCpp.pc
+         DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+diff --git a/cmake/CRCppConfig.cmake.in b/cmake/CRCppConfig.cmake.in
+index 67139f3..b06cc79 100644
+--- a/cmake/CRCppConfig.cmake.in
++++ b/cmake/CRCppConfig.cmake.in
+@@ -1,3 +1,3 @@
+ @PACKAGE_INIT@
+ 
+-set_and_check(CRCpp_INCLUDE_DIR "@PACKAGE_CRCpp_INCLUDE_INSTALL_DIR@")
++set_and_check(CRCpp_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")

--- a/ports/crcpp/portfile.cmake
+++ b/ports/crcpp/portfile.cmake
@@ -1,13 +1,14 @@
+set(VCPKG_BUILD_TYPE "release") # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO d-bahr/CRCpp
     REF "release-${VERSION}"
-    SHA512 61d6d4636cbf42752568900a1267336721836b80cbe99e1795c74be9fffd9d6368697182565beecf5b4050d649c7a77acbacfac2a20eff9de4073dab4ea073cf
+    SHA512 0e1338eb1f0f2a05d119ffae6071be06c24c39f20dcc846ea2c6248367ce600797af23b1f31dcd0f9e389efadc769bcc7129d8b741c30782571500c731c75451
     HEAD_REF master
+    PATCHES
+        install_fixes.patch
 )
-
-# header-only
-set(VCPKG_BUILD_TYPE "release")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -17,5 +18,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/crcpp/vcpkg.json
+++ b/ports/crcpp/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "crcpp",
-  "version": "1.2.1.0",
+  "version": "1.2.2.0",
   "description": "Easy to use and fast C++ CRC library.",
   "homepage": "https://github.com/d-bahr/CRCpp",
   "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2205,7 +2205,7 @@
       "port-version": 2
     },
     "crcpp": {
-      "baseline": "1.2.1.0",
+      "baseline": "1.2.2.0",
       "port-version": 0
     },
     "crfsuite": {

--- a/versions/c-/crcpp.json
+++ b/versions/c-/crcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3448d1340c8b107a929303fa6f6caa7db940fb3f",
+      "version": "1.2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "907d42101b451a0e70ab9044b669bdf6ca687560",
       "version": "1.2.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.