### PR TITLE
[aws-c-event-stream] Update to 0.7.2

### DIFF
--- a/ports/aws-c-event-stream/portfile.cmake
+++ b/ports/aws-c-event-stream/portfile.cmake
@@ -29,4 +29,8 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/NOTICE"
+)

--- a/ports/aws-c-event-stream/portfile.cmake
+++ b/ports/aws-c-event-stream/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-event-stream
     REF "v${VERSION}"
-    SHA512 7bc0ed2490f8f2d349fb4aaf77ea20276437f2d184c9c1bfabac72225d0cd37a5bc1e1a8b8dd834f5eccb81aa108426119b9a9250246d4bb88b745e81d9ad07d
-    HEAD_REF master
+    SHA512 38a8ac44e4cd6325e1ff75ccc57dd6aa792ce3ad81ba767a4dcd105723a59fa0fb4a109e67c0ae8511f2fdfafd337d7b00ebf48e70717e2a5c5a427c38532a45
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/aws-c-event-stream/vcpkg.json
+++ b/ports/aws-c-event-stream/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-event-stream",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "C99 implementation of the vnd.amazon.event-stream content-type.",
   "homepage": "https://github.com/awslabs/aws-c-event-stream",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-event-stream.json
+++ b/versions/a-/aws-c-event-stream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "857574e8e310ed9a283afdfc94c6c5377f8c35a2",
+      "git-tree": "b4f9c864189f308c6f3c0b73db2f2d2dd54134cf",
       "version": "0.7.2",
       "port-version": 0
     },

--- a/versions/a-/aws-c-event-stream.json
+++ b/versions/a-/aws-c-event-stream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "857574e8e310ed9a283afdfc94c6c5377f8c35a2",
+      "version": "0.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf66d9e852bff83e56bdebdb9cece4291778a775",
       "version": "0.7.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -473,7 +473,7 @@
       "port-version": 0
     },
     "aws-c-event-stream": {
-      "baseline": "0.7.1",
+      "baseline": "0.7.2",
       "port-version": 0
     },
     "aws-c-http": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
