### PR TITLE
Add port for Adobe DNG SDK 1.7.1

### DIFF
--- a/ports/adobe-dng-sdk/CMakeLists.txt
+++ b/ports/adobe-dng-sdk/CMakeLists.txt
@@ -1,0 +1,159 @@
+cmake_minimum_required(VERSION 3.21)
+project(dng_sdk)
+
+set(Upstream_VERSION "1.7.1")
+
+#
+# DNG SDK
+#
+set(DNG_SOURCE_DIR ${PROJECT_SOURCE_DIR}/dng_sdk/source)
+file(GLOB DNG_SOURCE ${DNG_SOURCE_DIR}/*.cpp)
+file(GLOB DNG_HEADERS ${DNG_SOURCE_DIR}/*.h)
+list(REMOVE_ITEM DNG_SOURCE ${DNG_SOURCE_DIR}/dng_validate.cpp)
+add_library(dng STATIC ${DNG_SOURCE})
+
+set_property(TARGET dng PROPERTY VERSION "${Upstream_VERSION}")
+set_property(TARGET dng PROPERTY INTERFACE_dng_MAJOR_VERSION 1)
+set_property(TARGET dng PROPERTY COMPATIBLE_INTERFACE_STRING 1)
+
+find_package(ZLIB REQUIRED)
+target_link_libraries(dng PRIVATE ZLIB::ZLIB)
+
+target_include_directories(dng PUBLIC $<BUILD_INTERFACE:${DNG_SOURCE_DIR}>)
+target_compile_definitions(dng PUBLIC $<$<PLATFORM_ID:Android>:qAndroid=1> $<$<PLATFORM_ID:Darwin>:qMacOS=1>
+                                      $<$<PLATFORM_ID:Linux>:qLinux=1> $<$<PLATFORM_ID:Windows>:qWinOS=1>)
+
+#
+# Threading support
+#
+find_package(Threads REQUIRED)
+target_link_libraries(dng PRIVATE Threads::Threads)
+target_compile_definitions(dng PUBLIC qDNGThreadSafe=1)
+
+#
+# JPEG
+#
+find_package(JPEG REQUIRED)
+target_link_libraries(dng PRIVATE JPEG::JPEG)
+target_compile_definitions(dng PUBLIC qDNGUseLibJPEG=1)
+
+#
+# XMP
+#
+find_package(EXPAT REQUIRED)
+
+set(XMP_ROOT ${PROJECT_SOURCE_DIR}/xmp/toolkit)
+file(GLOB XMP_SOURCE ${XMP_ROOT}/source/*.cpp)
+if (WIN32)
+    list(REMOVE_ITEM XMP_SOURCE ${XMP_ROOT}/source/Host_IO-POSIX.cpp)
+elseif (UNIX)
+    list(REMOVE_ITEM XMP_SOURCE ${XMP_ROOT}/source/Host_IO-Win.cpp)
+endif()
+file(GLOB XMP_CORE ${XMP_ROOT}/XMPCore/source/*.cpp)
+file(GLOB XMP_COMMON ${XMP_ROOT}/XMPCommon/source/*.cpp)
+file(GLOB XMP_ZUID ${XMP_ROOT}/third-party/zuid/sources/*.cpp)
+
+add_library(xmp STATIC ${XMP_SOURCE} ${XMP_CORE} ${XMP_COMMON} ${XMP_ZUID})
+target_link_libraries(xmp PRIVATE EXPAT::EXPAT)
+target_include_directories(
+    xmp
+    PUBLIC $<BUILD_INTERFACE:${XMP_ROOT}/public/include>
+    PRIVATE ${XMP_ROOT})
+target_compile_definitions(
+    xmp
+    PUBLIC $<$<PLATFORM_ID:Darwin>:MAC_ENV> $<$<PLATFORM_ID:Linux>:UNIX_ENV> $<$<PLATFORM_ID:Windows>:WIN_ENV>
+    PRIVATE $<$<PLATFORM_ID:Windows>:XMP_WinBuild> $<$<PLATFORM_ID:Linux>:XMP_UNIXBuild>
+    PRIVATE XMP_StaticBuild
+    PRIVATE XMP_COMPONENT_INT_NAMESPACE=AdobeXMPCore_Int)
+if(UNIX)
+    find_package(Boost REQUIRED COMPONENTS uuid)
+    target_link_libraries(xmp PRIVATE Boost::uuid)
+endif()
+
+target_link_libraries(dng PRIVATE xmp)
+target_compile_definitions(dng PUBLIC qDNGUseXMP=1 qDNGXMPFiles=0 qDNGXMPDocOps=0)
+
+#
+# JXL
+#
+# NOTE: For pkg_check_module to correctly create libjxl under PkgConfig::*,
+# IMPORTED_TARGET is required.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libjxl REQUIRED IMPORTED_TARGET libjxl libjxl_threads)
+target_link_libraries(dng PRIVATE PkgConfig::libjxl)
+
+set(PORT_PACKAGE_NAME dngsdk)
+
+install(TARGETS dng xmp EXPORT ${PORT_PACKAGE_NAME}Targets
+    RUNTIME  DESTINATION bin
+    ARCHIVE  DESTINATION lib
+    LIBRARY  DESTINATION lib
+)
+
+install(
+  FILES
+    ${DNG_HEADERS}
+  DESTINATION
+    include
+  COMPONENT
+    Devel
+)
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PORT_PACKAGE_NAME}ConfigVersion.cmake"
+  VERSION ${Upstream_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+export(EXPORT ${PORT_PACKAGE_NAME}Targets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PORT_PACKAGE_NAME}Targets.cmake"
+  NAMESPACE ${PORT_PACKAGE_NAME}::
+)
+
+configure_file(${PORT_PACKAGE_NAME}Config.cmake
+  "${CMAKE_CURRENT_BINARY_DIR}/${PORT_PACKAGE_NAME}Config.cmake"
+  COPYONLY
+)
+
+# Generate the dngsdkTargets.cmake file directly at the install location
+install(EXPORT ${PORT_PACKAGE_NAME}Targets
+  FILE
+    ${PORT_PACKAGE_NAME}Targets.cmake
+  NAMESPACE
+    ${PORT_PACKAGE_NAME}::
+  DESTINATION
+    "share/${PORT_PACKAGE_NAME}"
+)
+
+# Copy previously-generated Config.cmake and ConfigVersion.cmake to the install location
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PORT_PACKAGE_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PORT_PACKAGE_NAME}ConfigVersion.cmake"
+  DESTINATION
+    "share/${PORT_PACKAGE_NAME}"
+  COMPONENT
+    Devel
+)
+
+if(WITH_DNG_VALIDATE)
+    add_executable(dng_validate
+        ${DNG_SOURCE_DIR}/dng_validate.cpp
+        # NOTE: Required because dng_validate is supposed to be built with slightly
+        # different flags, and if this file is not present this creates missing symbols.
+        ${DNG_SOURCE_DIR}/dng_globals.cpp
+    )
+    target_link_libraries(dng_validate PRIVATE dng)
+    target_link_libraries(dng_validate PRIVATE xmp)
+    target_link_libraries(dng_validate PRIVATE PkgConfig::libjxl)
+    # NOTE: the qDNGValidate flag is required to build the executable, but this
+    # should in principle require recompiling the dng library target as it affects
+    # other .cpp sources than dng_validate.cpp... Not bothering for now.
+    target_compile_definitions(dng_validate PUBLIC qDNGValidateTarget=1 qDNGValidate=1)
+
+    install(TARGETS dng_validate
+        RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+    )
+endif()

--- a/ports/adobe-dng-sdk/dngsdkConfig.cmake
+++ b/ports/adobe-dng-sdk/dngsdkConfig.cmake
@@ -1,0 +1,7 @@
+include(CMakeFindDependencyMacro)
+find_dependency(EXPAT)
+if(UNIX)
+find_dependency(Boost REQUIRED COMPONENTS uuid)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/dngsdkTargets.cmake")

--- a/ports/adobe-dng-sdk/findnextfilew.patch
+++ b/ports/adobe-dng-sdk/findnextfilew.patch
@@ -1,0 +1,13 @@
+diff --git i/xmp/toolkit/source/Host_IO-Win.cpp w/xmp/toolkit/source/Host_IO-Win.cpp
+index ea33748..63aea29 100644
+--- i/xmp/toolkit/source/Host_IO-Win.cpp
++++ w/xmp/toolkit/source/Host_IO-Win.cpp
+@@ -595,7 +595,7 @@ bool Host_IO::GetNextChild ( Host_IO::FolderRef folder, std::string* childName )
+ 	if ( folder == Host_IO::noFolderRef ) return false;
+ 
+ 	do {	// Ignore all children with names starting in '.'. This covers ., .., .DS_Store, etc.
+-		found = (bool) FindNextFile ( folder, &childInfo );
++		found = (bool) FindNextFileW ( folder, &childInfo );
+ 	} while ( found && (childInfo.cFileName[0] == '.') );
+ 	if ( ! found ) return false;
+ 

--- a/ports/adobe-dng-sdk/missingincludes.patch
+++ b/ports/adobe-dng-sdk/missingincludes.patch
@@ -1,0 +1,20 @@
+diff --git i/xmp/toolkit/source/XMPStream_IO.cpp w/xmp/toolkit/source/XMPStream_IO.cpp
+index 34dd205..825f174 100644
+--- i/xmp/toolkit/source/XMPStream_IO.cpp
++++ w/xmp/toolkit/source/XMPStream_IO.cpp
+@@ -29,6 +29,8 @@
+ #include "source/XIO.hpp"
+ #include "source/XMP_LibUtils.hpp"
+ 
++#include <cstring>
++
+ #define TwoGB (XMP_Uns32)(2*1024*1024*1024UL)
+ 
+ #define XMP_STREAMIO_START try { /* int a;*/
+@@ -325,4 +327,4 @@ void XMPStream_IO::GetCurrentStream(char *outputBuffer, int outputLength)
+ int XMPStream_IO::GetCurrentStreamLength()
+ {
+ 	return this->length;
+-}
+\ No newline at end of file
++}

