### PR TITLE
[cppduals] Add new port

### DIFF
--- a/ports/cppduals/portfile.cmake
+++ b/ports/cppduals/portfile.cmake
@@ -1,0 +1,30 @@
+# Header-only: there is nothing to build in debug.
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.com
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tesch1/cppduals
+    REF "v${VERSION}"
+    SHA512 70e47ee403cd1faaf5893fdab18ea94ce90cd4e8f31d8efa3b907ceafee859f852ff33d8d92feae077c496a56fe34a505e847f86042bdc34de1c53bb417b5a50
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCPPDUALS_TESTING=OFF
+        -DCPPDUALS_BENCHMARK=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME cppduals CONFIG_PATH lib/cmake/cppduals)
+
+# No libraries to ship, only headers and the CMake package files.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cppduals/usage
+++ b/ports/cppduals/usage
@@ -1,0 +1,6 @@
+cppduals provides CMake targets:
+
+    find_package(cppduals CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE cppduals::duals)
+
+If you use this in research, please cite doi:10.21105/joss.01487 (Tesch, JOSS 4(43):1487, 2019).

--- a/ports/cppduals/vcpkg.json
+++ b/ports/cppduals/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "cppduals",
+  "version": "0.9.2",
+  "description": [
+    "Header-only C++17 dual-number library for exact forward-mode automatic differentiation",
+    "If you use this in research, please cite doi:10.21105/joss.01487 (Tesch, JOSS 4(43):1487, 2019)."
+  ],
+  "homepage": "https://gitlab.com/tesch1/cppduals",
+  "documentation": "https://tesch1.gitlab.io/cppduals/",
+  "license": "MPL-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2104,6 +2104,10 @@
       "baseline": "1.58.0-a",
       "port-version": 0
     },
+    "cppduals": {
+      "baseline": "0.9.2",
+      "port-version": 0
+    },
     "cppfs": {
       "baseline": "1.3.0",
       "port-version": 4

--- a/versions/c-/cppduals.json
+++ b/versions/c-/cppduals.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "406b71b85b52c82862c268bc2367edacadda5338",
+      "version": "0.9.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a port for [cppduals](https://gitlab.com/tesch1/cppduals), a header-only C++17 dual-number library for exact forward-mode automatic differentiation, with optional Eigen integration.  MPL-2.0.  The library is described in [JOSS 4(43):1487](https://doi.org/10.21105/joss.01487).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches the contents of the upstream license file.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested on `arm64-osx`: `vcpkg install cppduals` builds and passes post-build validation, and a consumer project links against `cppduals::duals` through the vcpkg toolchain and runs.  The port is header-only, so it sets `VCPKG_BUILD_TYPE release`.