### PR TITLE
[nanobind] update to 3.0.0

### DIFF
--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind
     REF "v${VERSION}"
-    SHA512 376c4e86cec0e97fe9d6d844fe4e79c1cbfdd2d6355d68ee5b8acff4329983044ea0f22d0948f731ee82009afa7bba837f4f849967c831bad9ea322ffb52fc00
+    SHA512 fd07f611e34a40c39c0ef8b860d7001551c8f2caf6b938d9e52d7439fd41f18cdd5ebaa7f8c2499a9238edc51ea8113583bbb4ac0a463b608f07b745ac5d33f8
     HEAD_REF master
 )
 

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobind",
-  "version-semver": "2.15.0",
+  "version-semver": "3.0.0",
   "description": "Tiny and efficient C++/Python bindings",
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6969,7 +6969,7 @@
       "port-version": 0
     },
     "nanobind": {
-      "baseline": "2.15.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "nanodbc": {

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94f9b2f65ec1b76d6f0db49e362201d747f73564",
+      "version-semver": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "23a5a495e46ca4a7f6bd567f74f4201f3454bff5",
       "version-semver": "2.15.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.