### PR TITLE
[engitsdatalib] New port

### DIFF
--- a/ports/engitsdatalib/portfile.cmake
+++ b/ports/engitsdatalib/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v1.0.0
     SHA512 7dc9c240b45bb3a768ea910c1a29c5aa885debd636b2aff49211ee1f4cef6ce2bc4803775e8afe5fc16c4ae8276cbcd3a0a56325da1930a395db57b1fa37dccf
     HEAD_REF master
+    PATCHES
+        use-system-doctest.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" EDL_BUILD_STATIC)
@@ -27,8 +29,4 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
-vcpkg_install_copyright(
-    FILE_LIST
-        "${SOURCE_PATH}/LICENSE"
-        "${SOURCE_PATH}/LICENSES/doctest.txt"
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/engitsdatalib/portfile.cmake
+++ b/ports/engitsdatalib/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO enGits/enGitsDataLib
+    REF v1.0.0
+    SHA512 7dc9c240b45bb3a768ea910c1a29c5aa885debd636b2aff49211ee1f4cef6ce2bc4803775e8afe5fc16c4ae8276cbcd3a0a56325da1930a395db57b1fa37dccf
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" EDL_BUILD_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DCREATE_STATIC_LIBRARY=${EDL_BUILD_STATIC}"
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME enGitsDataLib
+    CONFIG_PATH lib/cmake/enGitsDataLib
+)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/LICENSES/doctest.txt"
+)

