### PR TITLE
[ffmpeg] Update to version 9.0.1

### DIFF
--- a/ports/ffmpeg-bin2c/portfile.cmake
+++ b/ports/ffmpeg-bin2c/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
     REF "n${VERSION}"
-    SHA512 4327d259b2ed9cc35a6139606643bf9c9db5fb0372a9eb259fed61af50505a2b59f0c3d94c51fec89d2e0cd552a413c5f50514683931c94c429824198d56ec56
+    SHA512 41aa687cec4e93d0ffde21ea96faa48e4344fda0e9d2c9c71adfb68fedadf03beb274ec712eb1e082bf64fdcee87c55a47bb5c78d5193934be3f3f06e5e792b2
     HEAD_REF master
 )
 

--- a/ports/ffmpeg-bin2c/vcpkg.json
+++ b/ports/ffmpeg-bin2c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-bin2c",
-  "version": "9.0",
+  "version": "9.0.1",
   "description": "Host tool bin2c for FFmpeg build",
   "license": "MIT",
   "supports": "native",

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
     REF "n${VERSION}"
-    SHA512 4327d259b2ed9cc35a6139606643bf9c9db5fb0372a9eb259fed61af50505a2b59f0c3d94c51fec89d2e0cd552a413c5f50514683931c94c429824198d56ec56
+    SHA512 41aa687cec4e93d0ffde21ea96faa48e4344fda0e9d2c9c71adfb68fedadf03beb274ec712eb1e082bf64fdcee87c55a47bb5c78d5193934be3f3f06e5e792b2
     HEAD_REF master
     PATCHES
         0003-fix-windowsinclude.patch

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -291,7 +291,11 @@
     "ass": {
       "description": "Libass subtitles rendering, needed for subtitles and ass filter support in ffmpeg",
       "dependencies": [
-        "libass"
+        "libass",
+        {
+          "name": "libiconv",
+          "platform": "windows & static"
+        }
       ]
     },
     "avcodec": {

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg",
-  "version": "9.0",
+  "version": "9.0.1",
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3045,11 +3045,11 @@
       "port-version": 0
     },
     "ffmpeg": {
-      "baseline": "9.0",
+      "baseline": "9.0.1",
       "port-version": 0
     },
     "ffmpeg-bin2c": {
-      "baseline": "9.0",
+      "baseline": "9.0.1",
       "port-version": 0
     },
     "ffnvcodec": {

--- a/versions/f-/ffmpeg-bin2c.json
+++ b/versions/f-/ffmpeg-bin2c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8e7afbc7ce58834a14e937133272240aa55442a",
+      "version": "9.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf5cb6340d532f3fbe5e64ea27060703fc1520f6",
       "version": "9.0",
       "port-version": 0

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2e40a6d04d02bdeeacd8839f73fa3a7091213201",
+      "git-tree": "fec24d92181e0025717c37813075ef5494cdf5e1",
       "version": "9.0.1",
       "port-version": 0
     },

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e40a6d04d02bdeeacd8839f73fa3a7091213201",
+      "version": "9.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a716d32cde40e16a962dd0e016a6aebf849ca079",
       "version": "9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.