### PR TITLE
[units] Update to 3.5.0

### DIFF
--- a/ports/units/fix-project-version.patch
+++ b/ports/units/fix-project-version.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 50eedb8..87e16b0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ cmake_minimum_required(VERSION 3.16...4.99 FATAL_ERROR)
+ 
+-PROJECT(units VERSION 3.4.0 LANGUAGES CXX)
++PROJECT(units VERSION 3.5.0 LANGUAGES CXX)
+ 
+ # check if this is the main project
+ set(MAIN_PROJECT OFF)

--- a/ports/units/portfile.cmake
+++ b/ports/units/portfile.cmake
@@ -2,7 +2,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nholthaus/units
     REF v${VERSION}
-    SHA512 9cedc52e0405140b9a8014195f59f4deb2edd155fe78df76005eb721974c2a640975d9b959777be48f41c24f6a0a7047536649958da847e2aa8b0c3b9a6d139a
+    SHA512 547ff44975ed502b3b02d90fe502ccbf21e2610ad4ec025fe1b7d829f60c91e43dfd2eba31ae63b2453bcd751baec2b87027742a7259ac9af6ac12d68eee33ea
+    PATCHES
+        fix-project-version.patch
 )
 
 set(VCPKG_BUILD_TYPE "release")

--- a/ports/units/vcpkg.json
+++ b/ports/units/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "units",
-  "version": "3.3.0",
-  "description": "A compile-time, header-only, dimensional analysis and unit conversion library built on c++14 with no dependencies.",
+  "version": "3.5.0",
+  "description": "A compile-time, header-only, dimensional analysis and unit conversion library built on C++23 with no dependencies.",
   "homepage": "https://github.com/nholthaus/units",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10509,7 +10509,7 @@
       "port-version": 0
     },
     "units": {
-      "baseline": "3.3.0",
+      "baseline": "3.5.0",
       "port-version": 0
     },
     "unittest-cpp": {

--- a/versions/u-/units.json
+++ b/versions/u-/units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bccc55879a4245799f4fe7048e89269b716db3b",
+      "version": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1dad7eb82a4df280bead2a440e02ac5f9e36025c",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Updates units from 3.3.0 to 3.5.0. The release now requires C++23 and installs the expanded header tree. Includes a small downstream patch correcting the upstream CMake project version from 3.4.0 to 3.5.0 so exact-version find_package requests work. Validated with vcpkg install units:x64-linux and an external CMake consumer using find_package(units 3.5.0 EXACT).