### PR TITLE
[expat] Update to 2.8.3

### DIFF
--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -4,9 +4,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libexpat/libexpat
     REF "${REF}"
-    SHA512 e60e6d6ae9d0115f41186f06f3854008054863f0b29a58d44142f5b30057a494337145d820b5e18270b8ca3e779e318a757fcc6bf64d6d204e5498df5eeb2195
+    SHA512 547fe1a3183f75edd23e925ab4151ef7a3afa5f65329784456374d733d54f04e744257239868d4a6c1a21e17edcc3c1eced7b1ed9885cec42006444323fd47e5
     HEAD_REF master
 )
+
+# Avoid conflicting utf-8 flags for MSVC
+vcpkg_replace_string("${SOURCE_PATH}/expat/CMakeLists.txt" "/source-charset:utf-8" "")
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" EXPAT_LINKAGE)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" EXPAT_CRT_LINKAGE)

--- a/ports/expat/vcpkg.json
+++ b/ports/expat/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "expat",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "XML parser library written in C",
   "homepage": "https://github.com/libexpat/libexpat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2897,7 +2897,7 @@
       "port-version": 0
     },
     "expat": {
-      "baseline": "2.8.2",
+      "baseline": "2.8.3",
       "port-version": 0
     },
     "expected-lite": {

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aaa1614b66f176bd426d1fab95ae31b3b5fa25bf",
+      "version": "2.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "d828778d8b6c0ea3cfd1dcd6c42618f5ffec7b49",
       "version": "2.8.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

Also fix MSVC build issue where triplet `/utf-8` flag now conflicts with expat CMakeLists.txt `/source-charset:utf-8` flag.