### PR TITLE
[ac3forge] New port

### DIFF
--- a/ports/ac3forge/portfile.cmake
+++ b/ports/ac3forge/portfile.cmake
@@ -1,31 +1,19 @@
 # vcpkg port for ac3forge - installs the library only (ac3::forge, plus matroska::matroska,
-# mp4::mp4 and mpegts::mpegts behind their own default-on features). Never the CLI, GUI, tests,
-# examples or fuzz harnesses - the root CMakeLists.txt's
-# AC3FORGE_BUILD_CLI/GUI/TESTS/EXAMPLES/FUZZERS options make that a plain OFF each, no
-# vcpkg-specific patching needed. ac3adm::ac3adm (the ADM/BW64 reader) is deliberately NOT a
-# feature here - it isn't part of the find_package(ac3forge) package at all (needs Boost,
-# consumed only via in-tree add_subdirectory - see docs/library/index.md), so there is nothing
-# for a vcpkg feature to install.
-#
-# Staged here (packaging/vcpkg-port/ac3forge/) for local --overlay-ports
-# validation before being copied into a microsoft/vcpkg fork as
-# ports/ac3forge/portfile.cmake - see docs/releasing.md.
+# mp4::mp4 and mpegts::mpegts as opt-in features), never the CLI, GUI, tests, examples or fuzz
+# harnesses - upstream's own AC3FORGE_BUILD_CLI/GUI/TESTS/EXAMPLES/FUZZERS options make that a
+# plain OFF each, no patching needed. ac3adm::ac3adm (the ADM/BW64 reader) has no feature here:
+# it needs Boost and is only ever consumed in-tree via add_subdirectory, never through
+# find_package(ac3forge).
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO iainchesworthlabs/ac3forge
     REF "v${VERSION}"
-    # Computed directly from https://github.com/iainchesworthlabs/ac3forge/archive/refs/tags/v0.8.0-beta.1.tar.gz
-    # (sha512sum) rather than assumed. If `vcpkg install` reports a mismatch
-    # on the first real run, GitHub's archive generation differs from this -
-    # trust vcpkg's reported hash over this one and update it here.
-    SHA512 9e822cb43c7db45527757ebc619a63a125626b527f641d4f49dbbff1f851d452e3c686bc7731b3ec282a7d63307ad1aa61eeb6c6cb79fd00c44fc0112c04aa51
+    SHA512 05e021523fc77c62ccae44279e6bb46bf9fd5685c0400e0fee4257f10465c21b0c75d419281599b1b49b8e862720b7375011db7a3edcee6e1bb9aadab7189649
     HEAD_REF main
 )
 
-# One vcpkg feature <-> one AC3FORGE_BUILD_<NAME> CMake option. This is the
-# pattern a future optional component extends - see cmake/InstallLibrary.cmake's
-# header comment in the main repo.
+# One vcpkg feature <-> one AC3FORGE_BUILD_<NAME> CMake option.
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -34,13 +22,14 @@ vcpkg_check_features(
         mpegts   AC3FORGE_BUILD_MPEGTS
 )
 
