### PR TITLE
[scinumtools3] Update to v0.6.3

### DIFF
--- a/ports/scinumtools3/portfile.cmake
+++ b/ports/scinumtools3/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vrtulka23/scinumtools3
-    REF v0.5.11
-    SHA512 301484eb60e70baf703b97291f5ca668a0c74f7986641aa0ae09e57489e195cfa1e49c85d03bc37b566bfec849bb3f247a285b49a680f4a4a28e5133ac2f76d5
+    REF v0.6.3
+    SHA512 035501012adab118a82b56803af14cf68d6feeb9f8d9bf419d59af9feb0e7bfd085ef2957ed99eedc50569de71e0ef2cfc95c62d46e2a157e02064aec7d03468
 )
 
 vcpkg_cmake_configure(

--- a/ports/scinumtools3/vcpkg.json
+++ b/ports/scinumtools3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "scinumtools3",
-  "version": "0.5.11",
+  "version": "0.6.3",
   "description": "SciNumTools3: C++ toolkit for unit-aware scientific computation with runtime expressions and validated parameters.",
   "homepage": "https://github.com/vrtulka23/scinumtools3",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9129,7 +9129,7 @@
       "port-version": 0
     },
     "scinumtools3": {
-      "baseline": "0.5.11",
+      "baseline": "0.6.3",
       "port-version": 0
     },
     "sciplot": {

--- a/versions/s-/scinumtools3.json
+++ b/versions/s-/scinumtools3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ddbe0fe579ae5b6a8a15800d5b25455f7ed5cb2",
+      "git-tree": "475e5e0d3c61b71b13b66ee2b46efa571858cb11",
       "version": "0.6.3",
       "port-version": 0
     },

--- a/versions/s-/scinumtools3.json
+++ b/versions/s-/scinumtools3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ddbe0fe579ae5b6a8a15800d5b25455f7ed5cb2",
+      "version": "0.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "efeada69253b063572a7de870a8ae9665c557e14",
       "version": "0.5.11",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
