### PR TITLE
[aws-c-mqtt] Update to 0.16.2

### DIFF
--- a/ports/aws-c-mqtt/portfile.cmake
+++ b/ports/aws-c-mqtt/portfile.cmake
@@ -29,4 +29,8 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/NOTICE"
+)

--- a/ports/aws-c-mqtt/portfile.cmake
+++ b/ports/aws-c-mqtt/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-mqtt
     REF "v${VERSION}"
-    SHA512 59dcef959d8674af5020cf2e8a0e92c500a7ba568f0072ed277f9c4dab06f79db0192ff8c2634746d7a5c2d299df8fb01d9735b9351c2ace1db6f4873e1625ee
-    HEAD_REF master
+    SHA512 6abe7c2aa2861334930ae2c604f66e9ca2c8a155b7b196469bb8b545cbabe0ee6f6895f13b170953a2016b484d6331b82542e96c784531bd9952c7ea1a068d4b
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/aws-c-mqtt/vcpkg.json
+++ b/ports/aws-c-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-mqtt",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "C99 implementation of the MQTT 3.1.1 specification.",
   "homepage": "https://github.com/awslabs/aws-c-mqtt",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-mqtt.json
+++ b/versions/a-/aws-c-mqtt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "48a45f4934c7e67b7b12ab7427020fff6c5b06d4",
+      "git-tree": "aacbbc403c2b7b557debe4d1073661df5997a7fc",
       "version": "0.16.2",
       "port-version": 0
     },

--- a/versions/a-/aws-c-mqtt.json
+++ b/versions/a-/aws-c-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48a45f4934c7e67b7b12ab7427020fff6c5b06d4",
+      "version": "0.16.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "590f809cbc6b053b2d4251b88b60f6f0f9d1daf1",
       "version": "0.16.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -485,7 +485,7 @@
       "port-version": 0
     },
     "aws-c-mqtt": {
-      "baseline": "0.16.1",
+      "baseline": "0.16.2",
       "port-version": 0
     },
     "aws-c-s3": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.