### PR TITLE
[units] Update to 3.6.0

### DIFF
--- a/ports/units/portfile.cmake
+++ b/ports/units/portfile.cmake
@@ -2,19 +2,22 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nholthaus/units
     REF v${VERSION}
-    SHA512 9cedc52e0405140b9a8014195f59f4deb2edd155fe78df76005eb721974c2a640975d9b959777be48f41c24f6a0a7047536649958da847e2aa8b0c3b9a6d139a
+    SHA512 605cc58cef72084a89390c62cc29897c7eecb3c5d302da85a4123a4db2fabcd69baf6424728b1422f0b35d216e4e94160eb65847bf8e369ddb6a487e84d4daa7
 )
 
 set(VCPKG_BUILD_TYPE "release")
 
+# units is header-only. Turning tests off also turns the examples off (they follow UNITS_BUILD_TESTS), so the
+# configure step compiles nothing and the install stages only the header tree and the CMake package files.
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUNITS_BUILD_TESTS=OFF
+        -DUNITS_BUILD_EXAMPLES=OFF
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/units)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")  # from CMake config
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib") # header-only: no libraries, only the CMake config moved above
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/units/vcpkg.json
+++ b/ports/units/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "units",
-  "version": "3.3.0",
-  "description": "A compile-time, header-only, dimensional analysis and unit conversion library built on c++14 with no dependencies.",
+  "version": "3.6.0",
+  "description": "A compile-time, header-only, dimensional-analysis and unit-conversion library for C++23 with no dependencies.",
   "homepage": "https://github.com/nholthaus/units",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10509,7 +10509,7 @@
       "port-version": 0
     },
     "units": {
-      "baseline": "3.3.0",
+      "baseline": "3.6.0",
       "port-version": 0
     },
     "unittest-cpp": {

--- a/versions/u-/units.json
+++ b/versions/u-/units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4528f652f253c6f7eb324620272ba9a9736318ea",
+      "version": "3.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1dad7eb82a4df280bead2a440e02ac5f9e36025c",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Updates `units` from 3.3.0 to 3.6.0.

- Refreshes the source `REF`/`SHA512` to `v3.6.0`.
- Raises the description to C++23 (the library requires C++23 since 3.5.0).
- Configures with `-DUNITS_BUILD_TESTS=OFF -DUNITS_BUILD_EXAMPLES=OFF`. `units` is header-only; in 3.6.0 the examples follow the tests option, so a package build compiles nothing and installs only the header tree and the CMake package files. Passing both explicitly keeps the intent clear.
- Adds the version-database entry and bumps the baseline.

3.6.0 also fixes an incomplete-type issue in `is_unit` that made libc++ (macOS/Android) reject a translation unit mixing `units` with `<chrono>`; that was the cause of the earlier draft's arm64-osx and Android build failures.

Supersedes the 3.5.1 draft (#53446).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed.
- [x] Only one version is added to each modified port's versions file.