### PR TITLE
[orefkov-simstr] update to 1.9.1

### DIFF
--- a/ports/orefkov-simstr/portfile.cmake
+++ b/ports/orefkov-simstr/portfile.cmake
@@ -17,9 +17,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/simstr)
+vcpkg_cmake_config_fixup(PACKAGE_NAME simstr CONFIG_PATH lib/cmake/simstr)
+
+set(config_file "${CURRENT_PACKAGES_DIR}/share/simstr/simstrConfig.cmake")
+file(READ "${config_file}" config_contents)
+file(WRITE "${config_file}" "include(CMakeFindDependencyMacro)\nfind_dependency(simdutf CONFIG)\n\n${config_contents}")
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/orefkov-simstr/portfile.cmake
+++ b/ports/orefkov-simstr/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orefkov/simstr
-    SHA512 8361e677ff64b59c1f4d1fe02f1106a5fda56e7e7713085d40d7ea83b4036c66bcad293e4c6dc2b4768b0217cbdb585758378e4c650b8d7787ea03ac57fa3e90
+    SHA512 aadcf7acb57e1cc38d25e24bf3ec0d64e7c6fc7e0b9bd4d3f9d3f3c513f601e8d3d23f53c2b0169a6f149c7f3fda592b6838aef7c5b36c9ddd2fbee2bb8b35db
     REF "rel${VERSION}"
     HEAD_REF main
 )

--- a/ports/orefkov-simstr/usage
+++ b/ports/orefkov-simstr/usage
@@ -1,4 +1,0 @@
-orefkov-simstr provides CMake targets:
-
-  find_package(simstr CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE simstr::simstr)

--- a/ports/orefkov-simstr/vcpkg.json
+++ b/ports/orefkov-simstr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orefkov-simstr",
-  "version-semver": "1.8.1",
+  "version-semver": "1.9.1",
   "description": "Yet another C++ strings library implementation",
   "homepage": "https://github.com/orefkov/simstr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7617,7 +7617,7 @@
       "port-version": 2
     },
     "orefkov-simstr": {
-      "baseline": "1.8.1",
+      "baseline": "1.9.1",
       "port-version": 0
     },
     "ormpp": {

--- a/versions/o-/orefkov-simstr.json
+++ b/versions/o-/orefkov-simstr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "92646102e39f7312896065e14196b485ce3161b0",
+      "git-tree": "7be57c5f8c41a8829c8c8de74ffdbb3750fcd41a",
       "version-semver": "1.9.1",
       "port-version": 0
     },

--- a/versions/o-/orefkov-simstr.json
+++ b/versions/o-/orefkov-simstr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92646102e39f7312896065e14196b485ce3161b0",
+      "version-semver": "1.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "192430ea9d16ff00f396525c46e258fdcd213ecf",
       "version-semver": "1.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/orefkov/simstr/releases/tag/rel1.9.1
