### PR TITLE
[tgbot-cpp] update to 1.12.3

### DIFF
--- a/ports/tgbot-cpp/portfile.cmake
+++ b/ports/tgbot-cpp/portfile.cmake
@@ -19,14 +19,6 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/TgBot")
 
-file(READ "${CURRENT_PACKAGES_DIR}/share/tgbot-cpp/TgBotConfig.cmake" tgbot_config)
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/tgbot-cpp/TgBotConfig.cmake" "
-include(CMakeFindDependencyMacro)
-find_dependency(Boost COMPONENTS system)
-find_dependency(CURL)
-${tgbot_config}
-")
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tgbot-cpp/portfile.cmake
+++ b/ports/tgbot-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO reo7sp/tgbot-cpp
     REF "v${VERSION}"
-    SHA512 0ee6b7658894697ccc38fbf0f7d0b0ca80d9af2a86cec5c78cd5501e472fed8d2aa351364bb7d5a4860c73df9916a82879d9fdfd90e7accfe180ef679e1dcdfd
+    SHA512 7472a953338ad6946a4cf66d8170d34bee331aebc33ff6deae63846de8adc94321a438b14918ca192afbb4214304ae1fc45ecef7f9cee66236b5e1c24ab6135c
     HEAD_REF master
 )
 

--- a/ports/tgbot-cpp/vcpkg.json
+++ b/ports/tgbot-cpp/vcpkg.json
@@ -13,6 +13,7 @@
       "name": "curl",
       "default-features": false
     },
+    "nlohmann-json",
     "openssl",
     {
       "name": "vcpkg-cmake",

--- a/ports/tgbot-cpp/vcpkg.json
+++ b/ports/tgbot-cpp/vcpkg.json
@@ -1,17 +1,14 @@
 {
   "name": "tgbot-cpp",
-  "version": "1.10",
+  "version": "1.12.3",
   "description": "C++ library for Telegram bot API.",
   "homepage": "https://github.com/reo7sp/tgbot-cpp",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
-    "boost-algorithm",
     "boost-asio",
-    "boost-lexical-cast",
-    "boost-property-tree",
+    "boost-beast",
     "boost-system",
-    "boost-variant",
     {
       "name": "curl",
       "default-features": false

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10141,7 +10141,7 @@
       "port-version": 5
     },
     "tgbot-cpp": {
-      "baseline": "1.10",
+      "baseline": "1.12.3",
       "port-version": 0
     },
     "tgc": {

--- a/versions/t-/tgbot-cpp.json
+++ b/versions/t-/tgbot-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84e5fd6a976555299fc494ac6baa8c1311b7d93c",
+      "version": "1.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "74145ba7d040cc5bd62850cf45aa5ea2dd4b8eba",
       "version": "1.10",
       "port-version": 0

--- a/versions/t-/tgbot-cpp.json
+++ b/versions/t-/tgbot-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "84e5fd6a976555299fc494ac6baa8c1311b7d93c",
+      "git-tree": "fac882e0ff62c2a171d7199028c0beae6165ab9d",
       "version": "1.12.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/reo7sp/tgbot-cpp/releases/tag/v1.12.3

The tgbot-cpp's dependencies on boost libraries have changed significantly.