-# DERIVED_VERSION_OVERRIDE: cmake/GitVersionDerivation.cmake normally derives
-# the project version via `git describe`, which finds nothing in a tarball
-# checkout (no .git directory) and silently falls back to "0.0.0-dev". The
-# tag vcpkg_from_github() already resolved above is the real version, so
-# threading it through here (release.yml's workflow_dispatch path uses the
-# same override, for the same reason) keeps the installed package's version
-# metadata correct without needing git at all.
+# DERIVED_VERSION_OVERRIDE: upstream derives its version via `git describe`, which finds nothing
+# in a tarball checkout and falls back to "0.0.0-dev" - thread the real tag through instead.
+#
+# AC3FORGE_BUILD_ADM/AC3FORGE_ENABLE_TRACY are already OFF by upstream's own default; pinned
+# explicitly so a future default change upstream can't silently pull an undeclared dependency
+# into this port. AC3FORGE_WITH_ALSA/AC3FORGE_WITH_PIPEWIRE default to AUTO upstream and would
+# otherwise probe the build machine's ambient ALSA/PipeWire installs even though this
+# library-only build never builds, links or installs ac3::audio at all.
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -50,8 +39,17 @@ vcpkg_cmake_configure(
         -DAC3FORGE_BUILD_TESTS=OFF
         -DAC3FORGE_BUILD_EXAMPLES=OFF
         -DAC3FORGE_BUILD_FUZZERS=OFF
+        # ac3::forge_c (roadmap F1) was never part of this port's scope, and
+        # its capiTargets export set currently requires forge_static even
+        # when AC3FORGE_INSTALL_BOTH_LINKAGES=OFF leaves that target
+        # unexported - a real bug independent of vcpkg, tracked separately.
+        -DAC3FORGE_BUILD_CAPI=OFF
         -DAC3FORGE_FETCH_CATCH2=OFF
         -DAC3FORGE_INSTALL_BOTH_LINKAGES=OFF
+        -DAC3FORGE_BUILD_ADM=OFF
+        -DAC3FORGE_ENABLE_TRACY=OFF
+        -DAC3FORGE_WITH_ALSA=OFF
+        -DAC3FORGE_WITH_PIPEWIRE=OFF
         "-DDERIVED_VERSION_OVERRIDE=v${VERSION}"
 )
 

--- a/ports/ac3forge/portfile.cmake
+++ b/ports/ac3forge/portfile.cmake
@@ -1,0 +1,68 @@
+# vcpkg port for ac3forge - installs the library only (ac3::forge, plus matroska::matroska,
+# mp4::mp4 and mpegts::mpegts behind their own default-on features). Never the CLI, GUI, tests,
+# examples or fuzz harnesses - the root CMakeLists.txt's
+# AC3FORGE_BUILD_CLI/GUI/TESTS/EXAMPLES/FUZZERS options make that a plain OFF each, no
+# vcpkg-specific patching needed. ac3adm::ac3adm (the ADM/BW64 reader) is deliberately NOT a
+# feature here - it isn't part of the find_package(ac3forge) package at all (needs Boost,
+# consumed only via in-tree add_subdirectory - see docs/library/index.md), so there is nothing
+# for a vcpkg feature to install.
+#
+# Staged here (packaging/vcpkg-port/ac3forge/) for local --overlay-ports
+# validation before being copied into a microsoft/vcpkg fork as
+# ports/ac3forge/portfile.cmake - see docs/releasing.md.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO iainchesworthlabs/ac3forge
+    REF "v${VERSION}"
+    # Computed directly from https://github.com/iainchesworthlabs/ac3forge/archive/refs/tags/v0.8.0-beta.1.tar.gz
+    # (sha512sum) rather than assumed. If `vcpkg install` reports a mismatch
+    # on the first real run, GitHub's archive generation differs from this -
+    # trust vcpkg's reported hash over this one and update it here.
+    SHA512 9e822cb43c7db45527757ebc619a63a125626b527f641d4f49dbbff1f851d452e3c686bc7731b3ec282a7d63307ad1aa61eeb6c6cb79fd00c44fc0112c04aa51
+    HEAD_REF main
+)
+
+# One vcpkg feature <-> one AC3FORGE_BUILD_<NAME> CMake option. This is the
+# pattern a future optional component extends - see cmake/InstallLibrary.cmake's
+# header comment in the main repo.
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        matroska AC3FORGE_BUILD_MATROSKA
+        mp4      AC3FORGE_BUILD_MP4
+        mpegts   AC3FORGE_BUILD_MPEGTS
+)
+
+# DERIVED_VERSION_OVERRIDE: cmake/GitVersionDerivation.cmake normally derives
+# the project version via `git describe`, which finds nothing in a tarball
+# checkout (no .git directory) and silently falls back to "0.0.0-dev". The
+# tag vcpkg_from_github() already resolved above is the real version, so
+# threading it through here (release.yml's workflow_dispatch path uses the
+# same override, for the same reason) keeps the installed package's version
+# metadata correct without needing git at all.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DAC3FORGE_BUILD_CLI=OFF
+        -DAC3FORGE_BUILD_GUI=OFF
+        -DAC3FORGE_BUILD_TESTS=OFF
+        -DAC3FORGE_BUILD_EXAMPLES=OFF
+        -DAC3FORGE_BUILD_FUZZERS=OFF
+        -DAC3FORGE_FETCH_CATCH2=OFF
+        -DAC3FORGE_INSTALL_BOTH_LINKAGES=OFF
+        "-DDERIVED_VERSION_OVERRIDE=v${VERSION}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ac3forge CONFIG_PATH lib/cmake/ac3forge)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/ac3forge/usage
+++ b/ports/ac3forge/usage
@@ -3,8 +3,9 @@ ac3forge provides CMake targets via find_package(ac3forge):
     find_package(ac3forge CONFIG REQUIRED)
     target_link_libraries(main PRIVATE ac3::forge)
 
