### PR TITLE
[livepp] Update to 2.11.4

### DIFF
--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS https://liveplusplus.tech/downloads/${LIVEPP_FILE}
     FILENAME "${LIVEPP_FILE}"
-    SHA512 1ed5b9ff453bb5b290f97cdfdcdd3ca0e85842fa6a45418ab628d8f86c2d07ae42d19e3893201e19a72c7e63a44ad4e194c3db39ef72eedbee40231f7640349d
+    SHA512 f7407c1c5487bce086af0044e5d34913f3f10e75cef3485b65241b6f3092c187b8127e1879e93ab4e9b4d48f156b39e31f08cea3c47a31d455bff28be570120d
 )
 
 vcpkg_extract_source_archive(

--- a/ports/livepp/vcpkg.json
+++ b/ports/livepp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "livepp",
-  "version-semver": "2.11.3",
+  "version-semver": "2.11.4",
   "description": "Hot-reload for C & C++ transforms workflows and decreases iteration times.",
   "homepage": "https://liveplusplus.tech/",
   "documentation": "https://liveplusplus.tech/docs/documentation.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6193,7 +6193,7 @@
       "port-version": 0
     },
     "livepp": {
-      "baseline": "2.11.3",
+      "baseline": "2.11.4",
       "port-version": 0
     },
     "llama-cpp": {

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b2811d0ce2d0a5c4f37d14831c6daba03b60153",
+      "version-semver": "2.11.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8289c23c661628a0b37ab3a6049083b4a56e4ca",
       "version-semver": "2.11.3",
       "port-version": 0


### PR DESCRIPTION
Update livepp port from 2.11.3 to 2.11.4: https://liveplusplus.tech/releases.html

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.