### PR TITLE
[tinyexif] Update to 1.1.0

### DIFF
--- a/ports/tinyexif/portfile.cmake
+++ b/ports/tinyexif/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cdcseacave/TinyEXIF
     REF ${VERSION}
-    SHA512 cb4e1f15758bb65465e2234065e3b46493200278e7c2e12fa7b4e31e7bff52a93158f07252a642829bad1a7da5e47612aca33fb833f3188595c6bc56cc950f63
-    HEAD_REF 1.0.4
+    SHA512 8e2c0b4f1edcec0dbf4cb6164034520cc1ba23d4681af62dd558f759cb6a184c0f53ce24a41eb21f3f164b46429692f5267c175b4b8a8b15485764927329b047
+    HEAD_REF master
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" LINK_CRT_STATIC)
@@ -24,4 +24,10 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+# Upstream is MIT for its own contributions, but portions derive from easyexif
+# and remain additionally subject to its BSD-2-Clause terms; both notices ship
+# in the source tree and both must be installed.
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE"
+    "${SOURCE_PATH}/LICENSE.easyexif"
+)

--- a/ports/tinyexif/vcpkg.json
+++ b/ports/tinyexif/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "tinyexif",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "tiny ISO-compliant C++ EXIF and XMP parsing library for JPEG images",
   "homepage": "https://github.com/cdcseacave/TinyEXIF",
-  "license": "MIT",
+  "license": "MIT AND BSD-2-Clause",
   "dependencies": [
     "tinyxml2",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10233,7 +10233,7 @@
       "port-version": 0
     },
     "tinyexif": {
-      "baseline": "1.0.4",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "tinyexpr": {

--- a/versions/t-/tinyexif.json
+++ b/versions/t-/tinyexif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88ae065f01efaf8713daaa633bb6997d167e42be",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "68ddf12f8f20a8616b8a45b76c2be99d01ce15b1",
       "version": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
Updates `tinyexif` from 1.0.4 to [1.1.0](https://github.com/cdcseacave/TinyEXIF/releases/tag/1.1.0). I'm the upstream maintainer.

1.1.0 is a security release, published as advisory
[GHSA-jqj2-8c2j-gx82](https://github.com/cdcseacave/TinyEXIF/security/advisories/GHSA-jqj2-8c2j-gx82)
(High, CVE requested) — it bounds-checks every attacker-controlled buffer read in the EXIF/XMP parser, closing a privately reported out-of-bounds read plus four further memory-safety issues found during the audit and by a new fuzzer. Full notes are on the release page.

### Beyond the version bump

Two changes in `portfile.cmake` that aren't strictly part of the bump — happy to drop either if you'd prefer them separate:

**1. Copyright now installs both notices.** TinyEXIF is a fork of [easyexif](https://github.com/mayanklahiri/easyexif), which is BSD-2-Clause. Until 1.1.0 the repo shipped only an MIT `LICENSE`; it now also ships `LICENSE.easyexif` reproducing the upstream BSD-2-Clause notice, because portions of the code remain subject to it. The port installed only `LICENSE`, so the BSD-2-Clause terms weren't reaching users. `vcpkg_install_copyright` now lists both files, and `"license"` becomes `"MIT AND BSD-2-Clause"` to match.

**2. `HEAD_REF` corrected from `1.0.4` to `master`.** `HEAD_REF` should name a branch — as a tag it meant `--head` builds pinned to 1.0.4 forever rather than tracking upstream. Pre-existing, noticed while updating.

### Verification

- `SHA512` computed from the 1.1.0 tarball; both `LICENSE` and `LICENSE.easyexif` confirmed present in it
- Version database `git-tree` (`de1dac65306e0d6df74355d11c4bd6bae9191ca7`) verified against `git rev-parse HEAD:ports/tinyexif`
- `versions/baseline.json` touched only on the `tinyexif` entry

Upstream builds clean on macOS, Ubuntu and Windows in both shared and static configurations, and runs its sample corpus under ASan+UBSan in CI.



---

**Update:** force-pushed. The upstream 1.1.0 tag was moved to fold a follow-up commit into the release, which changed the source tarball, so the `SHA512` and the version database `git-tree` are both updated to match. Re-verified against the live tarball and against `git rev-parse HEAD:ports/tinyexif`. No other change.