--- a/ports/adobe-dng-sdk/portfile.cmake
+++ b/ports/adobe-dng-sdk/portfile.cmake
@@ -1,0 +1,55 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "https://download.adobe.com/pub/adobe/dng/dng_sdk_1_7_1_2652_20260714.zip"
+    FILENAME "dng_sdk_1_7_1_2652_20260714.zip"
+    SHA512 95312197791f78dd307e57ca8ff19b6e611409cf49d8d9d8a9b337a35c6a90bf48fed424caca0b3b88e1883652940ec653071eb5e7cf0bce95a0b15c7c48df90
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        findnextfilew.patch
+	missingincludes.patch
+)
+
+file(COPY "${CURRENT_PORT_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CURRENT_PORT_DIR}/dngsdkConfig.cmake" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        dng-validate    WITH_DNG_VALIDATE
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME dngsdk)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST LICENSE.txt)
+
+if("dng-validate" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES dng_validate AUTO_CLEAN)
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# vcpkg complains with the following warning:
+# 
+# ...\portfile.cmake: warning: ${CURRENT_PACKAGES_DIR}/debug/include should not exist.
+# To suppress this message, add set(VCPKG_POLICY_ALLOW_DEBUG_INCLUDE enabled)
+# note: If this directory was created by a build system that does not allow
+# installing headers in debug to be disabled, delete the duplicate directory
+# with file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+#
+# I do not know how to disable the creation of this folder, so I used the
+# suggestion to delete it manually.
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/adobe-dng-sdk/usage
+++ b/ports/adobe-dng-sdk/usage
@@ -1,0 +1,4 @@
+The package adobe-dng-sdk provides CMake targets:
+
+    find_package(dngsdk CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE dngsdk::dng)

