### PR TITLE
[openfbx] Fix typo in exported CMake namespace

### DIFF
--- a/ports/openfbx/CMakeLists.txt
+++ b/ports/openfbx/CMakeLists.txt
@@ -44,6 +44,6 @@ install(FILES ${CMAKE_SOURCE_DIR}/src/ofbx.h
 
 install(
     EXPORT unofficial-openfbxTargets
-    NAMESPACE unoffical::openfbx::
+    NAMESPACE unofficial::openfbx::
     DESTINATION ${CMAKE_INSTALL_DATADIR}/unofficial-openfbx
 )

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openfbx",
   "version-date": "2024-12-28",
+  "port-version": 1,
   "description": "Lightweight open source FBX importer",
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7470,7 +7470,7 @@
     },
     "openfbx": {
       "baseline": "2024-12-28",
-      "port-version": 0
+      "port-version": 1
     },
     "openfx": {
       "baseline": "1.4",

--- a/versions/o-/openfbx.json
+++ b/versions/o-/openfbx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b53a85cf53454b797f8648cf9176396a3b3edb73",
+      "version-date": "2024-12-28",
+      "port-version": 1
+    },
+    {
       "git-tree": "1a9af7acc4ae2b16073c3a79048c85dded206b90",
       "version-date": "2024-12-28",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


Fixes https://github.com/microsoft/vcpkg/issues/53451