### PR TITLE
[libgnutls] Update to 3.8.13

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -41,6 +41,7 @@ set(ENV{YACC} false)     # false, the program - not used here
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
+    LANGUAGES ASM C CXX
     OPTIONS
         --disable-dependency-tracking
         --disable-doc
@@ -62,7 +63,17 @@ vcpkg_make_configure(
 )
 vcpkg_make_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
+vcpkg_copy_tools(
+    TOOL_NAMES
+        certtool
+        gnutls-cli
+        gnutls-cli-debug
+        gnutls-serv
+        ocsptool
+        psktool
+    SEARCH_DIR "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin"
+)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
@@ -79,4 +90,5 @@ unless otherwise specified in the indivual source files.
     FILE_LIST
         "${SOURCE_PATH}/COPYING.LESSERv2"
         "${SOURCE_PATH}/COPYING"
+        "${SOURCE_PATH}/lib/inih/LICENSE.txt"
 )

--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
     FILENAME "gnutls-${VERSION}.tar.xz"
-    SHA512 332a8e5200461517c7f08515e3aaab0bec6222747422e33e9e7d25d35613e3d0695a803fce226bd6a83f723054f551328bd99dcf0573e142be777dcf358e1a3b
+    SHA512 71bf189a836fd18d58b9e995d4bfcecdb0aae6129dfd44247b98422b2f127dd868f9905d28fad2ca05afd919a0e6b3c8eebb6b95804067d3a8dab31ebdc72453
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${tarball}"

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgnutls",
-  "version": "3.8.12",
+  "version": "3.8.13",
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols.",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5117,7 +5117,7 @@
       "port-version": 1
     },
     "libgnutls": {
-      "baseline": "3.8.12",
+      "baseline": "3.8.13",
       "port-version": 0
     },
     "libgo": {

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f65d9728ab7c0faf0a8c9d37104a5fc9c29a65db",
+      "version": "3.8.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "79ee3e6ff71c38fb2b1f91930c94986db0506c85",
       "version": "3.8.12",
       "port-version": 0

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f65d9728ab7c0faf0a8c9d37104a5fc9c29a65db",
+      "git-tree": "56a20e18acacd00d679773b5e19986ce42d02e6b",
       "version": "3.8.13",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

// Edit: #51342 May be rebased after this