### PR TITLE
[ffmpeg] Fix arm64-ohos build: set --target-os=linux

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -55,6 +55,12 @@ elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
     string(APPEND OPTIONS " --target-os=android --enable-jni --enable-mediacodec")
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "QNX")
     string(APPEND OPTIONS " --target-os=qnx")
+elseif(VCPKG_TARGET_IS_OHOS)
+    # OHOS kernel is Linux/musl; ffmpeg configure has no "ohos" target-os,
+    # so without this it falls back to the host (e.g. darwin) and injects
+    # host-specific LDFLAGS (-Wl,-dynamic,-search_paths_first) that lld rejects,
+    # which also corrupts the memalign/posix_memalign link probes.
+    string(APPEND OPTIONS " --target-os=linux --enable-pthreads")
 endif()
 
 if(VCPKG_TARGET_IS_OSX)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "9.0.1",
+  "port-version": 1,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3046,7 +3046,7 @@
     },
     "ffmpeg": {
       "baseline": "9.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ffmpeg-bin2c": {
       "baseline": "9.0.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55cd8b8a4f19d8e6ba2ad114c8acacc4af5915a0",
+      "version": "9.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "fec24d92181e0025717c37813075ef5494cdf5e1",
       "version": "9.0.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #53459

ffmpeg configure has no "ohos" target-os, so on the `arm64-ohos` / `x64-ohos` community triplets it fell back to the host (darwin) and injected `-Wl,-dynamic,-search_paths_first` into LDFLAGS. lld rejects those flags, and the same pollution broke the `memalign`/`posix_memalign` link probes, aborting the build with:

```
ERROR: Building with assembly enabled is not supported on platforms without aligned memory allocations!
```

OHOS kernel is Linux/musl, so `--target-os=linux --enable-pthreads` makes configure take the linux path. LDFLAGS stay clean and the aligned-alloc probes succeed — no `--disable-asm` needed, assembly stays on.

### Changes

- `ports/ffmpeg/portfile.cmake`: add `elseif(VCPKG_TARGET_IS_OHOS)` branch (mirrors the existing Android/QNX/Linux branches).
- Bump `port-version` to 1 and update `versions/baseline.json` + `versions/f-/ffmpeg.json`.

### Verification

Cross-compiled on arm64-osx host for both OHOS community triplets (CI does not cover ohos):

| triplet | arch | ffmpeg | assembly enabled | result |
|---|---|---|---|---|
| arm64-ohos | aarch64 | 9.0.1#1 | NEON | ✅ build OK |
| x64-ohos | x86_64 | 9.0.1#1 | SSE / AVX / AVX2 / AVX512 | ✅ build OK |

`ffbuild/config.h` shows the probes now succeed:

```
#define HAVE_MEMALIGN 1
#define HAVE_POSIX_MEMALIGN 1
#define HAVE_NEON 1            (arm64-ohos)
#define HAVE_AVX 1             (x64-ohos)
#define HAVE_AVX2 1            (x64-ohos)
```

arm64-ohos libraries additionally linked into an FFmpeg-RAII test binary and run on an OHOS emulator (API 26): 440 unit + 54 integration cases pass.