### PR TITLE
[mongoose] update to 7.23

### DIFF
--- a/ports/mongoose/CMakeLists.txt
+++ b/ports/mongoose/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 if (ENABLE_SSL)
     find_package(OpenSSL REQUIRED)
-    target_compile_options(mongoose PRIVATE -DMG_ENABLE_SSL)
+    target_compile_definitions(mongoose PRIVATE MG_TLS=MG_TLS_OPENSSL)
     target_link_libraries(mongoose PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 endif()
 

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cesanta/mongoose
     REF "${VERSION}"
-    SHA512 49ddbb53a1d0588bfef06b6c541479ddc26d5a9e7ded34900f6e9e44023fcf54db7dca8ddf6d8a1cadd8ccf65ec3672dc692973cbbd083847efef19810e8df42
+    SHA512 7d4230a358befe424f6415436f957651af5a38a698ad216c83dc8c256eddbb8f87136b2f1b0db782b99bc6a6fa93460c53a55bb3601a3e1c40804bc87fc6bf12
     HEAD_REF master
 )
 

--- a/ports/mongoose/vcpkg.json
+++ b/ports/mongoose/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose",
-  "version": "7.22",
+  "version": "7.23",
   "description": "Embedded web server / embedded networking library",
   "homepage": "https://cesanta.com/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6741,7 +6741,7 @@
       "port-version": 0
     },
     "mongoose": {
-      "baseline": "7.22",
+      "baseline": "7.23",
       "port-version": 0
     },
     "monkeys-audio": {

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b653593e64def3261bc6c2d8b25bca4fcba4270",
+      "version": "7.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f6fbb2e533b914879c953143a78ed525afb9f4b",
       "version": "7.22",
       "port-version": 0

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3b653593e64def3261bc6c2d8b25bca4fcba4270",
+      "git-tree": "034f8ee72fe80cc3a69224fdcca7e0fae3164d50",
       "version": "7.23",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
