### PR TITLE
[libtmux] Add new port

### DIFF
--- a/ports/libtmux/portfile.cmake
+++ b/ports/libtmux/portfile.cmake
@@ -1,0 +1,30 @@
+# The library is not header-only and installs a CMake package config, so the
+# standard cmake helpers do the whole job.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO libtmux/libtmux-cxx
+  REF "v${VERSION}"
+  SHA512 23cfb3723834b3982bfc2bba6ca9a7998f1817bf60700e13db154638e45d4e68346a8f5f65f1293187fe39326aed1e76f5113b6d0fbd0090a984d6d0e8a65439
+  HEAD_REF master)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    # This project's own tests need GoogleTest and a real tmux, and its
+    # examples need a tmux to run against. Neither belongs in a consumer's
+    # dependency graph.
+    -DLIBTMUX_BUILD_TESTS=OFF
+    -DLIBTMUX_BUILD_EXAMPLES=OFF
+    # `libtmux::testing` does belong there, and follows those two switches
+    # unless it is asked for. It is the fixture a consumer's own suite runs
+    # on — a private tmux server per test — and it names no test framework and
+    # links nothing beyond the library, so shipping it costs a consumer an
+    # archive they never link unless they ask for the component.
+    -DLIBTMUX_BUILD_TESTING_LIBRARY=ON)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME libtmux CONFIG_PATH lib/cmake/libtmux)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libtmux/portfile.cmake
+++ b/ports/libtmux/portfile.cmake
@@ -25,6 +25,11 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME libtmux CONFIG_PATH lib/cmake/libtmux)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+# Headers come from the release tree, and so does the license: the project
+# installs it to `share/licenses/libtmux/` for an ordinary `cmake --install`,
+# which is right there and wrong here — vcpkg keeps a port's copyright at
+# `share/libtmux/copyright` and rejects a `debug/share` outright.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libtmux/vcpkg.json
+++ b/ports/libtmux/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libtmux",
+  "version-semver": "0.1.0-alpha.1",
+  "maintainers": "Tony Narlock <tony@git-pull.com>",
+  "description": [
+    "A typed C++ interface to the tmux terminal multiplexer.",
+    "Alpha prerelease: the API is not stable and may change without a deprecation period."
+  ],
+  "homepage": "https://github.com/libtmux/libtmux-cxx",
+  "license": "MIT",
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5808,6 +5808,10 @@
       "baseline": "4.5",
       "port-version": 0
     },
+    "libtmux": {
+      "baseline": "0.1.0-alpha.1",
+      "port-version": 0
+    },
     "libtomcrypt": {
       "baseline": "1.18.2",
       "port-version": 3

--- a/versions/l-/libtmux.json
+++ b/versions/l-/libtmux.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd629ef14a6be21ef051992285b818b2aa707566",
+      "git-tree": "b2f8c5173e892a663136aa2edf7b194ee7044f52",
       "version-semver": "0.1.0-alpha.1",
       "port-version": 0
     }

--- a/versions/l-/libtmux.json
+++ b/versions/l-/libtmux.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fd629ef14a6be21ef051992285b818b2aa707566",
+      "version-semver": "0.1.0-alpha.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
A typed C++ interface to the tmux terminal multiplexer.

- **Upstream:** https://github.com/libtmux/libtmux-cxx
- **Version:** `0.1.0-alpha.1` — an alpha prerelease; the upstream README and the port description both say the API may change without a deprecation period.
- **License:** MIT
- **Platforms:** `!windows`. tmux is POSIX-only, so there is nothing to build there.

## Notes for reviewers

**No dependencies.** The library links only `Threads`, which CMake finds. The upstream project's own tests need GoogleTest and a real tmux server, and its examples need a tmux to run against; the portfile turns both off so neither reaches a consumer's dependency graph.

**Two targets, one of them opt-in.** `libtmux::libtmux` is the library. `libtmux::testing` is a fixture that gives a test a private tmux server on its own socket, which the upstream project ships deliberately so a consumer's suite does not have to reinvent it — getting it wrong means one suite killing another's sessions. It is a separate archive behind `find_package(libtmux COMPONENTS testing)`, links nothing beyond the library, and names no test framework, so a program that only uses the library never links it.

## Verification

Built and installed on `x64-linux`, first through `--overlay-ports` and then from the version database with no overlay. A consumer project configured with the vcpkg toolchain links both targets and drives a real tmux server:

```
vcpkg consumer: 0.1.0-alpha.1 1 session(s) at /tmp/libtmux-cxx-vcpkg-dpPI3R/socket
```

`vcpkg format-manifest` and `vcpkg x-add-version libtmux` were both run; the version database and baseline are as they generated them.
