### PR TITLE
[dlib] fix public compiler flags leaking to consumers

### DIFF
--- a/ports/dlib/fix-flags.patch
+++ b/ports/dlib/fix-flags.patch
@@ -1,0 +1,195 @@
+diff --git a/dlib/CMakeLists.txt b/dlib/CMakeLists.txt
+index 2c69a29..46aeedf 100644
+--- a/dlib/CMakeLists.txt
++++ b/dlib/CMakeLists.txt
+@@ -816,13 +816,12 @@ if (NOT TARGET dlib)
+    endif()
+ 
+    target_compile_features(dlib PUBLIC cxx_std_14)
+-   if((MSVC AND CMAKE_VERSION VERSION_LESS 3.11))
+-      target_compile_options(dlib PUBLIC ${active_compile_opts})
+-      target_compile_options(dlib PRIVATE ${active_compile_opts_private})
+-   else()
+-      target_compile_options(dlib PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${active_compile_opts}>)
+-      target_compile_options(dlib PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${active_compile_opts_private}>)
+-   endif()
++   # Build-tree clients share dlib's compiler, so forward the options detected
++   # above to them. Do not put those options in the installed target, where
++   # dlibConfig.cmake recreates them for the consuming compiler's frontend.
++   target_compile_options(dlib INTERFACE "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${active_compile_opts}>>")
++   target_compile_options(dlib PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${active_compile_opts}>)
++   target_compile_options(dlib PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${active_compile_opts_private}>)
+ 
+    # Install the library
+    if (NOT DLIB_IN_PROJECT_BUILD)
+diff --git a/dlib/cmake_utils/dlibConfig.cmake.in b/dlib/cmake_utils/dlibConfig.cmake.in
+index 24755ce..bcf5fe4 100644
+--- a/dlib/cmake_utils/dlibConfig.cmake.in
++++ b/dlib/cmake_utils/dlibConfig.cmake.in
+@@ -27,7 +27,7 @@ endif()
+ 
+  
+ # Our library dependencies (contains definitions for IMPORTED targets)
+-if(NOT TARGET dlib-shared AND NOT dlib_BINARY_DIR)
++if(NOT TARGET dlib::dlib AND NOT TARGET dlib-shared AND NOT dlib_BINARY_DIR)
+    # Compute paths
+    get_filename_component(dlib_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+    include("${dlib_CMAKE_DIR}/dlib.cmake")
+@@ -41,6 +41,73 @@ if(NOT TARGET dlib-shared AND NOT dlib_BINARY_DIR)
+    endif()
+    unset(dlib_deps_threads_idx)
+    unset(dlib_deps_threads_check)
++
++   # Compiler options on an imported target are evaluated in the consuming
++   # project, not in the project that built dlib.  Select them here so an
++   # installed package never passes (for example) cl-style options to the
++   # clang++ driver.  MSVC is intentionally used instead of the compiler ID:
++   # CMake also sets it for compilers such as clang-cl that accept cl syntax.
++   set(_dlib_compile_options)
++   set(_dlib_compile_definitions)
++   set(_dlib_simd_level "@DLIB_SIMD_LEVEL@")
++
++   if(MSVC)
++      list(APPEND _dlib_compile_options /bigobj)
++
++      if(_dlib_simd_level STREQUAL "AVX")
++         list(APPEND _dlib_compile_options /arch:AVX)
++      elseif(_dlib_simd_level STREQUAL "SSE4")
++         if(CMAKE_SIZEOF_VOID_P EQUAL 4)
++            list(APPEND _dlib_compile_options /arch:SSE2)
++         endif()
++         list(APPEND _dlib_compile_definitions DLIB_HAVE_SSE2 DLIB_HAVE_SSE3 DLIB_HAVE_SSE41)
++      elseif(_dlib_simd_level STREQUAL "SSE2")
++         if(CMAKE_SIZEOF_VOID_P EQUAL 4)
++            list(APPEND _dlib_compile_options /arch:SSE2)
++         endif()
++         list(APPEND _dlib_compile_definitions DLIB_HAVE_SSE2)
++      endif()
++
++      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
++         if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.3)
++            list(APPEND _dlib_compile_options -Xclang -fcxx-exceptions)
++         endif()
++         if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
++            list(APPEND _dlib_compile_options -ftemplate-depth=500)
++         endif()
++      endif()
++   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
++          CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
++          CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR
++          CMAKE_CXX_COMPILER_ID STREQUAL "Intel" OR
++          CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
++      if(_dlib_simd_level STREQUAL "AVX")
++         list(APPEND _dlib_compile_options -mavx)
++      elseif(_dlib_simd_level STREQUAL "SSE4")
++         list(APPEND _dlib_compile_options -msse4)
++      elseif(_dlib_simd_level STREQUAL "SSE2")
++         list(APPEND _dlib_compile_options -msse2)
++      elseif(_dlib_simd_level STREQUAL "NEON")
++         list(APPEND _dlib_compile_options -mfpu=neon)
++      endif()
++
++      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++         list(APPEND _dlib_compile_options -Wreturn-type)
++      elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
++         list(APPEND _dlib_compile_options -ftemplate-depth=500)
++      endif()
++   endif()
++
++   if(_dlib_compile_options)
++      target_compile_options(dlib::dlib INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:${_dlib_compile_options}>")
++   endif()
++   if(_dlib_compile_definitions)
++      target_compile_definitions(dlib::dlib INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:${_dlib_compile_definitions}>")
++   endif()
++
++   unset(_dlib_compile_definitions)
++   unset(_dlib_compile_options)
++   unset(_dlib_simd_level)
+ endif()
+ 
+ set(dlib_LIBRARIES dlib::dlib)
+@@ -60,6 +127,3 @@ endfunction()
+ variable_watch(dlib_LIBRARIES __deprecated_var)
+ variable_watch(dlib_LIBS __deprecated_var)
+ variable_watch(dlib_INCLUDE_DIRS __deprecated_var)
+-
+-
+-
+diff --git a/dlib/cmake_utils/set_compiler_specific_options.cmake b/dlib/cmake_utils/set_compiler_specific_options.cmake
+index 6e2682d..be05c88 100644
+--- a/dlib/cmake_utils/set_compiler_specific_options.cmake
++++ b/dlib/cmake_utils/set_compiler_specific_options.cmake
+@@ -24,25 +24,29 @@ endif()
+ 
+ set(gcc_like_compilers GNU Clang  Intel)
+ set(intel_archs x86_64 i386 i686 AMD64 amd64 x86)
++set(DLIB_SIMD_LEVEL NONE)
+ 
+ 
+-# Setup some options to allow a user to enable SSE and AVX instruction use.  
++# Setup some options to allow a user to enable SSE and AVX instruction use.
+ if ((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};")  AND
+    (";${intel_archs};"        MATCHES ";${CMAKE_SYSTEM_PROCESSOR};") AND NOT USE_AUTO_VECTOR)
+    option(USE_SSE2_INSTRUCTIONS "Compile your program with SSE2 instructions" OFF)
+    option(USE_SSE4_INSTRUCTIONS "Compile your program with SSE4 instructions" OFF)
+    option(USE_AVX_INSTRUCTIONS  "Compile your program with AVX instructions"  OFF)
+    if(USE_AVX_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL AVX)
+       list(APPEND active_compile_opts -mavx)
+       message(STATUS "Enabling AVX instructions")
+    elseif (USE_SSE4_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL SSE4)
+       list(APPEND active_compile_opts -msse4)
+       message(STATUS "Enabling SSE4 instructions")
+    elseif(USE_SSE2_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL SSE2)
+       list(APPEND active_compile_opts -msse2)
+       message(STATUS "Enabling SSE2 instructions")
+    endif()
+-elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio 
++elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visual Studio
+    # Use SSE2 by default when using Visual Studio.
+    option(USE_SSE2_INSTRUCTIONS "Compile your program with SSE2 instructions" ON)
+    option(USE_SSE4_INSTRUCTIONS "Compile your program with SSE4 instructions" OFF)
+@@ -51,9 +55,11 @@ elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visu
+    include(CheckTypeSize)
+    check_type_size( "void*" SIZE_OF_VOID_PTR)
+    if(USE_AVX_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL AVX)
+       list(APPEND active_compile_opts /arch:AVX)
+       message(STATUS "Enabling AVX instructions")
+    elseif (USE_SSE4_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL SSE4)
+       # Visual studio doesn't have an /arch:SSE2 flag when building in 64 bit modes.
+       # So only give it when we are doing a 32 bit build.
+       if (SIZE_OF_VOID_PTR EQUAL 4)
+@@ -64,6 +70,7 @@ elseif (MSVC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC") # else if using Visu
+       list(APPEND active_preprocessor_switches "-DDLIB_HAVE_SSE3")
+       list(APPEND active_preprocessor_switches "-DDLIB_HAVE_SSE41")
+    elseif(USE_SSE2_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL SSE2)
+       # Visual studio doesn't have an /arch:SSE2 flag when building in 64 bit modes.
+       # So only give it when we are doing a 32 bit build.
+       if (SIZE_OF_VOID_PTR EQUAL 4)
+@@ -77,6 +84,7 @@ elseif((";${gcc_like_compilers};" MATCHES ";${CMAKE_CXX_COMPILER_ID};")  AND
+         ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^arm"))
+    option(USE_NEON_INSTRUCTIONS "Compile your program with ARM-NEON instructions" OFF)
+    if(USE_NEON_INSTRUCTIONS)
++      set(DLIB_SIMD_LEVEL NEON)
+       list(APPEND active_compile_opts -mfpu=neon)
+       message(STATUS "Enabling ARM-NEON instructions")
+    endif()
+@@ -110,11 +118,10 @@ if (MSVC)
+    # RAM.
+    list(APPEND active_compile_opts_private "/MP")
+ 
+-   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.3) 
++   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.3)
+       # Clang can compile all Dlib's code at Windows platform. Tested with Clang 5
+       list(APPEND active_compile_opts -Xclang)
+       list(APPEND active_compile_opts -fcxx-exceptions)
+    endif()
+ endif()
+ 
+-

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-dependencies.patch
+        fix-flags.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/dlib/external")
 

--- a/ports/dlib/vcpkg.json
+++ b/ports/dlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dlib",
   "version": "20.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++",
   "homepage": "https://github.com/davisking/dlib",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2586,7 +2586,7 @@
     },
     "dlib": {
       "baseline": "20.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "dlpack": {
       "baseline": "1.3",

--- a/versions/d-/dlib.json
+++ b/versions/d-/dlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4af44d302f9da49712de4ced5f0275b8bcadf050",
+      "version": "20.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "e237a400bae75c688af53444f3626ddb873fb300",
       "version": "20.0.1",
       "port-version": 2


### PR DESCRIPTION
Fixes #49035.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

## What this does

Adds `fix-flags.patch`, backporting the fix from [davisking/dlib#3157](https://github.com/davisking/dlib/pull/3157) onto `dlib` `v20.0.1`.

Previously, compiler-specific flags detected while building dlib (e.g. `/bigobj`, `/arch:AVX` on MSVC; `-mavx`, `-msse4` on GCC/Clang) were attached to the `dlib::dlib` target with `PUBLIC` scope. Because CMake evaluates `PUBLIC`/`INTERFACE` usage requirements in the *consuming* project, these flags were force-fed to every consumer regardless of which compiler it used. In particular, a dlib package built with MSVC would push `/bigobj` onto a Clang++ consumer, which rejects it outright and fails to build (#49035).

The upstream fix moves this logic into `dlibConfig.cmake`: the installed config now detects the *consumer's* compiler (via `MSVC`/`CMAKE_CXX_COMPILER_ID`, matching upstream's own detection logic) and re-derives the appropriate flags for that compiler, storing the SIMD level (`NONE`/`SSE2`/`SSE4`/`AVX`/`NEON`) selected at build time in a new `DLIB_SIMD_LEVEL` template variable so it can be translated correctly (e.g. `AVX` → `/arch:AVX` for MSVC-style frontends, `-mavx` for GCC-style ones). Build-tree consumers (same compiler as dlib itself) are unaffected, via `$<BUILD_INTERFACE:...>`.

### Testing

- `./vcpkg install dlib:x64-windows` (default features: `fftw3`, `sqlite3`) builds and installs successfully with both patches applied.
- Verified the installed `dlibConfig.cmake` contains the new consumer-side compiler gating, and that `/bigobj` is now conditioned on `if(MSVC)` rather than applied unconditionally.
- `./vcpkg x-add-version dlib --overwrite-version` reports the version database is already up to date with no diff.
