### PR TITLE
Updating [Jsonifier] to v1.0.1 

### DIFF
--- a/ports/jsonifier/portfile.cmake
+++ b/ports/jsonifier/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO realtimechris/jsonifier
+    REPO nihilai-collective/jsonifier
     REF "v${VERSION}"
-    SHA512 d417e8da4c4f64b7a37d70c85343daae46f52e72d5b0043b076fc5e18a0642cce7f5214aee7029b2acfb5953300977c5538f99098f0925fabc1199279408b820
+    SHA512 259b9b90aa093e1c6c79ddc1867199cc0256b3ac2066d4ea1606ba7727cc73c9bb690c4c4f27820098fad7c5bb339db6bbc00e6a3aa97427cd18b1f781ca502f
     HEAD_REF main
 )
 
@@ -14,4 +14,4 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.md")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.md" "${SOURCE_PATH}/Third_Party_Licenses.md")

--- a/ports/jsonifier/vcpkg.json
+++ b/ports/jsonifier/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "jsonifier",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A few classes for parsing and serializing json - very rapidly.",
-  "homepage": "https://github.com/realtimechris/jsonifier",
+  "homepage": "https://github.com/nihilai-collective/jsonifier",
   "license": "MIT",
   "supports": "(windows & x64 & !xbox) | (linux & x64) | (osx & x64)",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4241,7 +4241,7 @@
       "port-version": 0
     },
     "jsonifier": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "jsonnet": {

--- a/versions/j-/jsonifier.json
+++ b/versions/j-/jsonifier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d2cc770f9f1c0b006040573634c073af1c43888",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3a8dace2df243b3c7458fd7840fb2f232c1a85f4",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
## Update jsonifier to v1.0.1

This updates the `jsonifier` port to **v1.0.1** and migrates the upstream repository from `realtimechris/jsonifier` to `nihilai-collective/jsonifier` (the project's new organizational home).

### Summary of upstream changes since the last port update

This is a large release covering nearly every layer of the library:

- **Structural indexing** switched from raw pointers to compact `uint32_t` offsets across parsing, serialization, minification, and prettification, reducing memory footprint and improving cache behavior.
- **Full UTF-8 validation now runs by default** during parsing, backed by a Lemire/simdjson-derived streaming validator and an extensive new conformance suite (including the full Markus Kuhn UTF-8 stress-test corpus).
- **New experimental ARM SVE2 SIMD backend**, alongside existing NEON, AVX, AVX2, and AVX-512 support. AVX-512 codepath gating was also tightened to require F+BW+VBMI2 support together. PCLMULQDQ detection was added.
- **Parsing, validation, minification, and prettification** were reworked to propagate failure immediately (bool-returning, fail-fast) instead of continuing to process a buffer after the first error.
- Numerous correctness fixes, including a big-endian serialization bug, an `array::at()` bounds-check that previously failed to throw, and an `array::end()` iterator bug.
- Substantially expanded test coverage, including the full JSONTestSuite conformance corpus and dedicated SIMD-intrinsics correctness tests.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
