### PR TITLE
[tracy] Update to 0.14.0

### DIFF
--- a/ports/tracy/build-tools.patch
+++ b/ports/tracy/build-tools.patch
@@ -1,10 +1,10 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 72901a8c..365724a8 100644
+index 3bb2572..f9ccc8b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -193,3 +193,15 @@ if(TRACY_CLIENT_PYTHON)
- 
-     add_subdirectory(python)
+@@ -291,3 +291,16 @@ endif()
+ if(PROJECT_IS_TOP_LEVEL)
+     set(CMAKE_COLOR_DIAGNOSTICS ON)
  endif()
 +
 +option(VCPKG_CLI_TOOLS "library" OFF)
@@ -14,12 +14,13 @@ index 72901a8c..365724a8 100644
 +    add_subdirectory(capture)
 +    add_subdirectory(import)
 +    add_subdirectory(update)
++    add_subdirectory(merge)
 +endif()
 +if(VCPKG_GUI_TOOLS)
 +    add_subdirectory(profiler)
 +endif()
 diff --git a/cmake/server.cmake b/cmake/server.cmake
-index c12a3408..0d55cf91 100644
+index 8298d21..ca5e9f3 100644
 --- a/cmake/server.cmake
 +++ b/cmake/server.cmake
 @@ -1,3 +1,4 @@
@@ -28,7 +29,7 @@ index c12a3408..0d55cf91 100644
  
  set(TRACY_COMMON_SOURCES
 diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
-index 29f12cfa..40b3e078 100644
+index 90d1680..1add52c 100644
 --- a/cmake/vendor.cmake
 +++ b/cmake/vendor.cmake
 @@ -1,3 +1,4 @@
@@ -36,3 +37,57 @@ index 29f12cfa..40b3e078 100644
  # Vendor Specific CMake
  # The Tracy project keeps most vendor source locally
  
+
+diff --git a/cmake/GitRef.cmake b/cmake/GitRef.cmake
+--- a/cmake/GitRef.cmake
++++ b/cmake/GitRef.cmake
+@@ -1,37 +1,24 @@
+ function(add_git_ref target)
+-    if(NOT DEFINED GIT_REV)
+-        set(GIT_REV "HEAD")
+-    endif()
+-
+     get_property(_git_ref_created GLOBAL PROPERTY _GIT_REF_CREATED)
+     if(NOT _git_ref_created)
+         set_property(GLOBAL PROPERTY _GIT_REF_CREATED TRUE)
++        set(_git_ref_file "${CMAKE_BINARY_DIR}/GitRef.hpp")
+         find_package(Git)
+-        set_property(GLOBAL PROPERTY _GIT_FOUND "${Git_FOUND}")
+         if(Git_FOUND)
+-            add_custom_target(git-ref
+-                COMMAND ${CMAKE_COMMAND} -E echo "#pragma once" > GitRef.hpp.tmp
+-                COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} log -1 "--format=namespace tracy { static inline const char* GitRef = %x22%h%x22; }" ${GIT_REV} >> GitRef.hpp.tmp || echo "namespace tracy { static inline const char* GitRef = \"unknown\"; }" >> GitRef.hpp.tmp
+-                COMMAND ${CMAKE_COMMAND} -E copy_if_different GitRef.hpp.tmp GitRef.hpp
+-                BYPRODUCTS GitRef.hpp GitRef.hpp.tmp
+-                VERBATIM
++            execute_process(
++                COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} log -1 "--format=%h"
++                OUTPUT_VARIABLE _git_rev
++                OUTPUT_STRIP_TRAILING_WHITESPACE
++                RESULT_VARIABLE _git_result
+             )
++            if(NOT _git_result EQUAL 0)
++                set(_git_rev "unknown")
++            endif()
+         else()
+-            message(WARNING "git not found, using 'unknown' as git ref.")
+-            add_custom_command(
+-                OUTPUT GitRef.hpp
+-                COMMAND ${CMAKE_COMMAND} -E echo "#pragma once" > GitRef.hpp
+-                COMMAND ${CMAKE_COMMAND} -E echo "namespace tracy { static inline const char* GitRef = \"unknown\"; }" >> GitRef.hpp
+-                VERBATIM
+-            )
++            set(_git_rev "unknown")
+         endif()
++        file(WRITE "${_git_ref_file}" "#pragma once\nnamespace tracy { static inline const char* GitRef = \"${_git_rev}\"; }\n")
+     endif()
+ 
+-    target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+-    get_property(_git_found GLOBAL PROPERTY _GIT_FOUND)
+-    if(_git_found)
+-        add_dependencies(${target} git-ref)
+-    else()
+-        target_sources(${target} PUBLIC GitRef.hpp)
+-    endif()
++    target_include_directories(${target} PRIVATE ${CMAKE_BINARY_DIR})
+ endfunction()

