### PR TITLE
[msl] Add new port

### DIFF
--- a/ports/msl/portfile.cmake
+++ b/ports/msl/portfile.cmake
@@ -1,0 +1,27 @@
+include("${VCPKG_ROOT_DIR}/ports/vcpkg-cmake/vcpkg-port-config.cmake" OPTIONAL)
+include("${VCPKG_ROOT_DIR}/ports/vcpkg-cmake-config/vcpkg-port-config.cmake" OPTIONAL)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Alazar42/MSL
+    REF "v${VERSION}"
+    SHA512 e3212a6543d00b660b82e63ea085cbfe2c6221fffec95d5398b5aaa35723e27d3dae5bf42a9315ae55405419ed8b4ed3f825b1218b82c2a7077806056ef1d24c
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DMSL_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "msl" CONFIG_PATH "share/cmake/msl")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(TOUCH "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage-accurate")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/msl/vcpkg.json
+++ b/ports/msl/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "msl",
+  "version": "1.0.0",
+  "description": "Melkam Standard Library (MSL) - A modern, high-performance, header-only C++20 standard utility and math library.",
+  "homepage": "https://github.com/Alazar42/MSL",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6872,6 +6872,10 @@
       "baseline": "1.7",
       "port-version": 5
     },
+    "msl": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "msmpi": {
       "baseline": "10.1.12498.52",
       "port-version": 0

--- a/versions/m-/msl.json
+++ b/versions/m-/msl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "77f7e66d439c65137212d73a79fa5de2e9a2871d",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### Description
This PR adds the new port `msl` (Melkam Standard Library) version `1.0.0`.

**Melkam Standard Library (MSL)** is a modern, high-performance, memory-safe, header-only C++20 utility and math library providing core data types (`Array<T>`, `String`, `Color`, `Vector2`, `Vector3`).

- Upstream repository: https://github.com/Alazar42/MSL
- License: MIT

---

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Some other reason: Initial release of Melkam Standard Library (MSL) providing header-only C++20 math and data structure primitives.
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form (Alazar42/MSL).
- [x] Optional dependencies of the build are all controlled by the port.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says (`1.0.0`).
- [x] The license declaration in `vcpkg.json` matches what upstream says (`MIT`).
- [x] The file installed as the "copyright" file matches what upstream says (`LICENSE`).
- [x] The source code of the component installed comes from an authoritative source (`https://github.com/Alazar42/MSL/archive/v1.0.0.tar.gz`).
- [x] The generated "usage text" is brief and accurate.
- [x] The version database is fixed by running `vcpkg x-add-version msl` and committing the result.
- [x] Exactly one version is added in each modified versions file (`versions/m-/msl.json` and `versions/baseline.json`).
