### PR TITLE
[luau] update to 0.734

### DIFF
--- a/ports/luau/fix-unittest.patch
+++ b/ports/luau/fix-unittest.patch
@@ -1,17 +1,20 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4ccd3bd..cf0a18b 100644
+index cd417f8..c4a6f9a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -230,11 +230,11 @@ if(MSVC AND LUAU_BUILD_CLI)
+@@ -230,13 +230,14 @@ if(MSVC AND LUAU_BUILD_CLI)
      # the default stack size that MSVC linker uses is 1 MB; we need more stack space in Debug because stack frames are larger
      set_target_properties(Luau.Analyze.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
 -    set_target_properties(Luau.UnitTest PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
- 
+
  if(MSVC AND LUAU_BUILD_TESTS)
      # the default stack size that MSVC linker uses is 1 MB; we need more stack space in Debug because stack frames are larger
 +    set_target_properties(Luau.UnitTest PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
      set_target_properties(Luau.CLI.Test PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
      set_target_properties(Luau.Conformance PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
++    set_target_properties(Luau.UnitTest PROPERTIES LINK_FLAGS_OPTIMIZED /STACK:2097152)
+     set_target_properties(Luau.CLI.Test PROPERTIES LINK_FLAGS_OPTIMIZED /STACK:2097152)
+     set_target_properties(Luau.Conformance PROPERTIES LINK_FLAGS_OPTIMIZED /STACK:2097152)
  endif()

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 e1a3de791c5f46138b88efd898ae1e21377bbd299b8fd51817140f0d0b8dcfb039db66776d74dfde560829947aa781515f25236aa95cac0dcd3a29498b3f7a6b
+    SHA512 0bc7932e2387dc1a2a8e1dd99b77df21e057f45c1f5ffd7e7596ff599cbc07f1fb1073be002a8371d6f4a3a907fc3b9efcd0767ef83dc5c315c859eaf4cff2d8
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.733",
+  "version": "0.734",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6321,7 +6321,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.733",
+      "baseline": "0.734",
       "port-version": 0
     },
     "lunarg-vulkantools": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d875fa11f4f3fe1b765660dcd48e44a7da258c2",
+      "version": "0.734",
+      "port-version": 0
+    },
+    {
       "git-tree": "3e9d49d75c50e4659b4431a258058d847c7fb1c3",
       "version": "0.733",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The extra LINK_FLAGS_OPTIMIZED line is a deliberate no-op for vcpkg, which builds with LUAU_BUILD_TESTS=OFF.
0.734 added LINK_FLAGS_OPTIMIZED for the other two test targets.
Adding it keeps the block symmetric and makes the patch upstreamable as-is.
Luau.UnitTest needs the larger stack for the same reason the others do.

https://github.com/luau-lang/luau/releases/tag/0.734