### PR TITLE
[libpq] Fix build for iOS

### DIFF
--- a/ports/libpq/apple/ios-system.diff
+++ b/ports/libpq/apple/ios-system.diff
@@ -1,0 +1,37 @@
+diff --git a/src/fe_utils/archive.c b/src/fe_utils/archive.c
+index 5de3617..1d010e0 100644
+--- a/src/fe_utils/archive.c
++++ b/src/fe_utils/archive.c
+@@ -18,6 +18,10 @@
+ #include <unistd.h>
+ #include <sys/stat.h>
+ 
++#ifdef __APPLE__
++#include <TargetConditionals.h>
++#endif
++
+ #include "access/xlog_internal.h"
+ #include "common/archive.h"
+ #include "common/logging.h"
+@@ -54,8 +58,21 @@ RestoreArchivedFile(const char *path, const char *xlogfname,
+ 	 * archival storage.
+ 	 */
+ 	fflush(NULL);
++#if defined(__APPLE__) && TARGET_OS_IPHONE
++	/*
++	 * Apple's non-macOS platforms provide no command shell, so their C library
++	 * marks system() as unavailable and restore_command cannot work there.
++	 * Report the failure at runtime instead of failing to build.  Despite its
++	 * name, TARGET_OS_IPHONE covers all of them: iOS, tvOS, watchOS, visionOS,
++	 * Mac Catalyst and their simulators.
++	 */
++	pfree(xlogRestoreCmd);
++	pg_log_error("\"restore_command\" is not supported on this platform");
++	return -1;
++#else
+ 	rc = system(xlogRestoreCmd);
+ 	pfree(xlogRestoreCmd);
++#endif
+ 
+ 	if (rc == 0)
+ 	{

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive(
         windows/macro-def.patch
         windows/spin_delay.patch
         windows/getopt.patch
+        apple/ios-system.diff
 )
 
 file(GLOB _py3_include_path "${CURRENT_HOST_INSTALLED_DIR}/include/python3*")
@@ -45,6 +46,12 @@ endif()
 
 if("nls" IN_LIST FEATURES)
     list(APPEND MESON_OPTIONS -Dnls=enabled)
+endif()
+
+if(VCPKG_TARGET_IS_IOS)
+    # PostgreSQL probes for a sysroot with `xcrun --sdk macosx` and appends the
+    # result to the link flags, which overrides the SDK selected by vcpkg.
+    vcpkg_list(APPEND MESON_OPTIONS "-Ddarwin_sysroot=${VCPKG_DETECTED_CMAKE_OSX_SYSROOT}")
 endif()
 
 if("client" IN_LIST FEATURES)

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpq",
   "version": "18.4",
+  "port-version": 1,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5550,7 +5550,7 @@
     },
     "libpq": {
       "baseline": "18.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libpqxx": {
       "baseline": "8.0.2",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ca8404192047b571d2820427cca0a8ae49abc09",
+      "version": "18.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "8c165a9c39a43f72289e216677d33fdf161144f8",
       "version": "18.4",
       "port-version": 0


### PR DESCRIPTION
Two independent failures broke every iOS triplet:

- PostgreSQL probes for a sysroot with `xcrun --sdk macosx` and appends the result to the link flags, overriding the SDK selected by vcpkg. Every link-based meson check then failed against the wrong platform, surfacing as the misleading "openssl function CRYPTO_new_ex_data is required". Pass -Ddarwin_sysroot to point PostgreSQL at the right SDK.

- src/fe_utils/archive.c calls system() to run restore_command, which Apple's non-macOS platforms mark unavailable. fe_utils is built even with tools disabled because ecpg links it, so this broke the build regardless of the selected features.


Built locally on macOS 15.7.7 / Xcode 16.3, host `x64-osx`, target `arm64-ios`, producing a `.framework` that links `PostgreSQL::PostgreSQL`. Note that the iOS triplets are community triplets and are not covered by vcpkg CI.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
