### PR TITLE
[angle] Demote Linux system-dependency notice to STATUS

### DIFF
--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -1,6 +1,5 @@
 if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING "Building with a gcc version less than 6.1 is not supported.")
-    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    mesa-common-dev\n\nThese can be installed on Ubuntu systems via apt-get install mesa-common-dev.")
+    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    mesa-common-dev\n\nThese can be installed on Ubuntu systems via apt-get install mesa-common-dev.")
 endif()
 
 if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_7258",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56459234eb0caf4dd6137f538c97157fa219e99c",
+      "version-string": "chromium_7258",
+      "port-version": 3
+    },
+    {
       "git-tree": "6eb27c13ec4328ed3d63f058a485a4e213087bda",
       "version-string": "chromium_7258",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -154,7 +154,7 @@
     },
     "angle": {
       "baseline": "chromium_7258",
-      "port-version": 2
+      "port-version": 3
     },
     "ankurvdev-embedresource": {
       "baseline": "0.0.12",


### PR DESCRIPTION
Every Linux configure of a project consuming `angle` prints two `CMake Warning` blocks from `ports/angle/portfile.cmake`, neither of which is actionable.

**The gcc 6.1 line is dead text.** It predates #10414 (March 2020), and vcpkg's toolchain floor is now well past 6.1. It also could never have been made conditional: portfiles run in CMake script mode (`cmake -P` via `scripts/ports.cmake`, which unsets the `CMAKE_*` variables with the comment "These don't make sense in script context"), so no compiler is configured and `CMAKE_CXX_COMPILER_VERSION` is empty there. Consistently, no port in the tree checks a compiler version from a portfile. Removed.

**The `mesa-common-dev` notice is informational, not a diagnostic.** `WARNING` overstates it — in CMake semantics `WARNING` means something is wrong, and here nothing is. The tree is inconsistent today for this exact class of notice: `at-spi2-core` uses `STATUS`, while `freeglut`, `libusb` and `speex` use a bare `message()`. This aligns `angle` with `at-spi2-core`. For the same reason the check cannot be made conditional either: `check_include_file()` needs `try_compile`, which is unavailable in script mode.

No build behaviour changes; only the severity and presence of two messages.

Scoped deliberately to `angle`. `glew` and `libepoxy` carry the same overstated `WARNING` and could follow in a separate PR if maintainers want the tree uniform.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. *(n/a — no download changed)*
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed. *(patches unchanged)*
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
