### PR TITLE
Add AGENTS.md.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# vcpkg repository instructions
+
+## Port patches
+
+- Create or refresh patch files with `git diff --output=<patch-file> ...`, not shell output redirection. This preserves exact line endings, including CRLF bytes in patch hunks.
+
+## Pull requests
+
+- Before opening or drafting a pull request, read `.github/pull_request_template.md`, determine which checklist applies, and verify each relevant item.
+- Keep / uncomment applicable checklists in pull request bodies and complete them accurately. Do not make up your own checklists.
+- When considering opening a pull request, note that vcpkg maintainers review contributions according to `.github/skills/shared/review-vcpkg-pr-guide.md`. Consult it at that stage to anticipate the evidence and package-readiness checks the review will apply; it is not required for unrelated work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
This is intended to help with

1. the avalanche of clearly AI generated from start to finish PRs that don't fill out or consider the checklists, and
2. copilot-cli et al. constantly editing patches incorrectly

Note that the vcpkg maintainers do not use Claude Code, CLAUDE.md is here only so that contributors who themselves use Claude Code or similar harnesses get the instructions. See https://code.claude.com/docs/en/memory#agents-md