--- a/ports/tracy/downgrade-capstone-5.patch
+++ b/ports/tracy/downgrade-capstone-5.patch
@@ -1,17 +1,13 @@
-diff --git a/profiler/src/profiler/TracySourceView.cpp b/profiler/src/profiler/TracySourceView.cpp
-index c79948b8..2795bf92 100644
---- a/profiler/src/profiler/TracySourceView.cpp
-+++ b/profiler/src/profiler/TracySourceView.cpp
-@@ -4,7 +4,7 @@
- #include <sstream>
- #include <stdio.h>
- 
+diff --git a/profiler/src/profiler/TracyDisassembly.cpp b/profiler/src/profiler/TracyDisassembly.cpp
+--- a/profiler/src/profiler/TracyDisassembly.cpp
++++ b/profiler/src/profiler/TracyDisassembly.cpp
+@@ -1,4 +1,4 @@
 -#include <capstone.h>
 +#include <capstone/capstone.h>
+ #include <string.h>
  
- #include "imgui.h"
- #include "TracyCharUtil.hpp"
-@@ -713,7 +713,7 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+ #include "TracyDisassembly.hpp"
+@@ -249,7 +249,7 @@ DisasmData Disassemble( uint64_t symAddr, const Worker& worker )
          rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
          break;
      case CpuArchArm64:
@@ -20,7 +16,7 @@ index c79948b8..2795bf92 100644
          break;
      default:
          assert( false );
-@@ -778,9 +778,9 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+@@ -317,9 +317,9 @@ DisasmData Disassemble( uint64_t symAddr, const Worker& worker )
                      }
                      break;
                  case CpuArchArm64:
@@ -32,7 +28,7 @@ index c79948b8..2795bf92 100644
                      }
                      break;
                  default:
-@@ -865,18 +865,18 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+@@ -404,18 +404,18 @@ DisasmData Disassemble( uint64_t symAddr, const Worker& worker )
                  }
                  break;
              case CpuArchArm64:
@@ -57,7 +53,6 @@ index c79948b8..2795bf92 100644
                          break;
                      default:
 diff --git a/server/TracyWorker.cpp b/server/TracyWorker.cpp
-index d94a1ab5..437f4a78 100644
 --- a/server/TracyWorker.cpp
 +++ b/server/TracyWorker.cpp
 @@ -21,7 +21,7 @@
@@ -69,7 +64,7 @@ index d94a1ab5..437f4a78 100644
  
  #define ZDICT_STATIC_LINKING_ONLY
  #include <zdict.h>
-@@ -3912,7 +3912,7 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
+@@ -4010,7 +4010,7 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
          rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
          break;
      case CpuArchArm64:
@@ -78,7 +73,7 @@ index d94a1ab5..437f4a78 100644
          break;
      default:
          assert( false );
-@@ -3952,9 +3952,9 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
+@@ -4050,9 +4050,9 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
                          }
                          break;
                      case CpuArchArm64:

--- a/ports/tracy/fix-imgui-patch.patch
+++ b/ports/tracy/fix-imgui-patch.patch
@@ -1,5 +1,4 @@
 diff --git a/cmake/imgui-loader.patch b/cmake/imgui-loader.patch
-index 145fa755..71e5d6cb 100644
 --- a/cmake/imgui-loader.patch
 +++ b/cmake/imgui-loader.patch
 @@ -1,16 +1,16 @@
@@ -13,7 +12,7 @@ index 145fa755..71e5d6cb 100644
 +index 2c80cc598..1177da586 100644
 +--- a/backends/imgui_impl_opengl3_loader.h
 ++++ b/backends/imgui_impl_opengl3_loader.h
-+@@ -182,6 +182,7 @@ typedef khronos_uint8_t GLubyte;
++@@ -182,6 +183,7 @@ typedef khronos_uint8_t GLubyte;
   #define GL_EXTENSIONS                     0x1F03
 + #define GL_NEAREST                        0x2600
   #define GL_LINEAR                         0x2601
@@ -31,7 +30,7 @@ index 145fa755..71e5d6cb 100644
   #endif /* GL_VERSION_1_3 */
   #ifndef GL_VERSION_1_4
 -@@ -481,7 +484,7 @@ GL3W_API GL3WglProc imgl3wGetProcAddress(const char *proc);
