### PR TITLE
[libdaemon] New port

### DIFF
--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_download_distfile(ARCHIVE
-	URLS "http://0pointer.de/lennart/projects/libdaemon/libdaemon-${VERSION}.tar.gz"
+    URLS "http://0pointer.de/lennart/projects/libdaemon/libdaemon-${VERSION}.tar.gz"
     FILENAME "libdaemon-${VERSION}.tar.gz"
     SHA512 a96b25c09bd63cc192c1c5f8b5bf34cc6ad0c32d42ac14b520add611423b6ad3d64091a47e0c7ab9a94476a5e645529abccea3ed6b23596567163fba88131ff2
 )

--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_extract_source_archive(
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
+    OPTIONS
+      --disable-lynx
 )
 
 vcpkg_make_install()

--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_download_distfile(ARCHIVE
+	URLS "http://0pointer.de/lennart/projects/libdaemon/libdaemon-${VERSION}.tar.gz"
+    FILENAME "libdaemon-${VERSION}.tar.gz"
+    SHA512 a96b25c09bd63cc192c1c5f8b5bf34cc6ad0c32d42ac14b520add611423b6ad3d64091a47e0c7ab9a94476a5e645529abccea3ed6b23596567163fba88131ff2
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_make_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_fixup_pkgconfig()

--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_extract_source_archive(
 
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
 )
 
 vcpkg_make_install()

--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -18,3 +18,7 @@ vcpkg_make_install()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)

--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://0pointer.de/lennart/projects/libdaemon/libdaemon-${VERSION}.tar.gz"
+    URLS "https://0pointer.de/lennart/projects/libdaemon/libdaemon-${VERSION}.tar.gz"
     FILENAME "libdaemon-${VERSION}.tar.gz"
     SHA512 a96b25c09bd63cc192c1c5f8b5bf34cc6ad0c32d42ac14b520add611423b6ad3d64091a47e0c7ab9a94476a5e645529abccea3ed6b23596567163fba88131ff2
 )

--- a/ports/libdaemon/portfile.cmake
+++ b/ports/libdaemon/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_make_configure(
     AUTORECONF
     OPTIONS
       --disable-lynx
+      --disable-examples
 )
 
 vcpkg_make_install()

--- a/ports/libdaemon/vcpkg.json
+++ b/ports/libdaemon/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.14",
   "description": "libdaemon is a lightweight C library that eases the writing of UNIX daemons",
   "homepage": "https://0pointer.de/lennart/projects/libdaemon/",
-  "license": "LGPL-2.0-or-later",
+  "license": "LGPL-2.1-or-later",
   "supports": "linux | osx | openbsd | freebsd",
   "dependencies": [
     {

--- a/ports/libdaemon/vcpkg.json
+++ b/ports/libdaemon/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "libdaemon is a lightweight C library that eases the writing of UNIX daemons",
   "homepage": "https://0pointer.de/lennart/projects/libdaemon/",
   "license": "LGPL-2.0-or-later",
-  "supports": "linux",
+  "supports": "linux | osx | openbsd | freebsd",
   "dependencies": [
     {
       "name": "vcpkg-make",

--- a/ports/libdaemon/vcpkg.json
+++ b/ports/libdaemon/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "libdaemon is a lightweight C library that eases the writing of UNIX daemons",
   "homepage": "https://0pointer.de/lennart/projects/libdaemon/",
   "license": "LGPL-2.0-or-later",
-  "supports": "linux & !arm",
+  "supports": "linux",
   "dependencies": [
     {
       "name": "vcpkg-make",

--- a/ports/libdaemon/vcpkg.json
+++ b/ports/libdaemon/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "libdaemon is a lightweight C library that eases the writing of UNIX daemons",
   "homepage": "https://0pointer.de/lennart/projects/libdaemon/",
   "license": "LGPL-2.0-or-later",
-  "supports": "linux",
+  "supports": "linux & !arm",
   "dependencies": [
     {
       "name": "vcpkg-make",

--- a/ports/libdaemon/vcpkg.json
+++ b/ports/libdaemon/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "libdaemon",
+  "version": "0.14",
+  "description": "libdaemon is a lightweight C library that eases the writing of UNIX daemons",
+  "homepage": "https://0pointer.de/lennart/projects/libdaemon/",
+  "license": "LGPL-2.0-or-later",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4932,6 +4932,10 @@
       "baseline": "0.69.1",
       "port-version": 0
     },
+    "libdaemon": {
+      "baseline": "0.14",
+      "port-version": 0
+    },
     "libdatachannel": {
       "baseline": "0.24.5",
       "port-version": 0

--- a/versions/l-/libdaemon.json
+++ b/versions/l-/libdaemon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "45c61017ed8f0e7dc88e627cfb91722c8f139f1f",
+      "git-tree": "34ce55cea6172425c5c5c6f216f55d6d16ae53fd",
       "version": "0.14",
       "port-version": 0
     }

--- a/versions/l-/libdaemon.json
+++ b/versions/l-/libdaemon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5d6f231ac77f151e47015e6836c277f67b5970e4",
+      "git-tree": "aca10041286dc78f067e423715e7bf956a4f3027",
       "version": "0.14",
       "port-version": 0
     }

--- a/versions/l-/libdaemon.json
+++ b/versions/l-/libdaemon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ab0a70969dfeabec61f8a61ebca64609c2e81810",
+      "git-tree": "5d6f231ac77f151e47015e6836c277f67b5970e4",
       "version": "0.14",
       "port-version": 0
     }

--- a/versions/l-/libdaemon.json
+++ b/versions/l-/libdaemon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aca10041286dc78f067e423715e7bf956a4f3027",
+      "git-tree": "45c61017ed8f0e7dc88e627cfb91722c8f139f1f",
       "version": "0.14",
       "port-version": 0
     }

--- a/versions/l-/libdaemon.json
+++ b/versions/l-/libdaemon.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ab0a70969dfeabec61f8a61ebca64609c2e81810",
+      "version": "0.14",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libdaemon.json
+++ b/versions/l-/libdaemon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "34ce55cea6172425c5c5c6f216f55d6d16ae53fd",
+      "git-tree": "54b461fd89274910077b888f9cd4de01c2107821",
       "version": "0.14",
       "port-version": 0
     }


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [x] Is an official component of something else meeting that criteria (AVAHI)
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

----

Note: The maintainer guideline says
> Ports must be tested in at least one official triplet

Question: How can I check/ensure this?

> Packaged projects should be stable and actively maintained

`libdaemon` doesn't seem actively maintained but it seems stable given that it has several projects depending on it:
- [ifplugd](http://0pointer.de/lennart/projects/ifplugd/)
- [Avahi](http://freedesktop.org/Software/Avahi)
- [ivam2](http://0pointer.de/lennart/projects/ivam2/)
- [aeswepd](http://0pointer.de/lennart/projects/aeswepd/)

----

This is a dependency for [Avahi](http://freedesktop.org/Software/Avahi) and hence a prerequisite for an (upcoming) AVAHI port. See also https://github.com/microsoft/vcpkg/pull/44186