### PR TITLE
[otl] Update to 4.0.504

### DIFF
--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -1,9 +1,9 @@
-set(OTL_VERSION 40502)
+set(OTL_VERSION 40504)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
     FILENAME "otlv4_${OTL_VERSION}.zip"
-    SHA512 d458604ecd7454a4f9b778802a15053395322ec948bbaff6bbfb3240d3988a11296bb8a08cbd01d86feb902132b1f834b2781116b143bfcd5a5b701392ee7c52
+    SHA512 73111e15cd59822ece8d982992c6d45321bcfd78dac10487049b148286ae17a96de5b72913e779039547ee5a02f6e0408e818f1cc5b5b701cf9d69cdf9c44ec6
 )
 
 vcpkg_extract_source_archive(

--- a/ports/otl/vcpkg.json
+++ b/ports/otl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "otl",
-  "version": "4.0.502",
+  "version": "4.0.504",
   "description": "Oracle, Odbc and DB2-CLI Template Library",
   "homepage": "https://otl.sourceforge.net/",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7665,7 +7665,7 @@
       "port-version": 0
     },
     "otl": {
-      "baseline": "4.0.502",
+      "baseline": "4.0.504",
       "port-version": 0
     },
     "outcome": {

--- a/versions/o-/otl.json
+++ b/versions/o-/otl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8d34d41032cefb266d1892b26da157c7206fa09",
+      "version": "4.0.504",
+      "port-version": 0
+    },
+    {
       "git-tree": "355c84932700daebc87bbc552bd2d5bca37ba25c",
       "version": "4.0.502",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.