### PR TITLE
[wxwidgets] fix build by adding a dependency on libsm when building it for linux.

### DIFF
--- a/ports/libsm/portfile.cmake
+++ b/ports/libsm/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${LIBSM_ARCHIVE}"
     PATCHES
         msvc.patch
+        xtrans.patch
 )
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")

--- a/ports/libsm/vcpkg.json
+++ b/ports/libsm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsm",
   "version": "1.2.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "X Session Management Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libsm",
   "license": null,

--- a/ports/libsm/xtrans.patch
+++ b/ports/libsm/xtrans.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 7d274a5..3761020 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -59,7 +59,7 @@ XTRANS_CONNECTION_FLAGS
+ AC_CHECK_FUNCS([getaddrinfo]) ])
+ 
+ # Obtain compiler/linker options for dependencies
+-PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto $genid_module])
++PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto xtrans])
+ 
+ 
+ AC_CONFIG_FILES([Makefile

--- a/ports/wxwidgets/fix-wayland-build.patch
+++ b/ports/wxwidgets/fix-wayland-build.patch
@@ -1,0 +1,29 @@
+diff --git a/build/cmake/setup.h.in b/build/cmake/setup.h.in
+index d72d20d5cbc6..08169ee065e6 100644
+--- a/build/cmake/setup.h.in
++++ b/build/cmake/setup.h.in
+@@ -626,9 +626,9 @@
+ 
+     This is needed by any Wayland-specific code in wxGTK implementation.
+ 
+-    Recommended setting: 1, only set to 0 if wayland-client is not available.
++    Define if wayland-client is available.
+  */
+-#cmakedefine01 wxHAVE_WAYLAND_CLIENT
++#cmakedefine wxHAVE_WAYLAND_CLIENT 1
+ 
+ /*
+    Use XTest extension to implement wxUIActionSimulator?
+diff --git a/setup.h.in b/setup.h.in
+index 2de3139090d1..4bec4eb6e4e1 100644
+--- a/setup.h.in
++++ b/setup.h.in
+@@ -625,7 +625,7 @@
+ 
+     This is needed by any Wayland-specific code in wxGTK implementation.
+ 
+-    Recommended setting: 1, only set to 0 if wayland-client is not available.
++    Define if wayland-client is available.
+  */
+ #undef wxHAVE_WAYLAND_CLIENT
+ 

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         gtk3-link-libraries.patch
         sdl2.patch
         libsecret-link-dirs.patch
+        fix-wayland-build.patch # https://github.com/wxWidgets/wxWidgets/commit/c70a840f3a6dc288ff968ecd6f37df7251039483
 )
 
 # Submodule dependencies

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.3.3",
+  "port-version": 1,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",
@@ -31,6 +32,10 @@
     },
     "libjpeg-turbo",
     "libpng",
+    {
+      "name": "libsm",
+      "platform": "!windows & !osx & !ios"
+    },
     "libwebp",
     "nanosvg",
     "opengl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5694,7 +5694,7 @@
     },
     "libsm": {
       "baseline": "1.2.6",
-      "port-version": 1
+      "port-version": 2
     },
     "libsmacker": {
       "baseline": "1.2.0",
@@ -11110,7 +11110,7 @@
     },
     "wxwidgets": {
       "baseline": "3.3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/l-/libsm.json
+++ b/versions/l-/libsm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60bd08be9e8d1ab410500b8ec10a632bc6fe17f8",
+      "version": "1.2.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "ca22baec525802d5a6ac64f241ec51bc06e9da49",
       "version": "1.2.6",
       "port-version": 1

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0d906bd9f2ba62f81a62b36b4c7af9f2bfbc1be",
+      "version": "3.3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "eeb427e462674b9df707dc3412bd88f9a49aa9a2",
       "version": "3.3.3",
       "port-version": 0


### PR DESCRIPTION
[libsm] add missed 'libxtrans' port.
[libxtrans] add new port.

This fixes: #53370.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.