### PR TITLE
[qpdf] Update to 12.4.0

### DIFF
--- a/ports/qpdf/portfile.cmake
+++ b/ports/qpdf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qpdf/qpdf
     REF "v${VERSION}"
-    SHA512 1aa9f11dc561e2ddf95a3052f6224269ab73cf1dddc5fefcc4e021351da3472819ed5979fe2073501a04f25a2fcbb126726437dbe8793d89d3f27739d599e6f6
+    SHA512 2cd3c520cd43b7ee65e989fef331ab98ab3e23d1d7bc453247d6fb4f0e6d35e0cbd4f5c032eb39555b3a5cd008b9bd1e42b04a7a093df6a48392ebbf2c889e72
     PATCHES
         cmake-library-only.patch
 )

--- a/ports/qpdf/vcpkg.json
+++ b/ports/qpdf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qpdf",
-  "version": "12.3.2",
-  "port-version": 1,
+  "version": "12.4.0",
   "description": "A content-preserving PDF document transformer",
   "homepage": "https://qpdf.sourceforge.io/",
   "license": "Apache-2.0 AND MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8241,8 +8241,8 @@
       "port-version": 0
     },
     "qpdf": {
-      "baseline": "12.3.2",
-      "port-version": 1
+      "baseline": "12.4.0",
+      "port-version": 0
     },
     "qpid-proton": {
       "baseline": "0.40.0",

--- a/versions/q-/qpdf.json
+++ b/versions/q-/qpdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ec6f6ef4e923fdd9384ab22b8b128c80af8d394",
+      "version": "12.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9b5192826719e19f1b11e877b8024d2fc30a2abb",
       "version": "12.3.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.