### PR TITLE
[openexr] update to 3.4.14

### DIFF
--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/openexr
     REF "v${VERSION}"
-    SHA512 da3310f9c3f8b927c7f8fca9edeb381f16e5a492298ae19a3f9d54fa46859542a71ca923a7806ed40a9bbddea34e15cfaa25f9a07a288cc70f0e0fd267a52729
+    SHA512 dd7919417713c5407d41740dd219d6ba49c5defe234d332f83a914ce507d72ff9a656885149d94ee8f76c8bbbd710c7232e3a402bd3c49fd8df9943ef941aed3
     HEAD_REF main
 )
 

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openexr",
-  "version": "3.4.13",
+  "version": "3.4.14",
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7461,7 +7461,7 @@
       "port-version": 9
     },
     "openexr": {
-      "baseline": "3.4.13",
+      "baseline": "3.4.14",
       "port-version": 0
     },
     "openfbx": {

--- a/versions/o-/openexr.json
+++ b/versions/o-/openexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c1b9216b23b3ffec556cdb4b52c7967ca1ed44d",
+      "version": "3.4.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "48521629e41c4a321b28dc3db54695be41c66e2f",
       "version": "3.4.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.14
