### PR TITLE
[nanobind] update to 2.15.0

### DIFF
--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind
     REF "v${VERSION}"
-    SHA512 8ab384572d8142b29fdccab2e3693e576cee4cbd6c8d8ac54b3426e45dba6618beb4ccb3e413d41fc405d09935da1fd65f75ef46cf6f78156c2273052fe3e22a
+    SHA512 376c4e86cec0e97fe9d6d844fe4e79c1cbfdd2d6355d68ee5b8acff4329983044ea0f22d0948f731ee82009afa7bba837f4f849967c831bad9ea322ffb52fc00
     HEAD_REF master
 )
 

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobind",
-  "version-semver": "2.13.0",
+  "version-semver": "2.15.0",
   "description": "Tiny and efficient C++/Python bindings",
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6969,7 +6969,7 @@
       "port-version": 0
     },
     "nanobind": {
-      "baseline": "2.13.0",
+      "baseline": "2.15.0",
       "port-version": 0
     },
     "nanodbc": {

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23a5a495e46ca4a7f6bd567f74f4201f3454bff5",
+      "version-semver": "2.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae65341dd32843a466be26e7888d77b23c519cdc",
       "version-semver": "2.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/wjakob/nanobind/releases/tag/v2.15.0