-+@@ -490,7 +493,7 @@ GL3W_API GL3WglProc imgl3wGetProcAddress(const char *proc);
++@@ -489,7 +492,7 @@ GL3W_API GL3WglProc imgl3wGetProcAddress(const char *proc);
   
   /* gl3w internal state */
   union ImGL3WProcs {
@@ -40,7 +39,7 @@ index 145fa755..71e5d6cb 100644
           PFNGLACTIVETEXTUREPROC            ActiveTexture;
           PFNGLATTACHSHADERPROC             AttachShader;
 -@@ -497,6 +500,7 @@ union ImGL3WProcs {
-+@@ -506,6 +509,7 @@ union ImGL3WProcs {
++@@ -506,6 +510,7 @@ union ImGL3WProcs {
           PFNGLCLEARPROC                    Clear;
           PFNGLCLEARCOLORPROC               ClearColor;
           PFNGLCOMPILESHADERPROC            CompileShader;
@@ -49,16 +48,21 @@ index 145fa755..71e5d6cb 100644
           PFNGLCREATESHADERPROC             CreateShader;
           PFNGLDELETEBUFFERSPROC            DeleteBuffers;
 -@@ -563,6 +567,7 @@ GL3W_API extern union ImGL3WProcs imgl3wProcs;
-+@@ -575,6 +579,7 @@ GL3W_API extern union ImGL3WProcs imgl3wProcs;
++@@ -575,6 +580,7 @@ GL3W_API extern union ImGL3WProcs imgl3wProcs;
   #define glClear                           imgl3wProcs.gl.Clear
   #define glClearColor                      imgl3wProcs.gl.ClearColor
   #define glCompileShader                   imgl3wProcs.gl.CompileShader
-@@ -46,7 +46,7 @@ index 4ca0536..a1ff572 100644
+@@ -46,11 +46,11 @@ index 4ca0536..a1ff572 100644
   #define glCreateProgram                   imgl3wProcs.gl.CreateProgram
   #define glCreateShader                    imgl3wProcs.gl.CreateShader
   #define glDeleteBuffers                   imgl3wProcs.gl.DeleteBuffers
 -@@ -859,6 +864,7 @@ static const char *proc_names[] = {
-+@@ -883,6 +888,7 @@ static const char *proc_names[] = {
++@@ -873,6 +879,7 @@ static const char *proc_names[] = {
       "glClear",
       "glClearColor",
       "glCompileShader",
+ +    "glCompressedTexImage2D",
+      "glCreateProgram",
+      "glCreateShader",
+-     "glDeleteBuffers",
++     "glDeleteBuffers",

--- a/ports/tracy/fix-vendor-versions.patch
+++ b/ports/tracy/fix-vendor-versions.patch
@@ -1,8 +1,7 @@
 diff --git a/cmake/server.cmake b/cmake/server.cmake
-index a76d1c13..ec73f0b8 100644
 --- a/cmake/server.cmake
 +++ b/cmake/server.cmake
-@@ -29,7 +29,7 @@ list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")
+@@ -31,7 +31,7 @@ list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")
  
  add_library(TracyServer STATIC EXCLUDE_FROM_ALL ${TRACY_COMMON_SOURCES} ${TRACY_SERVER_SOURCES})
  target_include_directories(TracyServer PUBLIC ${TRACY_COMMON_DIR} ${TRACY_SERVER_DIR})
@@ -11,19 +10,19 @@ index a76d1c13..ec73f0b8 100644
  if(NO_STATISTICS)
      target_compile_definitions(TracyServer PUBLIC TRACY_NO_STATISTICS)
  endif()
+
 diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
-index adbd5de9..61683d51 100644
 --- a/cmake/vendor.cmake
 +++ b/cmake/vendor.cmake
-@@ -6,7 +6,6 @@ set (ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../")
+@@ -7,7 +7,6 @@ set (ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../")
  # Dependencies are taken from the system first and if not found, they are pulled with CPM and built from source
  
  include(FindPkgConfig)
 -include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
  
- option(DOWNLOAD_CAPSTONE "Force download capstone" ON)
- option(DOWNLOAD_GLFW "Force download glfw" OFF)
-@@ -16,105 +15,21 @@ option(DOWNLOAD_PUGIXML "Force download pugixml" OFF)
+ if(APPLE AND BUNDLE)
+     set(DLOPT ON)
+@@ -26,59 +25,11 @@ endif()
  
  # capstone
  
@@ -37,7 +36,7 @@ index adbd5de9..61683d51 100644
 -    CPMAddPackage(
 -        NAME capstone
 -        GITHUB_REPOSITORY capstone-engine/capstone
--        GIT_TAG 6.0.0-Alpha5
+-        GIT_TAG 6.0.0-Alpha10
 -        OPTIONS
 -            "CAPSTONE_X86_ATT_DISABLE ON"
 -            "CAPSTONE_ALPHA_SUPPORT OFF"
@@ -70,54 +69,6 @@ index adbd5de9..61683d51 100644
 -endif()
 +find_package(capstone CONFIG)
  
- # GLFW
- 
- if(NOT USE_WAYLAND AND NOT EMSCRIPTEN)
--    pkg_check_modules(GLFW glfw3)
--    if (GLFW_FOUND AND NOT DOWNLOAD_GLFW)
--        add_library(TracyGlfw3 INTERFACE)
--        target_include_directories(TracyGlfw3 INTERFACE ${GLFW_INCLUDE_DIRS})
--        target_link_libraries(TracyGlfw3 INTERFACE ${GLFW_LINK_LIBRARIES})
--    else()
--        CPMAddPackage(
--            NAME glfw
--            GITHUB_REPOSITORY glfw/glfw
--            GIT_TAG 3.4
--            OPTIONS
--                "GLFW_BUILD_EXAMPLES OFF"
--                "GLFW_BUILD_TESTS OFF"
--                "GLFW_BUILD_DOCS OFF"
--                "GLFW_INSTALL OFF"
--            EXCLUDE_FROM_ALL TRUE
--        )
--        add_library(TracyGlfw3 INTERFACE)
--        target_link_libraries(TracyGlfw3 INTERFACE glfw)
--    endif()
-+    find_package(glfw3 CONFIG)
- endif()
- 
- # freetype
- 
--pkg_check_modules(FREETYPE freetype2)
--if (FREETYPE_FOUND AND NOT DOWNLOAD_FREETYPE)
--    add_library(TracyFreetype INTERFACE)
--    target_include_directories(TracyFreetype INTERFACE ${FREETYPE_INCLUDE_DIRS})
--    target_link_libraries(TracyFreetype INTERFACE ${FREETYPE_LINK_LIBRARIES})
--else()
--    CPMAddPackage(
--        NAME freetype
--        GITHUB_REPOSITORY freetype/freetype
--        GIT_TAG VER-2-14-1
--        OPTIONS
--            "FT_DISABLE_HARFBUZZ ON"
--            "FT_WITH_HARFBUZZ OFF"
--        EXCLUDE_FROM_ALL TRUE
--    )
--    add_library(TracyFreetype INTERFACE)
--    target_link_libraries(TracyFreetype INTERFACE freetype)
--endif()
-+find_package(Freetype)
- 
  # Zstd
  
 -CPMAddPackage(
@@ -133,92 +84,8 @@ index adbd5de9..61683d51 100644
  
  # Diff Template Library
  
-@@ -134,169 +49,70 @@ target_include_directories(TracyGetOpt PUBLIC ${GETOPT_DIR})
+@@ -98,238 +49,89 @@ target_include_directories(TracyGetOpt PUBLIC ${GETOPT_DIR})
  
- # ImGui
- 
--CPMAddPackage(
--    NAME ImGui
--    GITHUB_REPOSITORY ocornut/imgui
--    GIT_TAG v1.92.5-docking
--    DOWNLOAD_ONLY TRUE
--    PATCHES
--        "${CMAKE_CURRENT_LIST_DIR}/imgui-emscripten.patch"
--        "${CMAKE_CURRENT_LIST_DIR}/imgui-loader.patch"
--)
--
--set(IMGUI_SOURCES
--    imgui_widgets.cpp
--    imgui_draw.cpp
--    imgui_demo.cpp
--    imgui.cpp
--    imgui_tables.cpp
--    misc/freetype/imgui_freetype.cpp
--    backends/imgui_impl_opengl3.cpp
--)
--
--list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
--
--add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
--target_include_directories(TracyImGui PUBLIC ${ImGui_SOURCE_DIR})
--target_link_libraries(TracyImGui PUBLIC TracyFreetype)
--target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
--#target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
--
--if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
--    find_package(X11 REQUIRED)
--    target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
--endif()
-+if (ImGui_SOURCE_DIR)
-+    set(IMGUI_SOURCES
-+        imgui_widgets.cpp
-+        imgui_draw.cpp
-+        imgui_demo.cpp
-+        imgui.cpp
-+        imgui_tables.cpp
-+        misc/freetype/imgui_freetype.cpp
-+        backends/imgui_impl_opengl3.cpp
-+    )
- 
--if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
--    target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
--endif()
-+    list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
- 
--# NFD
-+    add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
-+    target_include_directories(TracyImGui PUBLIC ${ImGui_SOURCE_DIR})
-+    target_link_libraries(TracyImGui PUBLIC Freetype::Freetype)
-+    target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
-+    #target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
- 
--if(NOT NO_FILESELECTOR AND NOT EMSCRIPTEN)
--    if(GTK_FILESELECTOR)
--        set(NFD_PORTAL OFF)
--    else()
--        set(NFD_PORTAL ON)
-+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
-+        find_package(X11 REQUIRED)
-+        target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
-     endif()
- 
--    CPMAddPackage(
--        NAME nfd
--        GITHUB_REPOSITORY btzy/nativefiledialog-extended
--        GIT_TAG v1.2.1
--        EXCLUDE_FROM_ALL TRUE
--        OPTIONS
--            "NFD_PORTAL ${NFD_PORTAL}"
--    )
-+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-+        target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
-+    endif()
- endif()
- 
-+# NFD
-+
-+find_package(nfd CONFIG)
-+
  # PPQSort
  
 -CPMAddPackage(
@@ -227,6 +94,7 @@ index adbd5de9..61683d51 100644
 -    VERSION 1.0.6
 -    PATCHES
 -        "${CMAKE_CURRENT_LIST_DIR}/ppqsort-nodebug.patch"
+-        "${CMAKE_CURRENT_LIST_DIR}/ppqsort-semaphore.patch"
 -    EXCLUDE_FROM_ALL TRUE
 -)
 +find_package(PPQSort CONFIG)
@@ -241,107 +109,265 @@ index adbd5de9..61683d51 100644
 -)
 +find_package(nlohmann_json CONFIG)
  
- # md4c
+ if(VENDOR_GUI)
  
--CPMAddPackage(
--    NAME md4c
--    GITHUB_REPOSITORY mity/md4c
--    GIT_TAG release-0.5.2
--    EXCLUDE_FROM_ALL TRUE
--)
-+find_package(md4c CONFIG)
+     # GLFW
  
- if(NOT EMSCRIPTEN)
+     if(NOT USE_WAYLAND AND NOT EMSCRIPTEN)
+-        pkg_check_modules(GLFW glfw3)
+-        if (GLFW_FOUND AND NOT DOWNLOAD_GLFW)
+-            add_library(TracyGlfw3 INTERFACE)
+-            target_include_directories(TracyGlfw3 INTERFACE ${GLFW_INCLUDE_DIRS})
+-            target_link_libraries(TracyGlfw3 INTERFACE ${GLFW_LINK_LIBRARIES})
+-        else()
+-            CPMAddPackage(
+-                NAME glfw
+-                GITHUB_REPOSITORY glfw/glfw
+-                GIT_TAG 3.4
+-                OPTIONS
+-                    "GLFW_BUILD_EXAMPLES OFF"
+-                    "GLFW_BUILD_TESTS OFF"
+-                    "GLFW_BUILD_DOCS OFF"
+-                    "GLFW_INSTALL OFF"
+-                EXCLUDE_FROM_ALL TRUE
+-            )
+-            add_library(TracyGlfw3 INTERFACE)
+-            target_link_libraries(TracyGlfw3 INTERFACE glfw)
+-        endif()
++        find_package(glfw3 CONFIG)
+     endif()
  
-     # base64
+     # freetype
  
--    set(BUILD_SHARED_LIBS_SAVE ${BUILD_SHARED_LIBS})
--    set(BUILD_SHARED_LIBS OFF)
--    CPMAddPackage(
--        NAME base64
--        GITHUB_REPOSITORY aklomp/base64
--        GIT_TAG v0.5.2
--        OPTIONS
--            "BASE64_BUILD_CLI OFF"
--            "BASE64_WITH_OpenMP OFF"
--        EXCLUDE_FROM_ALL TRUE
--    )
--    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVE})
-+    find_package(base64 CONFIG)
- 
-     # tidy
- 
--    CPMAddPackage(
--        NAME tidy
--        GITHUB_REPOSITORY htacg/tidy-html5
--        GIT_TAG 5.8.0
--        PATCHES
--            "${CMAKE_CURRENT_LIST_DIR}/tidy-cmake.patch"
--        EXCLUDE_FROM_ALL TRUE
--    )
-+    find_package(unofficial-tidy-html5 CONFIG)
- 
-     # usearch
- 
--    CPMAddPackage(
--        NAME usearch
--        GITHUB_REPOSITORY unum-cloud/usearch
--        GIT_TAG v2.21.3
--        EXCLUDE_FROM_ALL TRUE
--    )
-+    find_package(usearch CONFIG)
- 
-     # pugixml
- 
--    pkg_check_modules(PUGIXML pugixml)
--    if (PUGIXML_FOUND AND NOT DOWNLOAD_PUGIXML)
--        add_library(TracyPugixml INTERFACE)
--        target_include_directories(TracyPugixml INTERFACE ${PUGIXML_INCLUDE_DIRS})
--        target_link_libraries(TracyPugixml INTERFACE ${PUGIXML_LINK_LIBRARIES})
+-    pkg_check_modules(FREETYPE freetype2)
+-    if (FREETYPE_FOUND AND NOT DOWNLOAD_FREETYPE)
+-        add_library(TracyFreetype INTERFACE)
+-        target_include_directories(TracyFreetype INTERFACE ${FREETYPE_INCLUDE_DIRS})
+-        target_link_libraries(TracyFreetype INTERFACE ${FREETYPE_LINK_LIBRARIES})
 -    else()
 -        CPMAddPackage(
--            NAME pugixml
--            GITHUB_REPOSITORY zeux/pugixml
--            GIT_TAG v1.15
--            EXCLUDE_FROM_ALL TRUE
--        )
--        add_library(TracyPugixml INTERFACE)
--        target_link_libraries(TracyPugixml INTERFACE pugixml)
--    endif()
-+    find_package(pugixml CONFIG)
- 
-     # libcurl
- 
--    pkg_check_modules(LIBCURL libcurl>=7.87.0)
--    if (LIBCURL_FOUND AND NOT DOWNLOAD_LIBCURL)
--        add_library(TracyLibcurl INTERFACE)
--        target_include_directories(TracyLibcurl INTERFACE ${LIBCURL_INCLUDE_DIRS})
--        target_link_libraries(TracyLibcurl INTERFACE ${LIBCURL_LINK_LIBRARIES})
--    else()
--        CPMAddPackage(
--            NAME libcurl
--            GITHUB_REPOSITORY curl/curl
--            GIT_TAG curl-8_17_0
+-            NAME freetype
+-            GITHUB_REPOSITORY freetype/freetype
+-            GIT_TAG VER-2-14-3
 -            OPTIONS
--                "BUILD_STATIC_LIBS ON"
--                "BUILD_SHARED_LIBS OFF"
--                "HTTP_ONLY ON"
--                "CURL_ZSTD OFF"
--                "CURL_USE_LIBPSL OFF"
+-                "FT_DISABLE_HARFBUZZ ON"
+-                "FT_WITH_HARFBUZZ OFF"
+-                "FT_DISABLE_ZLIB ON"
+-                "FT_DISABLE_BZIP2 ON"
+-                "FT_DISABLE_PNG ON"
+-                "FT_DISABLE_BROTLI ON"
 -            EXCLUDE_FROM_ALL TRUE
 -        )
--        add_library(TracyLibcurl INTERFACE)
--        target_link_libraries(TracyLibcurl INTERFACE libcurl_static)
--        target_include_directories(TracyLibcurl INTERFACE ${libcurl_SOURCE_DIR}/include)
+-        add_library(TracyFreetype INTERFACE)
+-        target_link_libraries(TracyFreetype INTERFACE freetype)
 -    endif()
++    find_package(Freetype)
+ 
+     # ImGui
+ 
+-    CPMAddPackage(
+-        NAME ImGui
+-        GITHUB_REPOSITORY ocornut/imgui
+-        GIT_TAG v1.92.9b-docking
+-        DOWNLOAD_ONLY TRUE
+-        PATCHES
+-            "${CMAKE_CURRENT_LIST_DIR}/imgui-emscripten.patch"
+-            "${CMAKE_CURRENT_LIST_DIR}/imgui-loader.patch"
+-            "${CMAKE_CURRENT_LIST_DIR}/imgui-no-samplers.patch"
+-            "${CMAKE_CURRENT_LIST_DIR}/imgui-no-default-font.patch"
+-            "${CMAKE_CURRENT_LIST_DIR}/imgui-macos-clipboard.patch"
+-    )
 -
-+    find_package(CURL)
- endif()
+-    set(IMGUI_SOURCES
+-        imgui_widgets.cpp
+-        imgui_draw.cpp
+-        imgui_demo.cpp
+-        imgui.cpp
+-        imgui_tables.cpp
+-        misc/freetype/imgui_freetype.cpp
+-        backends/imgui_impl_opengl3.cpp
+-    )
+-
+-    list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
+-
+-    add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
+-    target_include_directories(TracyImGui PUBLIC ${ImGui_SOURCE_DIR})
+-    target_link_libraries(TracyImGui PUBLIC TracyFreetype)
+-    target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
+-    target_compile_definitions(TracyImGui PUBLIC "IMGUI_USE_WCHAR32")
+-    #target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
+-
+-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
+-        find_package(X11 REQUIRED)
+-        target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
+-    endif()
++    if (ImGui_SOURCE_DIR)
++        set(IMGUI_SOURCES
++            imgui_widgets.cpp
++            imgui_draw.cpp
++            imgui_demo.cpp
++            imgui.cpp
++            imgui_tables.cpp
++            misc/freetype/imgui_freetype.cpp
++            backends/imgui_impl_opengl3.cpp
++        )
+ 
+-    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+-        target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
+-    endif()
++        list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
+ 
+-    if(APPLE)
+-        target_link_libraries(TracyImGui PUBLIC "-framework ApplicationServices")
+-    endif()
++        add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
++        target_include_directories(TracyImGui PUBLIC ${ImGui_SOURCE_DIR})
++        target_link_libraries(TracyImGui PUBLIC Freetype::Freetype)
++        target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
++        target_compile_definitions(TracyImGui PUBLIC "IMGUI_USE_WCHAR32")
++        #target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
+ 
+-    # NFD
++        if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
++            find_package(X11 REQUIRED)
++            target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
++        endif()
+ 
+-    if(NOT NO_FILESELECTOR AND NOT EMSCRIPTEN)
+-        if(GTK_FILESELECTOR)
+-            set(NFD_PORTAL OFF)
+-        else()
+-            set(NFD_PORTAL ON)
++        if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
++            target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
+         endif()
+ 
+-        CPMAddPackage(
+-            NAME nfd
+-            GITHUB_REPOSITORY btzy/nativefiledialog-extended
+-            GIT_TAG 3cd252a8f7ca32419b1ca235c2990ba6a0ecba7c
+-            EXCLUDE_FROM_ALL TRUE
+-            OPTIONS
+-                "BUILD_SHARED_LIBS OFF"
+-                "NFD_PORTAL ${NFD_PORTAL}"
+-        )
++        if(APPLE)
++            target_link_libraries(TracyImGui PUBLIC "-framework ApplicationServices")
++        endif()
+     endif()
+ 
++    # NFD
++
++    find_package(nfd CONFIG)
++
+     # md4c
+ 
+-    CPMAddPackage(
+-        NAME md4c
+-        GITHUB_REPOSITORY mity/md4c
+-        GIT_TAG 65c6c9d72cebd9a731aaa5597414ce04d9ea5de3
+-        OPTIONS
+-            "BUILD_SHARED_LIBS OFF"
+-        EXCLUDE_FROM_ALL TRUE
+-    )
++    find_package(md4c CONFIG)
+ 
+     if(NOT EMSCRIPTEN)
+ 
+         # base64
+ 
+-        set(BUILD_SHARED_LIBS_SAVE ${BUILD_SHARED_LIBS})
+-        set(BUILD_SHARED_LIBS OFF)
+-        CPMAddPackage(
+-            NAME base64
+-            GITHUB_REPOSITORY aklomp/base64
+-            GIT_TAG v0.5.2
+-            OPTIONS
+-                "BASE64_BUILD_CLI OFF"
+-                "BASE64_WITH_OpenMP OFF"
+-            EXCLUDE_FROM_ALL TRUE
+-        )
+-        set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVE})
++        find_package(base64 CONFIG)
+ 
+         # tidy
+ 
+-        CPMAddPackage(
+-            NAME tidy
+-            GITHUB_REPOSITORY htacg/tidy-html5
+-            GIT_TAG 5.8.0
+-            PATCHES
+-                "${CMAKE_CURRENT_LIST_DIR}/tidy-cmake.patch"
+-            EXCLUDE_FROM_ALL TRUE
+-        )
++        find_package(unofficial-tidy-html5 CONFIG)
+ 
+         # usearch
+ 
+-        CPMAddPackage(
+-            NAME usearch
+-            GITHUB_REPOSITORY unum-cloud/usearch
+-            GIT_TAG v2.26.0
+-            EXCLUDE_FROM_ALL TRUE
+-        )
++        find_package(usearch CONFIG)
+ 
+         # pugixml
+ 
+-        pkg_check_modules(PUGIXML pugixml)
+-        if (PUGIXML_FOUND AND NOT DOWNLOAD_PUGIXML)
+-            add_library(TracyPugixml INTERFACE)
+-            target_include_directories(TracyPugixml INTERFACE ${PUGIXML_INCLUDE_DIRS})
+-            target_link_libraries(TracyPugixml INTERFACE ${PUGIXML_LINK_LIBRARIES})
+-        else()
+-            CPMAddPackage(
+-                NAME pugixml
+-                GITHUB_REPOSITORY zeux/pugixml
+-                GIT_TAG v1.16
+-                EXCLUDE_FROM_ALL TRUE
+-            )
+-            add_library(TracyPugixml INTERFACE)
+-            target_link_libraries(TracyPugixml INTERFACE pugixml)
+-        endif()
++        find_package(pugixml CONFIG)
+ 
+         # libcurl
+ 
+-        pkg_check_modules(LIBCURL libcurl>=7.87.0)
+-        if (LIBCURL_FOUND AND NOT DOWNLOAD_LIBCURL)
+-            add_library(TracyLibcurl INTERFACE)
+-            target_include_directories(TracyLibcurl INTERFACE ${LIBCURL_INCLUDE_DIRS})
+-            target_link_libraries(TracyLibcurl INTERFACE ${LIBCURL_LINK_LIBRARIES})
+-        else()
+-            CPMAddPackage(
+-                NAME libcurl
+-                GITHUB_REPOSITORY curl/curl
+-                GIT_TAG curl-8_21_0
+-                OPTIONS
+-                    "BUILD_STATIC_LIBS ON"
+-                    "BUILD_SHARED_LIBS OFF"
+-                    "HTTP_ONLY ON"
+-                    "CURL_ZSTD OFF"
+-                    "CURL_USE_LIBPSL OFF"
+-                    "CURL_USE_LIBSSH2 OFF"
+-                    "CURL_BROTLI OFF"
+-                    "USE_NGHTTP2 OFF"
+-                    "USE_LIBIDN2 OFF"
+-                EXCLUDE_FROM_ALL TRUE
+-            )
+-            add_library(TracyLibcurl INTERFACE)
+-            target_link_libraries(TracyLibcurl INTERFACE libcurl_static)
+-            target_include_directories(TracyLibcurl INTERFACE ${libcurl_SOURCE_DIR}/include)
+-        endif()
++        find_package(CURL)
+ 
+     endif()
+ 
+
 diff --git a/profiler/CMakeLists.txt b/profiler/CMakeLists.txt
-index 1681a64b..01043d3e 100644
 --- a/profiler/CMakeLists.txt
 +++ b/profiler/CMakeLists.txt
-@@ -244,7 +244,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
+@@ -301,7 +301,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
      TracyImGui
      Threads::Threads
      nlohmann_json::nlohmann_json
@@ -350,7 +376,7 @@ index 1681a64b..01043d3e 100644
  )
  target_include_directories(${PROJECT_NAME} PRIVATE
      ${tidy_SOURCE_DIR}/include
-@@ -255,11 +255,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
+@@ -312,11 +312,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
  
  if(NOT EMSCRIPTEN)
      target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -367,7 +393,7 @@ index 1681a64b..01043d3e 100644
      )
  endif()
  
-@@ -293,7 +293,7 @@ if(NOT EMSCRIPTEN)
+@@ -327,7 +327,7 @@ if(NOT EMSCRIPTEN)
          target_link_libraries(${PROJECT_NAME} PRIVATE nfd::nfd)
      endif()
      if(NOT USE_WAYLAND)

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfpld/tracy
     REF "v${VERSION}"
-    SHA512 18c0c589a1d97d0760958c8ab00ba2135bc602fd359d48445b5d8ed76e5b08742d818bb8f835b599149030f455e553a92db86fb7bae049b47820e4401cf9f935
+    SHA512 d6d07db668e62e2c4fb476b549243c240434613554e99bd68b6446b56b92e6cec606246186a02964ed9a223b5ccdac55546185510cd9f6fda05d458314fb05c1
     HEAD_REF master
     PATCHES
         build-tools.patch
@@ -30,8 +30,8 @@ if ("gui-tools" IN_LIST FEATURES)
    vcpkg_from_github(
        OUT_SOURCE_PATH tracy_imgui_path
        REPO ocornut/imgui
-       REF "v1.92.5-docking"
-       SHA512 4618b8bd6e65ac27cd7cecb3469d135622279d83f8a580c028231578f7023c4465911c5878ee7e40c2f6dda606aef86f27c3cecfb7bc9a6022bd1d89eed17c29
+       REF "v1.92.9b-docking"
+       SHA512 7eddcdb475f1db1fc8242d918533b955c964d2267abe713bdf23f8e2444770946d3c79c7855e360bab6168e36231b95bd05a84106c08f876dcd53daac9caccac
        PATCHES
            "${SOURCE_PATH}/cmake/imgui-emscripten.patch"
            "${SOURCE_PATH}/cmake/imgui-loader.patch"
@@ -73,7 +73,7 @@ endfunction()
 
 set(TOOLS)
 if("cli-tools" IN_LIST FEATURES)
-    list(APPEND TOOLS tracy-capture tracy-csvexport)
+    list(APPEND TOOLS tracy-capture tracy-capture-daemon tracy-csvexport tracy-merge)
     tracy_copy_tool(tracy-import-chrome import)
     tracy_copy_tool(tracy-import-fuchsia import)
     tracy_copy_tool(tracy-update update)

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tracy",
-  "version": "0.13.1",
-  "port-version": 1,
+  "version": "0.14.0",
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -25,7 +24,7 @@
   ],
   "features": {
     "cli-tools": {
-      "description": "Build Tracy command-line tools: `capture`, `csvexport`, `import-chrome`, `import-fuchsia` and `update`",
+      "description": "Build Tracy command-line tools: `capture`, `capture-daemon`, `csvexport`, `import-chrome`, `import-fuchsia`, `merge` and `update`",
       "supports": "!(windows & x86)",
       "dependencies": [
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10357,8 +10357,7 @@
       "port-version": 6
     },
     "tracy": {
-      "baseline": "0.13.1",
-      "port-version": 1
+      "baseline": "0.14.0"
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10357,7 +10357,8 @@
       "port-version": 6
     },
     "tracy": {
-      "baseline": "0.14.0"
+      "baseline": "0.14.0",
+      "port-version": 0
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51c9a9eadc9e5876a2eacbc9acc501be02585561",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "14b48412157c33902fa555b1fa4aeb18a49a47c3",
       "version": "0.13.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Update: https://github.com/wolfpld/tracy/releases/tag/v0.14.0