### PR TITLE
[mimalloc] update to 3.4.5

### DIFF
--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/mimalloc
     REF "v${VERSION}"
-    SHA512 99745743ca69dfce53526ad7ca4730451efda4d086cc11863c7307418686b13394587b7cac1e622fd57b91ed6ced074a01300f08ca5efe43034b815dfbfb80ce
+    SHA512 6cb7d1adc653a14abd209f98c141179393a2aaf78916d46c85f1dd71dc9c898b6a4f3b8b7bda54e008202dce824b7fc8852310b68821700641f8fac9482b4e3e
     HEAD_REF dev3
     PATCHES
         pkgconfig-cxx.diff

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mimalloc",
-  "version": "3.4.3",
+  "version": "3.4.5",
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6637,7 +6637,7 @@
       "port-version": 3
     },
     "mimalloc": {
-      "baseline": "3.4.3",
+      "baseline": "3.4.5",
       "port-version": 0
     },
     "mimicpp": {

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "247ee26c07fe08193aa7c63426291a5a379c8e21",
+      "version": "3.4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "aeb0d4f3b844ca978dd2ef936606cc0c61ea44be",
       "version": "3.4.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #53167 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.
