### PR TITLE
[qca] Fix macOS install names of the crypto plugins

### DIFF
--- a/ports/qca/0004-fix-macos-rpath.patch
+++ b/ports/qca/0004-fix-macos-rpath.patch
@@ -1,0 +1,28 @@
+Subject: [PATCH] macOS: keep @rpath install names
+
+qca 2.3.10 replaced `cmake_policy(SET CMP0042 OLD)` with
+`set(CMAKE_MACOSX_RPATH OFF)`. As a normal (non-cache) variable it overrides
+the `set(CMAKE_MACOSX_RPATH ON CACHE BOOL "")` from vcpkg's osx toolchain.
+
+Combined with USE_RELATIVE_PATHS=ON (which makes qca skip INSTALL_NAME_DIR),
+libqca ends up with the bare install name `libqca.2.dylib`, and the crypto
+plugins record that bare name as their dependency. vcpkg's
+z_vcpkg_fixup_macho_rpath_in_dir repairs libqca itself, but skips the plugins:
+they are CMake MODULEs, which `file -b` reports as "Mach-O 64-bit bundle"
+rather than "shared library"/"executable". The plugins are therefore left with
+an unresolvable dependency and dlopen() fails, so e.g. qca-ossl never
+registers.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7220566..a53557c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,8 +15,6 @@ set(QCA_LIB_MAJOR_VERSION "2")
+ set(QCA_LIB_MINOR_VERSION "3")
+ set(QCA_LIB_PATCH_VERSION "10")
+ 
+-set(CMAKE_MACOSX_RPATH OFF)
+-
+ option(BUILD_WITH_QT6 "Build with Qt 6" OFF)
+ option(BUILD_TESTS "Create test" ON)
+ option(BUILD_TOOLS "Compile mozcerts and qcatool" ON)

--- a/ports/qca/portfile.cmake
+++ b/ports/qca/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         0001-fix-path-for-vcpkg.patch
         0002-fix-build-error.patch
         0003-Define-NOMINMAX-for-botan-plugin-with-MSVC.patch
+        0004-fix-macos-rpath.patch
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)

--- a/ports/qca/vcpkg.json
+++ b/ports/qca/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qca",
   "version": "2.3.10",
+  "port-version": 1,
   "description": "Qt Cryptographic Architecture (QCA).",
   "homepage": "https://userbase.kde.org/QCA",
   "license": "LGPL-2.1-or-later AND BSD-2-Clause AND MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8182,7 +8182,7 @@
     },
     "qca": {
       "baseline": "2.3.10",
-      "port-version": 0
+      "port-version": 1
     },
     "qcbor": {
       "baseline": "1.6.1",

--- a/versions/q-/qca.json
+++ b/versions/q-/qca.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d08aebaf70eda288702860e985fefe10b8197348",
+      "version": "2.3.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "d93407eefa1f741a32b422a660478b00bff93ea2",
       "version": "2.3.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.



Since the update to 2.3.10 (#52994), the qca crypto plugins cannot be loaded on macOS. `QCA::isSupported("cert", "qca-ossl")` returns false, and `dlopen` of the plugin fails with:

```
Library not loaded: libqca.2.dylib
  Referenced from: .../bin/Qca/crypto/libqca-ossl.dylib
  Reason: tried: 'libqca.2.dylib' (no such file), ...
```

qca 2.3.10 replaced `cmake_policy(SET CMP0042 OLD)` with `set(CMAKE_MACOSX_RPATH OFF)`. This overrides `set(CMAKE_MACOSX_RPATH ON CACHE BOOL "")` from `scripts/toolchains/osx.cmake`. Until 2.3.10 the port's `0004-fix-cmake4.patch` deleted the policy call, so `MACOSX_RPATH` stayed on; that patch was dropped in the update and the new `set(... OFF)` took its place.

Combined with `USE_RELATIVE_PATHS=ON` (under which qca deliberately does not set `INSTALL_NAME_DIR`), libqca gets the bare install name `libqca.2.dylib`, and the crypto plugins record that bare name as their dependency.

`z_vcpkg_fixup_macho_rpath_in_dir` repairs `libqca.2.3.10.dylib` itself, but it skips the plugins: they are CMake `MODULE`s, which `file -b` reports as `Mach-O 64-bit bundle`, matching neither `.*Mach-O.*shared library.*` nor `.*Mach-O.*executable.*`. So the plugins keep an unresolvable dependency, and no provider ever registers.
