### PR TITLE
[daw-json-link] update to 3.36.0

### DIFF
--- a/ports/daw-json-link/portfile.cmake
+++ b/ports/daw-json-link/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/daw_json_link
     REF "v${VERSION}"
-    SHA512 63f77205bcb27bb6b31465932eac3f9bd9ccaa913ae0daadff0092a40ba8742e6792fdac22263d9200d2e916ea6227dfc7e1b806eb3ca69992f8ad5dfdef8f9f
+    SHA512 aa1f9f57c5aa4fa30f6c4c1b2ec5c39f4e1bffde2a87c54e30a849eaa02c2928eabb2bf6395d68b2bb5f2c0619903f72546b7aa0d476bfd7f4ab29197d487aa7
     HEAD_REF release
 )
 

--- a/ports/daw-json-link/vcpkg.json
+++ b/ports/daw-json-link/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-json-link",
-  "version": "3.35.0",
+  "version": "3.36.0",
   "description": "Perhaps the fastest JSON deserializer/serializer posssible or at least close to it.",
   "homepage": "https://github.com/beached/daw_json_link",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2425,7 +2425,7 @@
       "port-version": 0
     },
     "daw-json-link": {
-      "baseline": "3.35.0",
+      "baseline": "3.36.0",
       "port-version": 0
     },
     "daw-utf-range": {

--- a/versions/d-/daw-json-link.json
+++ b/versions/d-/daw-json-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b09f6c4de9a02f325c2353c14d5478027188b411",
+      "version": "3.36.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c9e2522e1d322cb03e560940a312f05c663ece5",
       "version": "3.35.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/beached/daw_json_link/releases/tag/v3.36.0