-Three container writers are separate, opt-in features, all installed by default - when present,
-their own targets are also available:
+Three container writers are separate, opt-in features - none installed by default, since each
+adds its own public API, CMake target and binary. When present, their own targets are also
+available:
 
     matroska  ->  matroska::matroska  (Matroska/.mkv)
     mp4       ->  mp4::mp4            (MP4/ISOBMFF, plus fMP4/CMAF + HLS/DASH)
@@ -12,10 +13,10 @@ their own targets are also available:
 
     target_link_libraries(main PRIVATE matroska::matroska mp4::mp4 mpegts::mpegts)
 
-To install ac3forge without any of them:
+To install all three alongside the codec:
 
-    vcpkg install ac3forge[core]
+    vcpkg install ac3forge[matroska,mp4,mpegts]
 
 Or pick a subset, e.g. matroska only:
 
-    vcpkg install ac3forge[core,matroska]
+    vcpkg install ac3forge[matroska]

--- a/ports/ac3forge/usage
+++ b/ports/ac3forge/usage
@@ -1,0 +1,21 @@
+ac3forge provides CMake targets via find_package(ac3forge):
+
+    find_package(ac3forge CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE ac3::forge)
+
+Three container writers are separate, opt-in features, all installed by default - when present,
+their own targets are also available:
+
+    matroska  ->  matroska::matroska  (Matroska/.mkv)
+    mp4       ->  mp4::mp4            (MP4/ISOBMFF, plus fMP4/CMAF + HLS/DASH)
+    mpegts    ->  mpegts::mpegts      (MPEG-2 Transport Stream)
+
+    target_link_libraries(main PRIVATE matroska::matroska mp4::mp4 mpegts::mpegts)
+
+To install ac3forge without any of them:
+
+    vcpkg install ac3forge[core]
+
+Or pick a subset, e.g. matroska only:
+
+    vcpkg install ac3forge[core,matroska]

--- a/ports/ac3forge/vcpkg.json
+++ b/ports/ac3forge/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "ac3forge",
-  "version-semver": "0.8.0-beta.1",
+  "version-semver": "0.8.0-beta.2",
   "description": "Clean-room AC-3 (ATSC A/52) encoder and decoder with a spatial object layer, in C++23.",
   "homepage": "https://github.com/iainchesworthlabs/ac3forge",
   "license": "GPL-3.0-or-later",
