### PR TITLE
[tree-sitter] update to 0.26.12

### DIFF
--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter
     REF "v${VERSION}"
-    SHA512 2175f7d1f913fffaba7395baa7b0a3228172bdc25169d22cf3e39fa3841df1a9902031e248e417328f8ea3e48e7042d34bf85a36c8545a79ca5f7321c6b9d848
+    SHA512 d0e5596b9445bf94177927f5ca6053f473bced8eee9d27f878677c37ad4e1f13d8898220c7156743b57f6c9591840c9c1accb9e1f6f54a6ac302a6875c48466b
     HEAD_REF master
     PATCHES
         unofficial-cmake.diff

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "tree-sitter",
-  "version-semver": "0.26.11",
+  "version-semver": "0.26.12",
   "description": "An incremental parsing system for programming tools.",
-  "homepage": "https://tree-sitter.github.io/",
+  "homepage": "https://tree-sitter.github.io/tree-sitter/",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10377,7 +10377,7 @@
       "port-version": 1
     },
     "tree-sitter": {
-      "baseline": "0.26.11",
+      "baseline": "0.26.12",
       "port-version": 0
     },
     "tree-sitter-c": {

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e51fb9eb6e3f092d60330b958825d3ff7fc3be5",
+      "version-semver": "0.26.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "eab591fac8d2af2d1d53482a46ba507a6581f6de",
       "version-semver": "0.26.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.12
