### PR TITLE
Combine stale bot runs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,23 +12,8 @@ jobs:
     steps:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
-          stale-issue-message: 'This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 28 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment.'
-          any-of-labels: 'category:question,requires:repro,requires:more-information'
-          days-before-issue-stale: 28
-          days-before-pr-stale: -1
-          days-before-close: 14
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
-        with:
-          stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 60 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
-          any-of-labels: 'category:new-port'
-          close-issue-label: 'info:new-port-unresolved'
-          days-before-issue-stale: 60
-          days-before-pr-stale: -1
-          days-before-close: 14
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
-        with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 180 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
-          exempt-issue-labels: 'no-stale,category:new-port,category:question,requires:repro,requires:more-information'
+          exempt-issue-labels: 'no-stale'
           days-before-issue-stale: 180
           days-before-pr-stale: -1
           days-before-close: 14


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/36674 we reverted stale bot to v8 to workaround https://github.com/actions/stale/issues/1133 . Unfortunately based on https://github.com/microsoft/vcpkg/pull/53388 we probably can't stay on v8 anymore because there are know exploits fixed in v11 and Node 20 is going away.

Instead, I'll workaround https://github.com/actions/stale/issues/1133 by removing the special cases and say all issues get 6 months, regardless of what they're tagged.
