### PR TITLE
[hdf5] Update to 2.2.0

### DIFF
--- a/ports/hdf5/libaec-config.diff
+++ b/ports/hdf5/libaec-config.diff
@@ -1,30 +1,31 @@
-diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
-index 6b75ff6..1be154e 100644
---- a/CMakeFilters.cmake
-+++ b/CMakeFilters.cmake
-@@ -202,12 +202,6 @@ endif ()
- if (HDF5_ENABLE_SZIP_SUPPORT)
-   cmake_dependent_option (HDF5_ENABLE_SZIP_ENCODING "Use SZip Encoding" ON HDF5_ENABLE_SZIP_SUPPORT OFF)
-   if (NOT SZIP_USE_EXTERNAL) # This checks if szip should be found on the system or built from an external source
--    if (HDF5_USE_LIBAEC_STATIC)
--      set (LIBAEC_SEARCH_TYPE "static")
--    else ()
--      set (LIBAEC_SEARCH_TYPE "shared")
--    endif ()
--    set (libaec_USE_STATIC_LIBS ${HDF5_USE_LIBAEC_STATIC})
-     set (SZIP_FOUND FALSE)
-     find_package (${LIBAEC_PACKAGE_NAME} OPTIONAL_COMPONENTS ${LIBAEC_SEARCH_TYPE})
-     set (H5_SZIP_FOUND ${${LIBAEC_PACKAGE_NAME}_FOUND})
+diff --git a/config/HDF5UseLibaec.cmake b/config/HDF5UseLibaec.cmake
+index 3b026970ebe..52fc1ab0e6b 100644
+--- a/config/HDF5UseLibaec.cmake
++++ b/config/HDF5UseLibaec.cmake
+@@ -42,13 +42,6 @@ function (system_szip_library)
+     message (FATAL_ERROR "LIBAEC_PACKAGE_NAME is undefined")
+   endif ()
+ 
+-  if (HDF5_USE_LIBAEC_STATIC)
+-    set (LIBAEC_SEARCH_TYPE "static")
+-  else ()
+-    set (LIBAEC_SEARCH_TYPE "shared")
+-  endif ()
+-  set (libaec_USE_STATIC_LIBS ${HDF5_USE_LIBAEC_STATIC})
+-
+   # For "libaec", start with our own Findlibaec.cmake module that prefers a
+   # CONFIG find mode if possible and falls back to MODULE find mode if necessary.
+   # For "szip", use CMake's standard MODULE find mode followed by a CONFIG find
 diff --git a/config/install/hdf5-config.cmake.in b/config/install/hdf5-config.cmake.in
-index bb9a8d6..a73bec8 100644
+index 1049f0b90db..f23eeb46608 100644
 --- a/config/install/hdf5-config.cmake.in
 +++ b/config/install/hdf5-config.cmake.in
-@@ -137,7 +137,7 @@ endif ()
- 
- if (${HDF5_PACKAGE_NAME}_PROVIDES_SZIP_SUPPORT)
-   if (NOT @SZIP_USE_EXTERNAL@)
--    find_dependency (@LIBAEC_PACKAGE_NAME@ OPTIONAL_COMPONENTS @LIBAEC_SEARCH_TYPE@)
-+    find_dependency (@LIBAEC_PACKAGE_NAME@ CONFIG)
-   endif ()
+@@ -140,7 +140,7 @@ endif ()
+ # If szip/libaec support was enabled and libaec was found on the system at build
+ # time, locate libaec to propagate the dependency
+ if (${HDF5_PACKAGE_NAME}_PROVIDES_SZIP_SUPPORT AND NOT @SZIP_USE_EXTERNAL@)
+-  find_dependency (@LIBAEC_PACKAGE_NAME@ OPTIONAL_COMPONENTS @LIBAEC_SEARCH_TYPE@)
++  find_dependency (@LIBAEC_PACKAGE_NAME@ CONFIG)
  endif ()
  
+ #-----------------------------------------------------------------------------

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  HDFGroup/hdf5
     REF "${VERSION}"
-    SHA512 45844e2f0e89b5a0291c9fecd9b4b663eed1a7a21b38e358fd6f6198fe509c19bcf91651d1ae3b4cf8de7445f7a71854acdb1635b939b6d08fdaf6b6c0e396d1
+    SHA512 b009572b70eba02fa0963119f202da202cdcf20a3b4c01a94c5618e8b612033c0b8dc23664ccb0c2a2ebbdab427ad96ba8163ff8eb0356bb093617d37a9932f8
     HEAD_REF develop
     PATCHES
         default-plugin-dir.diff # avoid absolute path
@@ -137,8 +137,10 @@ foreach(script IN ITEMS h5cc h5c++ h5hlcc h5hlc++ h5pcc h5fuse.sh)
 endforeach()
 vcpkg_clean_executables_in_bin(FILE_NAMES none)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
 if("parallel" IN_LIST FEATURES)
@@ -149,4 +151,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/H5public.h" "#define H5public_H" "#define H5public_H\n#ifndef H5_BUILT_AS_DYNAMIC_LIB\n#define H5_BUILT_AS_DYNAMIC_LIB\n#endif\n")
 endif()
 
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/data/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "hdf5",
-  "version": "2.1.1",
-  "port-version": 1,
+  "version-semver": "2.2.0",
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3797,8 +3797,8 @@
       "port-version": 0
     },
     "hdf5": {
-      "baseline": "2.1.1",
-      "port-version": 1
+      "baseline": "2.2.0",
+      "port-version": 0
     },
     "hdr-histogram": {
       "baseline": "0.11.10",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "934d6491fc674803ed8820660b6a8e537a0bc2ff",
+      "version-semver": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "488b04803484d74b9c630e43b0e6a86e9dd292f8",
       "version": "2.1.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

They follow semver [now](https://github.com/HDFGroup/hdf5/releases/tag/2.2.0#-executive-summary-hdf5-version-220)