--- a/ports/engitsdatalib/use-system-doctest.patch
+++ b/ports/engitsdatalib/use-system-doctest.patch
@@ -1,0 +1,107 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e825e7b..86244d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,6 +17,8 @@ include(CMakePackageConfigHelpers)
+ include(CTest)
+ include(TestBigEndian)
+ 
++find_package(doctest CONFIG REQUIRED)
++
+ # export build setup for development environment
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 
+@@ -66,7 +68,6 @@ edl/amr.h
+ edl/bmap.h
+ edl/containertricks.h
+ edl/csvreader.h
+-edl/doctest.h
+ edl/edlerror.h
+ edl/edl.h
+ edl/fastremovelist.h
+@@ -137,6 +138,7 @@ else(CREATE_STATIC_LIBRARY)
+ endif(CREATE_STATIC_LIBRARY)
+ 
+ target_compile_features(engitsdatalib PUBLIC cxx_std_17)
++target_link_libraries(engitsdatalib PUBLIC doctest::doctest)
+ 
+ target_compile_definitions(engitsdatalib
+   PUBLIC
+diff --git a/cmake/enGitsDataLibConfig.cmake.in b/cmake/enGitsDataLibConfig.cmake.in
+index dbb9be4..ee92d55 100644
+--- a/cmake/enGitsDataLibConfig.cmake.in
++++ b/cmake/enGitsDataLibConfig.cmake.in
+@@ -1,5 +1,8 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(doctest CONFIG)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/enGitsDataLibTargets.cmake")
+ 
+ if(TARGET enGitsDataLib::engitsdatalib)
+diff --git a/edl/edl.cpp b/edl/edl.cpp
+index d76d74c..22d530e 100644
+--- a/edl/edl.cpp
++++ b/edl/edl.cpp
+@@ -10,7 +10,7 @@
+ 
+ #include "edl/edl.h"
+ #define DOCTEST_CONFIG_IMPLEMENT
+-#include "edl/doctest.h"
++#include <doctest/doctest.h>
+ 
+ namespace EDL_NAMESPACE
+ {
+diff --git a/edl/edl.h b/edl/edl.h
+index 0dd2389..6618128 100644
+--- a/edl/edl.h
++++ b/edl/edl.h
+@@ -32,7 +32,7 @@ template <class T, unsigned int DIM> class StaticVector;
+ #include <map>
+ #include <string>
+ 
+-#include "edl/doctest.h"
++#include <doctest/doctest.h>
+ 
+ #if defined(_WIN32) && defined(_MSC_VER)
+ #include "engitsdatalib_export.h"
+diff --git a/edl/tools.h b/edl/tools.h
+index 7aa4f3e..8c6881e 100644
+--- a/edl/tools.h
++++ b/edl/tools.h
+@@ -18,7 +18,7 @@
+ #include <cstddef>
+ #include <vector>
+ 
+-#include "doctest.h"
++#include <doctest/doctest.h>
+ 
+ namespace EDL_NAMESPACE
+ {
+diff --git a/tests/doctest_test.cpp b/tests/doctest_test.cpp
+index 9b68586..769609d 100644
+--- a/tests/doctest_test.cpp
++++ b/tests/doctest_test.cpp
+@@ -8,7 +8,7 @@
+ // +                                                                    +
+ // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 
+-#include "edl/doctest.h"
++#include <doctest/doctest.h>
+ 
+ #define EDL_DOCTEST
+ 
+diff --git a/tests/geometrytools_test.cpp b/tests/geometrytools_test.cpp
+index 6ad116c..ec37db0 100644
+--- a/tests/geometrytools_test.cpp
++++ b/tests/geometrytools_test.cpp
+@@ -9,7 +9,7 @@
+ // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 
+ #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+-#include "edl/doctest.h"
++#include <doctest/doctest.h>
+ 
+ #include "edl/geometrytools.h"
+ 

--- a/ports/engitsdatalib/vcpkg.json
+++ b/ports/engitsdatalib/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "engitsdatalib",
+  "version": "1.0.0",
+  "description": "C++ data structures, geometry, interpolation, and numerical utilities from enGits",
+  "homepage": "https://github.com/enGits/enGitsDataLib",
+  "license": "MIT",
+  "supports": "windows | linux | osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/engitsdatalib/vcpkg.json
+++ b/ports/engitsdatalib/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "C++ data structures, geometry, interpolation, and numerical utilities from enGits",
   "homepage": "https://github.com/enGits/enGitsDataLib",
   "license": "MIT",
-  "supports": "windows | linux | osx",
   "dependencies": [
     "doctest",
     {

--- a/ports/engitsdatalib/vcpkg.json
+++ b/ports/engitsdatalib/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "supports": "windows | linux | osx",
   "dependencies": [
+    "doctest",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2852,6 +2852,10 @@
       "baseline": "1.3.18",
       "port-version": 0
     },
+    "engitsdatalib": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "enkits": {
       "baseline": "1.12",
       "port-version": 0

--- a/versions/e-/engitsdatalib.json
+++ b/versions/e-/engitsdatalib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f28c6487ff1ed7eb69edb303a849d61b6c1d5190",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/engitsdatalib.json
+++ b/versions/e-/engitsdatalib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f28c6487ff1ed7eb69edb303a849d61b6c1d5190",
+      "git-tree": "d6f3dc3f3a2a175dda9b5f8a2b3a040baee5ec08",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/e-/engitsdatalib.json
+++ b/versions/e-/engitsdatalib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d6f3dc3f3a2a175dda9b5f8a2b3a040baee5ec08",
+      "git-tree": "0e3d9a583acbc20568ee93b43d28161e470f3755",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
Adds enGitsDataLib 1.0.0 as a new port.

Validation:
- Built and passed vcpkg post-build validation for x64-windows shared and static triplets with Visual Studio 18 2026.
- The upstream release passed its Windows Debug/Release test suite and external find_package consumer validation.
- The upstream release was also tested successfully on Linux.

New port checklist:
- [x] Changes comply with the maintainer guide.
- [x] The packaged project is mature and ready for broad sharing; it has demonstrated public development since 2014.
- [x] The port name is the exact case-normalized name of the authoritative enGits/enGitsDataLib GitHub project.
- [x] Optional build dependencies are controlled; EDL has no optional external build dependencies.
- [x] The versioning scheme matches upstream.
- [x] The MIT license declaration matches upstream.
- [x] Installed copyright files match upstream.
- [x] Source comes from the authoritative enGits repository and immutable v1.0.0 tag.
- [x] Automatically generated CMake usage is accurate.
- [x] Registry metadata was generated and rechecked with x-add-version.
- [x] Exactly one version was added.