### PR TITLE
[libtorrent] Update to 2.1.1

### DIFF
--- a/ports/libtorrent/fix-shared-extra-exports.patch
+++ b/ports/libtorrent/fix-shared-extra-exports.patch
@@ -1,10 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 63f903c..c339f3a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1071,6 +1071,12 @@
+@@ -1071,6 +1071,12 @@ if (MSVC)
  	)
  endif()
-
+ 
 +# Tests, examples and tools use some internal functions. Export those symbols
 +# from shared builds whenever any of these targets are enabled.
 +if(build_tests OR build_examples OR build_tools)
@@ -22,4 +23,4 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 -	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_EXPORT_EXTRA)
  	add_subdirectory(test)
  endif()
-
+ 

--- a/ports/libtorrent/fix-shared-extra-exports.patch
+++ b/ports/libtorrent/fix-shared-extra-exports.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1071,6 +1071,12 @@
+ 	)
+ endif()
+
++# Tests, examples and tools use some internal functions. Export those symbols
++# from shared builds whenever any of these targets are enabled.
++if(build_tests OR build_examples OR build_tools)
++	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_EXPORT_EXTRA)
++endif()
++
+ # === build tools ===
+ if (build_tools)
+ 	add_subdirectory(tools)
+@@ -1084,8 +1090,6 @@ endif()
+ # === build tests ===
+ if(build_tests)
+ 	enable_testing()
+-	# this will make some internal functions available in the DLL interface
+-	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_EXPORT_EXTRA)
+ 	add_subdirectory(test)
+ endif()
+

--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
     HEAD_REF RC_2_1
     PATCHES
         use-system-libdatachannel.patch
+        fix-shared-extra-exports.patch
 )
 
 vcpkg_from_github(

--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -1,11 +1,7 @@
-if(VCPKG_TARGET_IS_WINDOWS)
-    # Building python bindings is currently broken on Windows
-    if("python" IN_LIST FEATURES)
-        message(FATAL_ERROR "The python feature is currently broken on Windows")
-    endif()
-    if(VCPKG_CRT_LINKAGE STREQUAL "static")
-        set(_static_runtime ON)
-    endif()
+﻿if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
+    set(_static_runtime ON)
+else()
+    set(_static_runtime OFF)
 endif()
 
 vcpkg_check_features(
@@ -13,78 +9,62 @@ vcpkg_check_features(
     FEATURES
         deprfun     deprecated-functions
         examples    build_examples
-        iconv       iconv
         python      python-bindings
         test        build_tests
         tools       build_tools
-)
-
-if("python" IN_LIST FEATURES)
-    vcpkg_find_acquire_program(PYTHON3)
-    get_filename_component(PYTHON3_PATH ${PYTHON3} DIRECTORY)
-    vcpkg_add_to_path(${PYTHON3_PATH})
-    file(GLOB BOOST_PYTHON_LIB "${CURRENT_INSTALLED_DIR}/lib/*boost_python*")
-    string(REGEX REPLACE ".*(python)([0-9])([0-9]+).*" "\\1\\2\\3" _boost-python-module-name "${BOOST_PYTHON_LIB}")
-endif()
-
-vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO arvidn/libtorrent
-        REF "v${VERSION}"
-        SHA512 375fb12754ce73b34b215c1ca077b0ec58a8c91f6a6e4a48e2ae55251be38f647405d135ebeae38f8b0dfb478bcea8d5f0d6509e97f1baddbc2cd2e788948f2a
-        HEAD_REF RC_2_0
+        webtorrent  webtorrent
 )
 
 vcpkg_from_github(
-        OUT_SOURCE_PATH TRYSIGNAL_SOURCE_PATH
-        REPO arvidn/try_signal
-        REF 105cce59972f925a33aa6b1c3109e4cd3caf583d #2022-10-27
-        SHA512 4a0090755831e0e4a1930817345fa5934144421d9a9d710fe8ed3712233fa2fa037fc0e0d4f88b7cc8fb1bc05fe2d55372af1ff47d6fbf5208e03f45f2a424e4
-        HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO arvidn/libtorrent
+    REF "v${VERSION}"
+    SHA512 5563939466e4240849fd24b1eec394b56f39f71ebae9a26fd858e638e819c78c856afb6146963e998e2e1355eaed56b74f27228980ceed1c53ad189cf3fc2b80
+    HEAD_REF RC_2_1
+    PATCHES
+        use-system-libdatachannel.patch
 )
 
 vcpkg_from_github(
-        OUT_SOURCE_PATH ASIO_GNUTLS_SOURCE_PATH
-        REPO paullouisageneau/boost-asio-gnutls
-        REF a57d4d36923c5fafa9698e14be16b8bc2913700a
-        SHA512 1e093dd4e999cce9c6d74f1d4c2d20f73512258b83505c307c7d53b8c7ed15626a8e90c8e6a6280827aafa069bc233c0c6f4c9276f1c332e4b141c7c350c47c0
-        HEAD_REF master
+    OUT_SOURCE_PATH TRYSIGNAL_SOURCE_PATH
+    REPO arvidn/try_signal
+    REF 105cce59972f925a33aa6b1c3109e4cd3caf583d
+    SHA512 4a0090755831e0e4a1930817345fa5934144421d9a9d710fe8ed3712233fa2fa037fc0e0d4f88b7cc8fb1bc05fe2d55372af1ff47d6fbf5208e03f45f2a424e4
+    HEAD_REF master
 )
 
-vcpkg_from_github(
-        OUT_SOURCE_PATH LIB_SIMULATOR_SOURCE_PATH
-        REPO arvidn/libsimulator
-        REF 39144efe83fcd38778cf76fc609e3475694642ca #2022-10-27
-        SHA512 a021f769d52d127355ecaceaf912bf3e86aaa256d4768d270fbe6066793b6159eddecd0262f3f2158602f883d49b3aac39eb79be5399212cdd7711f921ffa15a
-        HEAD_REF master
-)
-
-file(COPY ${TRYSIGNAL_SOURCE_PATH}/ DESTINATION ${SOURCE_PATH}/deps/try_signal)
-file(COPY ${ASIO_GNUTLS_SOURCE_PATH}/ DESTINATION ${SOURCE_PATH}/deps/asio-gnutls)
-file(COPY ${LIB_SIMULATOR_SOURCE_PATH}/ DESTINATION ${SOURCE_PATH}/simulation/libsimulator)
+file(COPY "${TRYSIGNAL_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/deps/try_signal")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-       ${FEATURE_OPTIONS}
-       -Dboost-python-module-name=${_boost-python-module-name}
-       -Dstatic_runtime=${_static_runtime}
-       -DPython3_USE_STATIC_LIBS=ON
+        ${FEATURE_OPTIONS}
+        -Dstatic_runtime=${_static_runtime}
+        -Dgnutls=OFF
 )