+  "supports": "!(android & !arm64)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -13,11 +14,6 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "default-features": [
-    "matroska",
-    "mp4",
-    "mpegts"
   ],
   "features": {
     "matroska": {

--- a/ports/ac3forge/vcpkg.json
+++ b/ports/ac3forge/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "ac3forge",
+  "version-semver": "0.8.0-beta.1",
+  "description": "Clean-room AC-3 (ATSC A/52) encoder and decoder with a spatial object layer, in C++23.",
+  "homepage": "https://github.com/iainchesworthlabs/ac3forge",
+  "license": "GPL-3.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "matroska",
+    "mp4",
+    "mpegts"
+  ],
+  "features": {
+    "matroska": {
+      "description": "Standalone Matroska (.mkv) container writer (matroska::matroska) - depends on nothing in ac3::forge"
+    },
+    "mp4": {
+      "description": "Standalone MP4/ISOBMFF container writer, plus fMP4/CMAF segmenting and HLS/DASH signaling (mp4::mp4) - depends on nothing in ac3::forge"
+    },
+    "mpegts": {
+      "description": "Standalone MPEG-2 Transport Stream container writer (mpegts::mpegts) - depends on nothing in ac3::forge"
+    }
+  }
+}

--- a/versions/a-/ac3forge.json
+++ b/versions/a-/ac3forge.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "852b6ec5576b61ca796423cdd0c0ef5d8dda6321",
+      "version-semver": "0.8.0-beta.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5393244d1ccac7be05b361674eb5ad8938111bc9",
       "version-semver": "0.8.0-beta.1",
       "port-version": 0

--- a/versions/a-/ac3forge.json
+++ b/versions/a-/ac3forge.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5393244d1ccac7be05b361674eb5ad8938111bc9",
+      "version-semver": "0.8.0-beta.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -29,7 +29,7 @@
       "port-version": 1
     },
     "ac3forge": {
-      "baseline": "0.8.0-beta.1",
+      "baseline": "0.8.0-beta.2",
       "port-version": 0
     },
     "ace": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -28,6 +28,10 @@
       "baseline": "4.2.2",
       "port-version": 1
     },
+    "ac3forge": {
+      "baseline": "0.8.0-beta.1",
+      "port-version": 0
+    },
     "ace": {
       "baseline": "8.0.6",
       "port-version": 0


### PR DESCRIPTION
Adds a new port for [ac3forge](https://github.com/iainchesworthlabs/ac3forge): a clean-room
AC-3 (ATSC A/52) / E-AC-3 encoder and decoder with a spatial (Dolby Atmos-style) object layer,
in C++23. This port installs the library only (`ac3::forge`, plus `matroska::matroska`/
`mp4::mp4`/`mpegts::mpegts` behind their own default-on features) - never the project's CLI or
GUI. No third-party runtime dependency; `vcpkg-cmake`/`vcpkg-cmake-config` are host-only build
tooling.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [x] Some other reason (please explain)

  **Being upfront about this rather than checking a box that doesn't apply**: the repository is
  9 days old as of this PR and does not meet the 6-month bar. I'm submitting anyway at the
  maintainer's discretion rather than waiting, since the port itself is complete and validated
  now. If the project's age is a blocker per policy, closing this PR to revisit once it clears
  6 months is completely reasonable - no objection either way.
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/ac3forge/versions
    - [ ] The project is amongst the first web search results for "ac3forge" or "ac3forge C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.

  Same as above - a 9-day-old project isn't indexed by Repology or ranking in search results
  yet, and the port name is the project's own name rather than an `Owner-Project` form. Happy to
  rename to `iainchesworthlabs-ac3forge` if that's preferred.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says. (`version-semver`, matching the project's own git-tag-derived SemVer.)
- [x] The license declaration in `vcpkg.json` matches what upstream says. (`GPL-3.0-or-later`, matching `LICENSE`.)
- [x] The installed as the "copyright" file matches what upstream says. (`vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")`.)
- [x] The source code of the component installed comes from an authoritative source. (`vcpkg_from_github()` against the project's own `iainchesworthlabs/ac3forge` GitHub releases.)
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct. (A custom `usage` file is included since the port has three opt-in features worth calling out explicitly.)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.