### PR TITLE
[x264] Update to 0.165.3222

### DIFF
--- a/ports/x264/configure.patch
+++ b/ports/x264/configure.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure
-index 5116bb97..8083a2ea 100755
+index 5116bb97..e4ff41cc 100755
 --- a/configure
 +++ b/configure
 @@ -1,4 +1,7 @@
@@ -27,14 +27,3 @@ index 5116bb97..8083a2ea 100755
          fi
          ;;
      s390|s390x)
-@@ -1429,8 +1434,10 @@ if [ $SYS = WINDOWS -a $ARCH = X86 -a $compiler = GNU ] ; then
- fi
- 
- if cc_check "stdio.h" "-D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64" "fseeko(stdin,0,0);" ; then
-+  if cc_check "" "" "#if defined(__ANDROID_API__) && __ANDROID_API__ < 24\n#error\n#endif\n" ; then
-     define fseek fseeko
-     define ftell ftello
-+  fi
- elif cc_check "stdio.h" "" "fseeko64(stdin,0,0);" ; then
-     define fseek fseeko64
-     define ftell ftello64

--- a/ports/x264/configure.patch
+++ b/ports/x264/configure.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure
-index e242e73c..e0d1df76 100755
+index 5116bb97..8083a2ea 100755
 --- a/configure
 +++ b/configure
 @@ -1,4 +1,7 @@
@@ -11,7 +11,7 @@ index e242e73c..e0d1df76 100755
  
  if test x"$1" = x"-h" -o x"$1" = x"--help" ; then
  cat <<EOF
-@@ -837,6 +840,7 @@ case $host_cpu in
+@@ -865,6 +868,7 @@ case $host_cpu in
              AS="${AS-${SRCPATH}/tools/gas-preprocessor.pl -arch aarch64 -as-type armasm -- armasm64 -nologo}"
          else
              AS="${AS-${CC}}"
@@ -19,7 +19,7 @@ index e242e73c..e0d1df76 100755
          fi
          ;;
      arm*)
-@@ -855,6 +859,7 @@ case $host_cpu in
+@@ -883,6 +887,7 @@ case $host_cpu in
              AS="${AS-${SRCPATH}/tools/gas-preprocessor.pl -arch arm -as-type clang -force-thumb -- ${CC} -mimplicit-it=always}"
          else
              AS="${AS-${CC}}"
@@ -27,10 +27,10 @@ index e242e73c..e0d1df76 100755
          fi
          ;;
      s390|s390x)
-@@ -1354,8 +1359,10 @@ if [ $SYS = WINDOWS -a $ARCH = X86 -a $compiler = GNU ] ; then
+@@ -1429,8 +1434,10 @@ if [ $SYS = WINDOWS -a $ARCH = X86 -a $compiler = GNU ] ; then
  fi
  
- if cc_check "stdio.h" "" "fseeko(stdin,0,0);" ; then
+ if cc_check "stdio.h" "-D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64" "fseeko(stdin,0,0);" ; then
 +  if cc_check "" "" "#if defined(__ANDROID_API__) && __ANDROID_API__ < 24\n#error\n#endif\n" ; then
      define fseek fseeko
      define ftell ftello

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -2,7 +2,7 @@
 set(ref b35605ace3ddf7c1a5d67a2eb553f034aef41d55)
 
 # Note on x264 versioning:
-# The pc file exports "0.164.<N>" where is the number of commits.
+# The pc file exports "0.<ABI>.<N>" where N is the number of commits.
 # The binary releases on https://artifacts.videolan.org/x264/ are named x264-r<N>-<COMMIT>.
 # With a git clone, this can be determined by running `versions.sh`.
 # With vcpkg_from_gitlab, we modify `versions.sh` accordingly.

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -1,5 +1,5 @@
 # The latest ref in branch stable
-set(ref 31e19f92f00c7003fa115047ce50978bc98c3a0d)
+set(ref b35605ace3ddf7c1a5d67a2eb553f034aef41d55)
 
 # Note on x264 versioning:
 # The pc file exports "0.164.<N>" where is the number of commits.
@@ -12,11 +12,11 @@ string(REGEX MATCH "[0-9]+\$" revision "${VERSION}")
 configure_file("${CURRENT_PORT_DIR}/version.diff.in" "${CURRENT_BUILDTREES_DIR}/src/version-${VERSION}.diff" @ONLY)
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://code.videolan.org/
+    GITLAB_URL https://code.videolan.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO videolan/x264
     REF "${ref}"
-    SHA512 707ff486677a1b5502d6d8faa588e7a03b0dee45491c5cba89341be4be23d3f2e48272c3b11d54cfc7be1b8bf4a3dfc3c3bb6d9643a6b5a2ed77539c85ecf294
+    SHA512 bfac118da55da2fcc4587b17a3184d9ed70d6e03188bc0497f5922df22b5685fa49fa4325f9c5196c76d03e6e3f56d5906475c540d0df7e1739dc4182816eebe
     HEAD_REF master
     PATCHES
         "${CURRENT_BUILDTREES_DIR}/src/version-${VERSION}.diff"

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "x264",
-  "version": "0.164.3108",
-  "port-version": 2,
+  "version": "0.165.3222",
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://www.videolan.org/developers/x264.html",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11125,8 +11125,8 @@
       "port-version": 1
     },
     "x264": {
-      "baseline": "0.164.3108",
-      "port-version": 2
+      "baseline": "0.165.3222",
+      "port-version": 0
     },
     "x265": {
       "baseline": "4.3",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "332a06b75d5a911a4083e5797c97cebdc49d9603",
+      "version": "0.165.3222",
+      "port-version": 0
+    },
+    {
       "git-tree": "9367314b9b01285a64c3c6b5e9f895d0ad0f0e48",
       "version": "0.164.3108",
       "port-version": 2

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "332a06b75d5a911a4083e5797c97cebdc49d9603",
+      "git-tree": "baa8ea876d82e7434ed11b198d98820e610eb716",
       "version": "0.165.3222",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Matches version/commit in Ubuntu 26.04 (https://packages.ubuntu.com/resolute/libx264-dev)