### PR TITLE
[sentry-native] Limit the pkgconf host dependency to linux

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -38,6 +38,13 @@ if("compression" IN_LIST FEATURES)
     vcpkg_list(APPEND options "-DSENTRY_TRANSPORT_COMPRESSION=ON")
 endif()
 
+# sentry-native only looks for pkg-config on Linux, to locate the system libunwind for
+# SENTRY_LIBUNWIND_SYSTEM. Acquire it directly instead of depending on the pkgconf port.
+if(VCPKG_TARGET_IS_LINUX)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    vcpkg_list(APPEND options "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(VCPKG_CXX_FLAGS "/D_CRT_DECLARE_NONSTDC_NAMES ${VCPKG_CXX_FLAGS}")
     set(VCPKG_C_FLAGS "/D_CRT_DECLARE_NONSTDC_NAMES ${VCPKG_C_FLAGS}")

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sentry-native",
   "version": "0.16.3",
+  "port-version": 1,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT AND Apache-2.0 AND BSD-3-Clause AND ICU",
@@ -36,10 +37,10 @@
       ],
       "dependencies": [
         {
-          "$comment": "pkgcong is used by the breakpad backend.",
+          "$comment": "pkgconf locates the system libunwind, which sentry-native only looks for on Linux.",
           "name": "pkgconf",
           "host": true,
-          "platform": "!android & !ios"
+          "platform": "linux"
         },
         {
           "$comment": "sentry-native[transport] is used by the crashpad backend.",

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -37,12 +37,6 @@
       ],
       "dependencies": [
         {
-          "$comment": "pkgconf locates the system libunwind, which sentry-native only looks for on Linux.",
-          "name": "pkgconf",
-          "host": true,
-          "platform": "linux"
-        },
-        {
           "$comment": "sentry-native[transport] is used by the crashpad backend.",
           "name": "sentry-native",
           "features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9270,7 +9270,7 @@
     },
     "sentry-native": {
       "baseline": "0.16.3",
-      "port-version": 0
+      "port-version": 1
     },
     "septag-dmon": {
       "baseline": "2026-02-23",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca4a88373a71892ff433e3b3d3d38342e5fd999b",
+      "version": "0.16.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "776b0da04c690faa0335326b7561d4b619248867",
       "version": "0.16.3",
       "port-version": 0

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ca4a88373a71892ff433e3b3d3d38342e5fd999b",
+      "git-tree": "ff357c41819f2f3218eaf39e39f941c9015e4aa4",
       "version": "0.16.3",
       "port-version": 1
     },


### PR DESCRIPTION
`ports/sentry-native` declares `pkgconf` as a host dependency of the default `backend` feature for `!android & !ios`, so `vcpkg install sentry-native` builds `pkgconf` on Windows and macOS too. sentry-native never invokes `pkg-config` on those platforms:

* `CMakeLists.txt:708` sits under `SENTRY_WITH_LIBUNWIND`, which `CMakeLists.txt:310-312` sets only when `LINUX`. This is the lookup the port actually exercises, since the portfile passes `-DSENTRY_LIBUNWIND_SYSTEM=ON`.
* `CMakeLists.txt:806` additionally requires `SENTRY_BREAKPAD_SYSTEM=ON`, which the portfile never sets.
* The vendored crashpad consults it only under `LINUX AND CRASHPAD_ENABLE_STACKTRACE`, which defaults to `OFF` and the portfile does not enable.

The dependency is therefore Linux-only in practice. This narrows the platform expression to match, and corrects the `$comment`, which attributed the dependency to the breakpad backend rather than the system-libunwind lookup.

Install plans before and after, same tree:

```
# before, sentry-native:x64-windows
  * pkgconf:x64-linux@3.0.3
    sentry-native[backend,core,transport,wer]:x64-windows@0.16.3
  * vcpkg-cmake:x64-linux@2025-08-07
  * vcpkg-cmake-config:x64-linux@2026-07-21
  * vcpkg-cmake-get-vars:x64-linux@2025-05-29
  * vcpkg-tool-meson:x64-linux@1.9.0#10
  * zlib:x64-windows@1.3.2#2

# after, sentry-native:x64-windows
    sentry-native[backend,core,transport,wer]:x64-windows@0.16.3#1
  * vcpkg-cmake:x64-linux@2025-08-07
  * vcpkg-cmake-config:x64-linux@2026-07-21
  * zlib:x64-windows@1.3.2#2

# after, sentry-native:x64-linux (unchanged, pkgconf retained)
  * libunwind:x64-linux@1.8.3#1
  * pkgconf:x64-linux@3.0.3
    sentry-native[backend,core,transport]:x64-linux@0.16.3#1
```

Beyond removing a pointless build, this avoids a real failure on Windows. `ports/pkgconf` is on 3.0.3, and since pkgconf 2.9.90 the release tarball contains `tests/lib1/të😋st/lib/pkgconfig/utf8.pc`. GitHub's `git archive` stores that name as raw UTF-8 in the 100-byte `ustar` name field with no `hdrcharset` record, so `tar.exe` decodes it using the machine's legacy code page. Where that code page rejects the bytes (cp932, cp949, cp950, cp874), libarchive clears every form of the entry name, `archive_entry_pathname_w()` returns NULL, and extraction aborts with `Invalid empty pathname` and a non-zero exit. Reproduced with libarchive directly:

```
$ bsdtar --options hdrcharset=CP932 -xf pkgconf-3.0.3.tar.gz
bsdtar: Pathname can't be converted from CP932 to current locale.
$ echo $?
1
```

Affected users currently cannot install sentry-native at all, while building a tool the port would never invoke. Same class as #43984.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (No download changed.)
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary. (No change needed.)
- [x] Any fixed CI baseline and CI feature baseline entries are removed from that file, or no entries needed to be changed. (No entries needed changing.)
- [x] All patch files in the port are applied and succeed. (Unchanged.)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