-
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME LibtorrentRasterbar CONFIG_PATH lib/cmake/LibtorrentRasterbar)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME LibtorrentRasterbar
+    CONFIG_PATH lib/cmake/LibtorrentRasterbar
+)
 
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
-# Do not duplicate include files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/share/cmake")
+file(
+    REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/cmake"
+)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-       file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(
+        REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
 endif()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -1,7 +1,25 @@
-﻿if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
     set(_static_runtime ON)
 else()
     set(_static_runtime OFF)
+endif()
+
+# Libtorrent exports TORRENT_ABI_VERSION=2 when deprecated-functions is enabled,
+# and 100 otherwise. Public headers use this value to select their ABI:
+# https://github.com/arvidn/libtorrent/blob/56ae8caba38bf154ffc210403cb23f91d0ecaa49/CMakeLists.txt#L738-L741
+if("deprfun" IN_LIST FEATURES)
+    set(_torrent_abi_version 2)
+else()
+    set(_torrent_abi_version 100)
+endif()
+
+# Libtorrent exports TORRENT_USE_RTC=0 when WebTorrent is disabled. When enabled,
+# config.hpp defaults it to 1, so no explicit definition is emitted:
+# https://github.com/arvidn/libtorrent/blob/56ae8caba38bf154ffc210403cb23f91d0ecaa49/CMakeLists.txt#L749-L750
+if("webtorrent" IN_LIST FEATURES)
+    set(_torrent_use_rtc 1)
+else()
+    set(_torrent_use_rtc 0)
 endif()
 
 vcpkg_check_features(
@@ -46,12 +64,54 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+# These mirror libtorrent's public target compile definitions for this port's
+# fixed OpenSSL configuration. TORRENT_USE_LIBCRYPTO also selects the public
+# lcrypto inline namespace, so headers must define it to match the library ABI.
+# https://github.com/arvidn/libtorrent/blob/56ae8caba38bf154ffc210403cb23f91d0ecaa49/CMakeLists.txt#L769-L784
+set(_torrent_header_config [=[
+#ifndef TORRENT_USE_OPENSSL
+#define TORRENT_USE_OPENSSL
+#endif
+#ifndef TORRENT_USE_LIBCRYPTO
+#define TORRENT_USE_LIBCRYPTO
+#endif
+#ifndef TORRENT_SSL_PEERS
+#define TORRENT_SSL_PEERS
+#endif
+#ifndef TORRENT_ABI_VERSION
+#define TORRENT_ABI_VERSION @_torrent_abi_version@
+#endif
+#ifndef TORRENT_USE_RTC
+#define TORRENT_USE_RTC @_torrent_use_rtc@
+#endif
+]=])
+string(CONFIGURE "${_torrent_header_config}" _torrent_header_config @ONLY)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    # Libtorrent exports this definition when building torrent-rasterbar shared:
+    # https://github.com/arvidn/libtorrent/blob/56ae8caba38bf154ffc210403cb23f91d0ecaa49/CMakeLists.txt#L549-L554
+    string(APPEND _torrent_header_config [=[
+#ifndef TORRENT_LINKING_SHARED
+#define TORRENT_LINKING_SHARED
+#endif
+]=])
+endif()
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/include/libtorrent/config.hpp"
+    "#define TORRENT_CONFIG_HPP_INCLUDED"
+    "#define TORRENT_CONFIG_HPP_INCLUDED\n${_torrent_header_config}"
+)
+
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME LibtorrentRasterbar
     CONFIG_PATH lib/cmake/LibtorrentRasterbar
 )
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/include/libtorrent/aux_/puff.hpp"
+        "${TRYSIGNAL_SOURCE_PATH}/LICENSE"
+)
 
 file(
     REMOVE_RECURSE

--- a/ports/libtorrent/use-system-libdatachannel.patch
+++ b/ports/libtorrent/use-system-libdatachannel.patch
@@ -1,0 +1,99 @@
+﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -846,30 +846,10 @@
+ endif()
+ 
+ if (webtorrent)
+-	option(NO_WEBSOCKET "Disable WebSocket support in libdatachannel" ON)
+-	option(NO_MEDIA "Disable media transport support in libdatachannel" ON)
+-	if(GNUTLS_FOUND)
+-		option(USE_GNUTLS "Use GnuTLS instead of OpenSSL for libdatachannel" ON)
++	if (BUILD_SHARED_LIBS)
++		find_package(LibDataChannel CONFIG REQUIRED)
+ 	else()
+-		option(USE_GNUTLS "Use GnuTLS instead of OpenSSL for libdatachannel" OFF)
+-	endif()
+-
+-    set(LIBDATACHANNEL_STATIC ON CACHE BOOL "" FORCE)
+-    set(LIBDATACHANNEL_EXPORT OFF CACHE BOOL "" FORCE)
+-    set(LIBDATACHANNEL_INSTALL OFF CACHE BOOL "" FORCE)
+-    set(PLOG_INSTALL OFF CACHE BOOL "" FORCE)
+-    set(JUICE_INSTALL OFF CACHE BOOL "" FORCE)
+-    set(NO_EXAMPLES ON CACHE BOOL "" FORCE)
+-    set(NO_TESTS ON CACHE BOOL "" FORCE)
+-
+-	add_subdirectory(deps/libdatachannel EXCLUDE_FROM_ALL)
+-	set_target_properties(datachannel-static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+-
+-	if(CMAKE_CXX_COMPILER_ID MATCHES Clang|GNU)
+-		target_compile_options(datachannel-static PRIVATE
+-			-Wno-pedantic
+-			-Wno-unused-parameter
+-			-Wno-unused-variable)
++		find_public_dependency(LibDataChannel CONFIG REQUIRED)
+ 	endif()
+ endif()
+ 
+@@ -960,17 +940,12 @@
+ add_subdirectory(bindings)
+ 
+ if(webtorrent)
+-    set(USRSCTP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/libdatachannel/deps/usrsctp/usrsctplib")
+-    target_include_directories(datachannel-static PRIVATE "${USRSCTP_INCLUDE_DIR}")
+-    target_include_directories(torrent-rasterbar PRIVATE
+-        "${USRSCTP_INCLUDE_DIR}"
+-        deps/libdatachannel/include
+-        deps/libdatachannel/include/rtc
+-    )
+     if (BUILD_SHARED_LIBS)
+-        target_link_libraries(torrent-rasterbar PRIVATE datachannel-static)
++        target_link_libraries(torrent-rasterbar PRIVATE LibDataChannel::LibDataChannel)
+     else()
+-        target_link_libraries(torrent-rasterbar PUBLIC datachannel-static)
++        target_link_libraries(torrent-rasterbar PUBLIC LibDataChannel::LibDataChannel)
+     endif()
+-    target_compile_definitions(torrent-rasterbar PRIVATE BOOST_JSON_HEADER_ONLY)
++    target_compile_definitions(torrent-rasterbar PRIVATE
++        BOOST_JSON_HEADER_ONLY
++        BOOST_JSON_STATIC_LINK)
+ endif()
+@@ -980,15 +955,5 @@
+ endif()
+ 
+ set(LIBTORRENT_EXPORT_TARGETS torrent-rasterbar)
+-if (webtorrent AND NOT BUILD_SHARED_LIBS)
+-    # these are only linked PUBLIC (and therefore need to be installed and
+-    # part of the export set) when torrent-rasterbar itself is static; for a
+-    # shared build they're linked PRIVATE and are already embedded in
+-    # libtorrent-rasterbar.so, so consumers never need them
+-    list(APPEND LIBTORRENT_EXPORT_TARGETS datachannel-static juice-static plog usrsctp)
+-	if (TARGET usrsctp)
+-        set_target_properties(usrsctp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
+-    endif()
+-endif()
+ 
+ install(TARGETS ${LIBTORRENT_EXPORT_TARGETS}
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -47,15 +47,9 @@
+ if (webtorrent AND TARGET test_rtc)
+-	# torrent-rasterbar links datachannel-static privately when building
+-	# shared libs (so its include directories aren't propagated to
+-	# consumers), and test_rtc.cpp includes <rtc/rtc.hpp> directly; only
+-	# the include path is needed here, NOT a
+-	# direct link -- datachannel-static is a static library, so linking it
+-	# into test_rtc directly would give test_rtc its own separate copy of
+-	# everything in it (ThreadPool, Init, and any other global/static state),
+-	# disconnected from the copy torrent-rasterbar's own compiled code
+-	# (rtc_signaling.cpp) actually uses
++	# torrent-rasterbar links LibDataChannel privately when building shared
++	# libs, so its include directories are not propagated to consumers.
++	# test_rtc.cpp includes <rtc/rtc.hpp> directly, so expose only its include path.
+ 	target_include_directories(test_rtc PRIVATE
+-		$<TARGET_PROPERTY:datachannel-static,INTERFACE_INCLUDE_DIRECTORIES>)
++		$<TARGET_PROPERTY:LibDataChannel::LibDataChannel,INTERFACE_INCLUDE_DIRECTORIES>)
+ endif()
+ 
+ file(GLOB GZIP_ASSETS "${CMAKE_CURRENT_SOURCE_DIR}/*.gz")

--- a/ports/libtorrent/use-system-libdatachannel.patch
+++ b/ports/libtorrent/use-system-libdatachannel.patch
@@ -77,7 +77,7 @@
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -47,15 +47,9 @@
+@@ -47,15 +47,5 @@
  if (webtorrent AND TARGET test_rtc)
 -	# torrent-rasterbar links datachannel-static privately when building
 -	# shared libs (so its include directories aren't propagated to
@@ -88,12 +88,9 @@ diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
 -	# everything in it (ThreadPool, Init, and any other global/static state),
 -	# disconnected from the copy torrent-rasterbar's own compiled code
 -	# (rtc_signaling.cpp) actually uses
-+	# torrent-rasterbar links LibDataChannel privately when building shared
-+	# libs, so its include directories are not propagated to consumers.
-+	# test_rtc.cpp includes <rtc/rtc.hpp> directly, so expose only its include path.
- 	target_include_directories(test_rtc PRIVATE
+-	target_include_directories(test_rtc PRIVATE
 -		$<TARGET_PROPERTY:datachannel-static,INTERFACE_INCLUDE_DIRECTORIES>)
-+		$<TARGET_PROPERTY:LibDataChannel::LibDataChannel,INTERFACE_INCLUDE_DIRECTORIES>)
++	target_link_libraries(test_rtc PRIVATE LibDataChannel::LibDataChannel)
  endif()
  
  file(GLOB GZIP_ASSETS "${CMAKE_CURRENT_SOURCE_DIR}/*.gz")

--- a/ports/libtorrent/use-system-libdatachannel.patch
+++ b/ports/libtorrent/use-system-libdatachannel.patch
@@ -90,7 +90,7 @@ diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
 -	# (rtc_signaling.cpp) actually uses
 -	target_include_directories(test_rtc PRIVATE
 -		$<TARGET_PROPERTY:datachannel-static,INTERFACE_INCLUDE_DIRECTORIES>)
-+	target_link_libraries(test_rtc PRIVATE LibDataChannel::LibDataChannel)
++	target_link_libraries(test_rtc LibDataChannel::LibDataChannel)
  endif()
  
  file(GLOB GZIP_ASSETS "${CMAKE_CURRENT_SOURCE_DIR}/*.gz")

--- a/ports/libtorrent/use-system-libdatachannel.patch
+++ b/ports/libtorrent/use-system-libdatachannel.patch
@@ -1,7 +1,8 @@
-﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 63f903c..2f7286d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -846,30 +846,10 @@
+@@ -846,30 +846,10 @@ else()
  endif()
  
  if (webtorrent)
@@ -35,7 +36,7 @@
  	endif()
  endif()
  
-@@ -960,17 +940,12 @@
+@@ -960,19 +940,14 @@ include(CheckCXXCompilerFlag)
  add_subdirectory(bindings)
  
  if(webtorrent)
@@ -58,7 +59,9 @@
 +        BOOST_JSON_HEADER_ONLY
 +        BOOST_JSON_STATIC_LINK)
  endif()
-@@ -980,15 +955,5 @@
+ 
+ if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+@@ -980,16 +955,6 @@ if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
  endif()
  
  set(LIBTORRENT_EXPORT_TARGETS torrent-rasterbar)
@@ -74,10 +77,14 @@
 -endif()
  
  install(TARGETS ${LIBTORRENT_EXPORT_TARGETS}
+     EXPORT LibtorrentRasterbarTargets
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 885818c..e7f7a7b 100644
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -47,15 +47,5 @@
+@@ -44,17 +44,7 @@ foreach(TARGET_SRC ${tests})
+ endforeach()
+ 
  if (webtorrent AND TARGET test_rtc)
 -	# torrent-rasterbar links datachannel-static privately when building
 -	# shared libs (so its include directories aren't propagated to

--- a/ports/libtorrent/vcpkg.json
+++ b/ports/libtorrent/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "An efficient feature complete C++ BitTorrent implementation",
   "homepage": "https://libtorrent.org",
   "documentation": "https://libtorrent.org/reference.html",
-  "license": "BSD-2-Clause",
+  "license": "BSD-3-Clause AND Zlib AND BSL-1.0 AND APSL-2.0 AND BSD-4-Clause",
   "supports": "!uwp",
   "dependencies": [
     "boost-asio",

--- a/ports/libtorrent/vcpkg.json
+++ b/ports/libtorrent/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtorrent",
-  "version": "2.0.11",
+  "version": "2.1.1",
   "maintainers": "Arvid Norberg <arvid.norberg@gmail.com>",
   "description": "An efficient feature complete C++ BitTorrent implementation",
   "homepage": "https://libtorrent.org",
@@ -33,32 +33,53 @@
     }
   ],
   "default-features": [
-    "iconv"
+    {
+      "name": "webtorrent",
+      "platform": "!xbox"
+    }
   ],
   "features": {
     "deprfun": {
-      "description": "build with deprecated functions enabled"
+      "description": "Build with deprecated libtorrent APIs enabled"
     },
     "examples": {
-      "description": "build the examples in the examples directory"
-    },
-    "iconv": {
-      "description": "build with libiconv",
-      "dependencies": [
-        "libiconv"
-      ]
+      "description": "Build the examples in the examples directory"
     },
     "python": {
-      "description": "build the python bindings in bindings/python directory",
+      "description": "Build the Python bindings",
+      "supports": "native & !emscripten & !ios & !android & !mingw & !(staticcrt & windows)",
       "dependencies": [
-        "boost-python"
+        "boost-python",
+        {
+          "name": "libtorrent",
+          "default-features": false,
+          "features": [
+            "deprfun"
+          ]
+        },
+        {
+          "name": "python3",
+          "default-features": false,
+          "features": [
+            "extensions"
+          ]
+        }
       ]
     },
     "test": {
-      "description": "build the libtorrent tests"
+      "description": "Build the libtorrent tests"
     },
     "tools": {
-      "description": "build the tools in the tools directory"
+      "description": "Build the libtorrent tools"
+    },
+    "webtorrent": {
+      "description": "Build with WebTorrent/WebRTC support",
+      "supports": "!xbox",
+      "dependencies": [
+        "boost-beast",
+        "boost-json",
+        "libdatachannel"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5817,7 +5817,7 @@
       "port-version": 0
     },
     "libtorrent": {
-      "baseline": "2.0.11",
+      "baseline": "2.1.1",
       "port-version": 0
     },
     "libtracepoint": {

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d81d748ae3f6e48ac720850da74786edd55bd151",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f442bff5e6f8cc0a4a7b1226db0b7d8069b68b4c",
       "version": "2.0.11",
       "port-version": 0

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "036e6ed0f06d3dd40058fbe78c9e556933cbbf24",
+      "git-tree": "74bbddc5a2f9bca0f7bbc4b713b0ffdd0f766ef6",
       "version": "2.1.1",
       "port-version": 0
     },

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "521c3ac14c7d8f9eac929a7eeaba307f14098ad5",
+      "git-tree": "d596f65ca27f07edcec4076ba5001dffd2dcb5d3",
       "version": "2.1.1",
       "port-version": 0
     },

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d81d748ae3f6e48ac720850da74786edd55bd151",
+      "git-tree": "036e6ed0f06d3dd40058fbe78c9e556933cbbf24",
       "version": "2.1.1",
       "port-version": 0
     },

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "74bbddc5a2f9bca0f7bbc4b713b0ffdd0f766ef6",
+      "git-tree": "521c3ac14c7d8f9eac929a7eeaba307f14098ad5",
       "version": "2.1.1",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

## Summary

Update `libtorrent` from 2.0.11 to 2.1.1.

This update also adapts the port to libtorrent 2.1's WebTorrent support and modernizes the Python binding integration.

## Changes

* Update libtorrent to 2.1.1 and switch `HEAD_REF` from `RC_2_0` to `RC_2_1`.
* Remove the obsolete `iconv` feature.
* Add a `webtorrent` feature and enable it by default where supported, matching libtorrent 2.1's upstream default.
* Use vcpkg's `libdatachannel` port instead of libtorrent's bundled libdatachannel tree.
* Add `boost-json` and `libdatachannel` dependencies for WebTorrent.
* Keep `try_signal` as an explicitly populated submodule dependency because libtorrent compiles its sources directly into `torrent-rasterbar`.
* Remove the old `asio-gnutls` and `libsimulator` source population from the port because they are not required by this CMake configuration.
* Remove the old Python interpreter/path/Boost.Python-name workarounds and rely on vcpkg's current Python3 CMake integration.
* Restrict the Python feature to native builds and supported Python extension configurations because upstream executes the discovered Python interpreter during CMake configuration.
* Make the Python feature enable libtorrent's deprecated API feature, which is required by the upstream Python bindings.

## WebTorrent dependency handling

Upstream libtorrent 2.1 builds a bundled static copy of libdatachannel when WebTorrent is enabled. In vcpkg this port instead uses the existing `libdatachannel` package.

The patch:

* resolves `LibDataChannel` with `find_package()`;
* links `LibDataChannel::LibDataChannel`;
* records `LibDataChannel` as a public package dependency for static libtorrent builds;
* keeps it private for shared libtorrent builds;
* removes bundled libdatachannel/usrsctp/libjuice/plog targets from libtorrent's install export set;
* updates `test_rtc` to obtain the RTC include path from the imported vcpkg target.

The vcpkg libdatachannel package is used instead of libtorrent's bundled copy. This allows libdatachannel and its transitive dependencies to be managed consistently by vcpkg. The defualt config with upstream may will build [core,ws].

Fix: #52903 #50461 
close: #50474 
