### PR TITLE
[libe57format] Update to 3.4.0

### DIFF
--- a/ports/libe57format/portfile.cmake
+++ b/ports/libe57format/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO asmaloney/libE57Format
     REF "v${VERSION}"
-    SHA512 2a224bd9ff88cdfd182267c96e4d6151a51a0ae6959c41dbe11d65e31cd1c9d5ecbf7f69c355daef6331181b454b123978036478f14cbf1cd2e51544bab16102
+    SHA512 415c003720349dc3257dee9df67a5be46ffc0ec5e6c5e935eec8e0fc5ac44add1ab11c0f8ff326d19881bc28429eee6490d03bd26558e20b85bb8bcddeb41019
     HEAD_REF master
 )
 
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
         -DE57_BUILD_TEST=OFF
         -DE57_BUILD_SHARED=${E57_BUILD_SHARED}
         -DE57_RELEASE_LTO=OFF
+        -DE57_USE_EXTERNAL_CRCPP=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=1
 )
 vcpkg_cmake_install()

--- a/ports/libe57format/vcpkg.json
+++ b/ports/libe57format/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "libe57format",
-  "version": "3.3.0",
-  "port-version": 1,
+  "version": "3.4.0",
   "description": "A library to provide read & write support for the E57 file format.",
   "homepage": "https://github.com/asmaloney/libE57Format",
   "license": "BSL-1.0",
   "dependencies": [
+    "crcpp",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4997,8 +4997,8 @@
       "port-version": 0
     },
     "libe57format": {
-      "baseline": "3.3.0",
-      "port-version": 1
+      "baseline": "3.4.0",
+      "port-version": 0
     },
     "libebur128": {
       "baseline": "1.2.6",

--- a/versions/l-/libe57format.json
+++ b/versions/l-/libe57format.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8937067dc5d533dd2db2a2d73ef32c823c41e84",
+      "version": "3.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d70380f61673c26328c29757d9782cff3fd15313",
       "version": "3.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

// Edit: `E57_USE_EXTERNAL_CRCPP` contains a bug, as the `crcpp_INCLUDE_PATH` isn't added to the target. As the CI is fine, not sure whether we need to fix it or not