### PR TITLE
[wavelib] Update to 2025-12-12

### DIFF
--- a/ports/wavelib/portfile.cmake
+++ b/ports/wavelib/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rafat/wavelib
-    REF a92456d2e20451772dd76c2a0a3368537ee94184
-    SHA512 d14ebc0d96e86d9226fa346cb6ef157b2949985dfedf4228dd4356ccacaac48fde47edfcba31e7455b25dc95c7a1cb148ad6845143c17ae5972659c98e683865
+    REF 7f61bf592f3c470b2a7d8199431fde821d7253ac
+    SHA512 c977e0a3fb9235d2ca84e25f0f5479c4bd6d8dc5d3f7fcb0d6c259519d2273f5eff6ab43d47d2b2e325a1f736135efbf69d2dced8ec2bc16a7f51d38ed4046eb
     HEAD_REF master
     PATCHES
         disable-test.patch
@@ -20,6 +20,9 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/wavelib/vcpkg.json
+++ b/ports/wavelib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wavelib",
-  "version-date": "2021-11-26",
+  "version-date": "2025-12-12",
   "description": "C implementation of wavelet transform (DWT,SWT and MODWT)",
   "homepage": "https://github.com/rafat/wavelib",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10941,7 +10941,7 @@
       "port-version": 2
     },
     "wavelib": {
-      "baseline": "2021-11-26",
+      "baseline": "2025-12-12",
       "port-version": 0
     },
     "wavpack": {

--- a/versions/w-/wavelib.json
+++ b/versions/w-/wavelib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d8c0e7e018ca5a5a44669099ca55bee62375491",
+      "version-date": "2025-12-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8428a438c8eaf72dae62ada2a5dd3ddc58ca1ed",
       "version-date": "2021-11-26",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.