--- a/ports/adobe-dng-sdk/vcpkg.json
+++ b/ports/adobe-dng-sdk/vcpkg.json
@@ -1,0 +1,47 @@
+{
+  "name": "adobe-dng-sdk",
+  "version": "1.7.1",
+  "description": "Adobe DNG SDK",
+  "homepage": "https://www.adobe.com/devnet/xmp.html",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    {
+      "name": "expat",
+      "host": true
+    },
+    {
+      "name": "libjxl",
+      "host": true
+    },
+    {
+      "name": "libjpeg-turbo",
+      "host": true
+    },
+    {
+      "name": "zlib",
+      "host": true
+    },
+    {
+      "name": "boost-uuid",
+      "host": true,
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "dng-validate": {
+      "description": "Build the dng_validate exacutable",
+      "dependencies": []
+    }
+  }
+}


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This is a draft port for Adobe DNG SDK in hopes that it is useful to someone. This is an adaptation of @CitrusPeel's [CMake build files](https://github.com/CitrusPeel/dng_sdk/blob/main/dng_sdk/projects/linux/CMakeLists.txt) to work with vcpkg.

I checked that it works for my purposes, but there are a few issues that need fixing before this is merged (besides the checklist above) so I do not think this is fully ready.

Notably, a few that come to mind:

* There are vendored dependencies (zuid, the Adobe XMP SDK which has another [port PR](https://github.com/microsoft/vcpkg/pull/43566))
* Adobe does not really define public/private headers so I included all of them. I am not sure if this is the right way to do it ?
* The build of the `dng_validate` executable should technically be done using a different set of defines than the ones used to build the library, but I'm not sure how to handle that in vcpkg ?
* The license is a custom license text from Adobe, I'm not sure what SPDX identifier to use for that ?