### PR TITLE
[poco] fix TARGET_RUNTIME_DLLS on zlib dependency

### DIFF
--- a/ports/poco/0003-fix-dependency.patch
+++ b/ports/poco/0003-fix-dependency.patch
@@ -146,7 +146,8 @@ index 32b5d83..4d816c9 100644
 @@ -2,8 +2,8 @@ if(@POCO_UNBUNDLED@)
  	include(CMakeFindDependencyMacro)
  	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
- 	find_dependency(ZLIB REQUIRED)
+-	find_dependency(ZLIB REQUIRED)
++	find_dependency(ZLIB CONFIG REQUIRED)
 -	find_dependency(PCRE2 REQUIRED)
 -	find_dependency(Utf8Proc REQUIRED)
 +	find_dependency(PCRE2 CONFIG COMPONENTS 8BIT)
@@ -198,7 +199,7 @@ index 173eacd..90f68fc 100644
  endif()
  
 +include(CMakeFindDependencyMacro)
-+find_dependency(ZLIB)
++find_dependency(ZLIB CONFIG REQUIRED)
 +if(Poco_FIND_REQUIRED_XML)
 +    find_dependency(expat CONFIG)
 +endif()

--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -8,7 +8,8 @@ index cb29e69..8ff6332 100644
  if(POCO_UNBUNDLED)
 -	find_package(PCRE2 REQUIRED)
 +	find_package(PCRE2 CONFIG REQUIRED COMPONENTS 8BIT)
- 	find_package(ZLIB REQUIRED)
+-	find_package(ZLIB REQUIRED)
++	find_package(ZLIB CONFIG REQUIRED)
 -	find_package(Utf8Proc REQUIRED)
 +	find_package(utf8proc CONFIG REQUIRED)
  

--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -17,12 +17,19 @@ index cb29e69..8ff6332 100644
  	POCO_SOURCES(SRCS RegExp
  		src/pcre2_ucd.c
  		src/pcre2_tables.c
-@@ -99,7 +99,7 @@ set_target_properties(Foundation
+@@ -99,7 +99,14 @@ set_target_properties(Foundation
  )
  
  if(POCO_UNBUNDLED)
 -	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
-+	target_link_libraries(Foundation PUBLIC PCRE2::8BIT ZLIB::ZLIB utf8proc::utf8proc)
++	if(TARGET ZLIB::ZLIB)
++		set(POCO_ZLIB_TARGET ZLIB::ZLIB)
++	elseif(TARGET ZLIB::ZLIBSTATIC)
++		set(POCO_ZLIB_TARGET ZLIB::ZLIBSTATIC)
++	else()
++		message(FATAL_ERROR "Zlib config package did not provide a supported target")
++	endif()
++	target_link_libraries(Foundation PUBLIC PCRE2::8BIT ${POCO_ZLIB_TARGET} utf8proc::utf8proc)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
  	add_definitions(
  		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "poco",
   "version": "1.14.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSD-3-Clause AND BSL-1.0 AND MIT AND Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7962,7 +7962,7 @@
     },
     "poco": {
       "baseline": "1.14.1",
-      "port-version": 3
+      "port-version": 4
     },
     "podofo": {
       "baseline": "1.1.1",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2eaa3edc93b9cf9a9ad138c14742ecfc079c524f",
+      "version": "1.14.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "5d5335d1bb4af801ce93eedf25656caad588a4ea",
       "version": "1.14.1",
       "port-version": 3

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2eaa3edc93b9cf9a9ad138c14742ecfc079c524f",
+      "git-tree": "9b61912d5d1ee6a022db51b48b36ad07174ea58b",
       "version": "1.14.1",
       "port-version": 4
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

Hi! I'm migrating my company's dependencies to vcpkg, and we'd appreciate to have a proper TARGET_RUNTIME_DLLS filled with the linked dll's in each target so our CI and tests have the required dependencies.
I hope this fix is good, and later may come more fixes for libraries :D

zlib was not being properly linked, and with the CONFIG option makes the zlib dll properly propagated.