### PR TITLE
[aws-c-io] Update to 0.27.7

### DIFF
--- a/ports/aws-c-io/portfile.cmake
+++ b/ports/aws-c-io/portfile.cmake
@@ -29,4 +29,8 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/NOTICE"
+)

--- a/ports/aws-c-io/portfile.cmake
+++ b/ports/aws-c-io/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-io
     REF "v${VERSION}"
-    SHA512 85d58aa93533999417b9860e5c51f22de72f2afad0930c73880e9d6f71b048bc5ac910f141b23ee35cbe4f40ef9711785cb36356cae09b8b059b6c22b73780ee
-    HEAD_REF master
+    SHA512 e812fd7168c0b71cc98a7f835dd3dd48174d0c14e5d92ed10b5ecf558fc29bed2b4adf32f55408ee3ed7f54dfaa50d9f12334f5c89b0d76cedb800fb08daf483
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/aws-c-io/vcpkg.json
+++ b/ports/aws-c-io/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-io",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "description": "Handles all IO and TLS work for application protocols.",
   "homepage": "https://github.com/awslabs/aws-c-io",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-io.json
+++ b/versions/a-/aws-c-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7227ee1b451deb62bd70c770a58747354e75adb8",
+      "version": "0.27.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "21eb2e8b780bfccbbbae80a5e3708ae67a5ddd93",
       "version": "0.27.6",
       "port-version": 0

--- a/versions/a-/aws-c-io.json
+++ b/versions/a-/aws-c-io.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7227ee1b451deb62bd70c770a58747354e75adb8",
+      "git-tree": "425ee481cc6e0013079b6316228fb49d3a528679",
       "version": "0.27.7",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -481,7 +481,7 @@
       "port-version": 0
     },
     "aws-c-io": {
-      "baseline": "0.27.6",
+      "baseline": "0.27.7",
       "port-version": 0
     },
     "aws-c-mqtt": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
