### PR TITLE
[qtwebengine] Add more diagnostic logging and reduce concurrency on Windows.

### DIFF
--- a/ports/qtwebengine/node-wrapper-diagnostics.diff
+++ b/ports/qtwebengine/node-wrapper-diagnostics.diff
@@ -1,8 +1,33 @@
+diff --git a/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py b/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
+index c4a2a65..ea6df74 100644
+--- a/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
++++ b/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
+@@ -59,7 +59,19 @@ def runTsc(tsconfig_location):
+                                universal_newlines=True)
+     stdout, stderr = process.communicate()
+     # TypeScript does not correctly write to stderr because of https://github.com/microsoft/TypeScript/issues/33849
+-    return process.returncode, stdout + stderr
++    output = stdout + stderr
++    if process.returncode != 0:
++        details = [
++            'Command \'%s\' failed with exit code %d' %
++                (' '.join(cmd), process.returncode),
++            'Working directory: %s' % os.getcwd(),
++            'stdout:',
++            stdout,
++            'stderr:',
++            stderr,
++        ]
++        output = '\n'.join(details)
++    return process.returncode, output
+ 
+ 
+ # To ensure that Ninja only rebuilds dependents when the actual content/public API of a TypeScript target changes,
 diff --git a/src/3rdparty/chromium/third_party/node/node.py b/src/3rdparty/chromium/third_party/node/node.py
-index 3af0f1d9ee..20516742f5 100644
+index 067a2c6..0e7815f 100644
 --- a/src/3rdparty/chromium/third_party/node/node.py
 +++ b/src/3rdparty/chromium/third_party/node/node.py
-@@ -32,9 +32,15 @@ def RunNode(cmd_parts, stdout=None):
+@@ -36,10 +36,16 @@ def RunNode(cmd_parts, stdout=None):
    stdout, stderr = process.communicate()
  
    if process.returncode != 0:
@@ -22,3 +47,4 @@ index 3af0f1d9ee..20516742f5 100644
 +    raise RuntimeError('\n'.join(details))
  
    return stdout
+ 

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -199,6 +199,11 @@ if(buildtree_length GREATER 22 AND VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_
     file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}")
 endif()
 
+set(qtwebengine_install_options ADD_BIN_TO_PATH)
+if(VCPKG_TARGET_IS_WINDOWS)
+    # The outer CMake build invokes a parallel Chromium Ninja build.
+    list(APPEND qtwebengine_install_options DISABLE_PARALLEL)
+endif()
 set(ENV{QTWEBENGINE_GN_THREADS} "${VCPKG_CONCURRENCY}")
 set(ENV{NINJAFLAGS} "-j${VCPKG_CONCURRENCY} $ENV{NINJAFLAGS}")
 
@@ -252,7 +257,7 @@ if(NOT VCPKG_BUILD_TYPE)
         file(APPEND "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/core/Debug/${target_args_gn}" "\ngcc_target_rpath=\"\\\${ORIGIN}:${CURRENT_INSTALLED_DIR}/debug/lib\"\n")
     endif()
     vcpkg_host_path_list(PREPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig" "${CURRENT_INSTALLED_DIR}/share/pkgconfig")
-    vcpkg_cmake_install(ADD_BIN_TO_PATH)
+    vcpkg_cmake_install(${qtwebengine_install_options})
     endblock()
 endif()
 vcpkg_restore_env_variables(VARS PKG_CONFIG_PATH)
@@ -262,7 +267,7 @@ if(VCPKG_TARGET_IS_LINUX AND EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}
     file(APPEND "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/core/Release/${target_args_gn}" "\ngcc_target_rpath=\"\\\${ORIGIN}:${CURRENT_INSTALLED_DIR}/lib\"\n")
 endif()
 vcpkg_host_path_list(PREPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/lib/pkgconfig" "${CURRENT_INSTALLED_DIR}/share/pkgconfig")
-vcpkg_cmake_install(ADD_BIN_TO_PATH)
+vcpkg_cmake_install(${qtwebengine_install_options})
 endblock()
 vcpkg_restore_env_variables(VARS PKG_CONFIG_PATH)
 

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.11.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt modules for rendering web and PDF content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8618,7 +8618,7 @@
     },
     "qtwebengine": {
       "baseline": "6.11.1",
-      "port-version": 1
+      "port-version": 2
     },
     "qtwebsockets": {
       "baseline": "6.11.1",

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e942b62c9538f2da5545cc095145124b9b9ee76",
+      "version": "6.11.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "aa9371eee2255a22028bb2706483742f33d95149",
       "version": "6.11.1",
       "port-version": 1


### PR DESCRIPTION
Still trying to run down the intermittent qtwebengine failures.

The baseline https://dev.azure.com/vcpkg/public/_build/results?buildId=135846&view=results

Elapsed time to handle qtwebengine:x64-windows: 5.7 h
Elapsed time to handle qtwebengine:x64-windows-release: 2.9 h
