### PR TITLE
[bde] Update to 4.39.0.0

### DIFF
--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
     REF "${BDE_TOOLS_VER}"
-    SHA512 d250e40955aa7e4076a6d6382d20d10a4a0deabab3f729dce45dfa8e479cd5aecfb603e8d06c8283e15d81e74bf1cdec307c32c6e109097d9a5db9614b0ad30e
+    SHA512 3d15bb0aff27facd167e243a5c5c77c33e1c27e340c84e7deb870c98525a1e653f8d25b82ea7d89c703b87c82b61bc39a94da406b94654d211739618a89d8293
     HEAD_REF main
 )
 
@@ -23,7 +23,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 a3ca09ea673e5a35ca5385482838a8e017ac2c9ca0f570679598d9873c04517e0a9b01e2010c03d7ad56e1e8bcc6b6b87ee507e296420d7d650d0763039e14a6
+    SHA512 d895d11de518eb67805baaa50ef08d2c8c872375a23134c55dd9db8c790436143823ac8dd5707e1cce583f23a5e455fe9f13d7907d92cc2e86b85c3f3d0a5309
     HEAD_REF main
     PATCHES
         fix-bdlar-target.patch
@@ -51,10 +51,14 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 list(APPEND SUBPACKAGES "inteldfp" "s_baltst" "bsl" "bbryu" "bdl" "bbl" "bal")
 include(GNUInstallDirs) # needed for CMAKE_INSTALL_LIBDIR
 foreach(subpackage IN LISTS SUBPACKAGES)
-    vcpkg_cmake_config_fixup(PACKAGE_NAME ${subpackage} CONFIG_PATH /${CMAKE_INSTALL_LIBDIR}/cmake/${subpackage} DO_NOT_DELETE_PARENT_CONFIG_PATH)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "${subpackage}" CONFIG_PATH "/${CMAKE_INSTALL_LIBDIR}/cmake/${subpackage}" DO_NOT_DELETE_PARENT_CONFIG_PATH)
 endforeach()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake" "${CURRENT_PACKAGES_DIR}/debug/${CMAKE_INSTALL_LIBDIR}/cmake")
 
-# Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/thirdparty/bbryu/LICENSE-Boost"
+        "${SOURCE_PATH}/thirdparty/inteldfp/eula.txt"
+)
 vcpkg_fixup_pkgconfig()

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "bde",
-  "version": "4.38.0.0",
+  "version": "4.39.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "homepage": "https://github.com/bloomberg/bde",
   "documentation": "https://bloomberg.github.io/bde/",

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc53ed8da858342101cbd07b9aaa15c6e51c1c91",
+      "version": "4.39.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a7259739d6678ff37bdef773adad278e6e987dfd",
       "version": "4.38.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -665,7 +665,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "4.38.0.0",
+      "baseline": "4.39.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

@BillyONeal No idea how to fix the pcre issue mentioned in #52708, as it seems it requires `find_dependency`+ `ALIAS` creation (that's what I assume after seeing `use-vcpkg-pcre2.patch`)