### PR TITLE
[gmsh] update to cxx_17

### DIFF
--- a/ports/gmsh/compatible-occ-8.diff
+++ b/ports/gmsh/compatible-occ-8.diff
@@ -1,5 +1,5 @@
 diff --git a/src/geo/OCCEdge.cpp b/src/geo/OCCEdge.cpp
-index 2ed6e08..248f938 100644
+index 28ca9f7..248f938 100644
 --- a/src/geo/OCCEdge.cpp
 +++ b/src/geo/OCCEdge.cpp
 @@ -1,4 +1,4 @@
@@ -8,7 +8,15 @@ index 2ed6e08..248f938 100644
  //
  // See the LICENSE.txt file in the Gmsh root directory for license information.
  // Please report all issues on https://gitlab.onelab.info/gmsh/gmsh/issues.
-@@ -34,6 +34,12 @@
+@@ -16,7 +16,6 @@
+ 
+ #include <Standard_Version.hxx>
+ #include <TopoDS.hxx>
+-#include <Geom2dLProp_CLProps2d.hxx>
+ #include <Geom_BezierCurve.hxx>
+ #include <Geom_OffsetCurve.hxx>
+ #include <Geom_Ellipse.hxx>
+@@ -35,6 +34,12 @@
  #include <BRep_Builder.hxx>
  #include <BOPTools_AlgoTools.hxx>
  
@@ -21,7 +29,7 @@ index 2ed6e08..248f938 100644
  OCCEdge::OCCEdge(GModel *m, TopoDS_Edge c, int num, GVertex *v1, GVertex *v2)
    : GEdge(m, num, v1, v2), _c(c), _trimmed(nullptr)
  {
-@@ -266,7 +272,7 @@ bool OCCEdge::containsPoint(const SPoint3 &pt) const
+@@ -267,7 +272,7 @@ bool OCCEdge::containsPoint(const SPoint3 &pt) const
    double u;
    SPoint3 xyz;
    if(_project(pt.data(), u, xyz.data())) {
@@ -30,7 +38,7 @@ index 2ed6e08..248f938 100644
      if(pt.distance(xyz) <= tolerance) return true;
    }
    return false;
-@@ -411,9 +417,13 @@ double OCCEdge::curvature(double par) const
+@@ -412,9 +417,13 @@ double OCCEdge::curvature(double par) const
  
    if(degenerate(0)) return eps;
  
@@ -45,7 +53,7 @@ index 2ed6e08..248f938 100644
      aCLProps.SetParameter(par);
      if(!aCLProps.IsTangentDefined())
        Crv = eps;
-@@ -458,4 +468,4 @@ void OCCEdge::writeGEO(FILE *fp)
+@@ -459,4 +468,4 @@ void OCCEdge::writeGEO(FILE *fp)
      GEdge::writeGEO(fp);
  }
  

--- a/ports/gmsh/compatible-occ-8.diff
+++ b/ports/gmsh/compatible-occ-8.diff
@@ -1,0 +1,54 @@
+diff --git a/src/geo/OCCEdge.cpp b/src/geo/OCCEdge.cpp
+index 2ed6e08..248f938 100644
+--- a/src/geo/OCCEdge.cpp
++++ b/src/geo/OCCEdge.cpp
+@@ -1,4 +1,4 @@
+-// Gmsh - Copyright (C) 1997-2025 C. Geuzaine, J.-F. Remacle
++// Gmsh - Copyright (C) 1997-2026 C. Geuzaine, J.-F. Remacle
+ //
+ // See the LICENSE.txt file in the Gmsh root directory for license information.
+ // Please report all issues on https://gitlab.onelab.info/gmsh/gmsh/issues.
+@@ -34,6 +34,12 @@
+ #include <BRep_Builder.hxx>
+ #include <BOPTools_AlgoTools.hxx>
+ 
++#if OCC_VERSION_HEX < 0x080000
++#include <Geom2dLProp_CLProps2d.hxx>
++#else
++#include <GeomLProp.hxx>
++#endif
++
+ OCCEdge::OCCEdge(GModel *m, TopoDS_Edge c, int num, GVertex *v1, GVertex *v2)
+   : GEdge(m, num, v1, v2), _c(c), _trimmed(nullptr)
+ {
+@@ -266,7 +272,7 @@ bool OCCEdge::containsPoint(const SPoint3 &pt) const
+   double u;
+   SPoint3 xyz;
+   if(_project(pt.data(), u, xyz.data())) {
+-    const Standard_Real tolerance = BRep_Tool::Tolerance(_c);
++    const double tolerance = BRep_Tool::Tolerance(_c);
+     if(pt.distance(xyz) <= tolerance) return true;
+   }
+   return false;
+@@ -411,9 +417,13 @@ double OCCEdge::curvature(double par) const
+ 
+   if(degenerate(0)) return eps;
+ 
+-  Standard_Real Crv;
++  double Crv;
+   if(_curve.IsNull()) {
++#if OCC_VERSION_HEX < 0x080000
+     Geom2dLProp_CLProps2d aCLProps(_curve2d, 2, eps);
++#else
++    GeomLProp_CLProps2d aCLProps(_curve2d, 2, eps);
++#endif
+     aCLProps.SetParameter(par);
+     if(!aCLProps.IsTangentDefined())
+       Crv = eps;
+@@ -458,4 +468,4 @@ void OCCEdge::writeGEO(FILE *fp)
+     GEdge::writeGEO(fp);
+ }
+ 
+-#endif
++#endif
+\ No newline at end of file

--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_extract_source_archive(
         linking-and-naming.diff
         opencascade.diff
         use-cxx-17.diff
+        compatible-occ-8.diff
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_LIB)

--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_extract_source_archive(
         installdirs.diff
         linking-and-naming.diff
         opencascade.diff
+        use-cxx-17.diff
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_LIB)

--- a/ports/gmsh/use-cxx-17.diff
+++ b/ports/gmsh/use-cxx-17.diff
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed5d404..1919bed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,8 +16,8 @@ endif()
+ 
+ project(gmsh CXX C)
+ 
+-# require C++14 and request C99
+-set(CMAKE_CXX_STANDARD 14)
++# require C++17 and request C99
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_C_STANDARD 99)
+ 

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gmsh",
   "version": "4.15.2",
+  "port-version": 1,
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
   "license": "LGPL-2.0-or-later",

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -30,7 +30,10 @@
     "mpi": {
       "description": "Enable MPI (experimental, not used for meshing)",
       "dependencies": [
-        "openmpi"
+        {
+          "name": "openmpi",
+          "platform": "!windows"
+        }
       ]
     },
     "occ": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3534,7 +3534,7 @@
     },
     "gmsh": {
       "baseline": "4.15.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gobject-introspection": {
       "baseline": "1.86.0",

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9cca96fd338252be7e351e32e83093b1e43ffb4a",
+      "git-tree": "f0bb00d366435735ea65f1bdc1c96bcaa098d5cb",
       "version": "4.15.2",
       "port-version": 1
     },

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c33645762a6bdf8ac181ef878ea283cf8b7edbd5",
+      "git-tree": "9cca96fd338252be7e351e32e83093b1e43ffb4a",
       "version": "4.15.2",
       "port-version": 1
     },

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c33645762a6bdf8ac181ef878ea283cf8b7edbd5",
+      "version": "4.15.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "a37f5abcf7e81672c39b276871582cef586cc1e2",
       "version": "4.15.2",
       "port-version": 0


### PR DESCRIPTION
The original archive still contains the c++14,
this commit aims to introduce the support for c++17 and align the port with gitlab repository

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
