### PR TITLE
[aws-c-http] Update to 0.11.1

### DIFF
--- a/ports/aws-c-http/portfile.cmake
+++ b/ports/aws-c-http/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-http
     REF "v${VERSION}"
-    SHA512 f25bebbcbb5dcc6c996b8f20abfcd1c2bb2bc8f042097f0b81322ff3f83c44fec884a5f145a2bf5253ebb7137b806d28af6a93d46c74c2d865a19a5a97e804af
-    HEAD_REF master
+    SHA512 311b778df5a2d5dea7c8933d8fa1cdd2c4f8b11ec5f022c14d2487ba1fe039b19ef3f77d8aaaf159721912ac6b434532535a9ad6dd30ab6183d74b8c38fde0ad
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/aws-c-http/portfile.cmake
+++ b/ports/aws-c-http/portfile.cmake
@@ -29,4 +29,8 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/NOTICE"
+)

--- a/ports/aws-c-http/vcpkg.json
+++ b/ports/aws-c-http/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-http",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "C99 implementation of the HTTP/1.1 and HTTP/2 specifications",
   "homepage": "https://github.com/awslabs/aws-c-http",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-http.json
+++ b/versions/a-/aws-c-http.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4fb6bec961424a857ad29c8243dd0894f4106b57",
+      "git-tree": "172e893e8efff99979282a03764419d42f6ec1f3",
       "version": "0.11.1",
       "port-version": 0
     },

--- a/versions/a-/aws-c-http.json
+++ b/versions/a-/aws-c-http.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4fb6bec961424a857ad29c8243dd0894f4106b57",
+      "version": "0.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f49f52b96a237b9a9e1333d717140ee6137eb9a6",
       "version": "0.11.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -477,7 +477,7 @@
       "port-version": 0
     },
     "aws-c-http": {
-      "baseline": "0.11.0",
+      "baseline": "0.11.1",
       "port-version": 0
     },
     "aws-c-io": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
