### PR TITLE
[blake3] Update to 1.8.7

### DIFF
--- a/ports/blake3/portfile.cmake
+++ b/ports/blake3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BLAKE3-team/BLAKE3
     REF "${VERSION}"
-    SHA512 8e0e9e23576fdc1f2a4d6da8943418621ff48c44c226b8b84efa368b79cace197d247fe334ec0d76fbaa821a75eb076ffaafe1a6675ce961039e9733c0838687
+    SHA512 02374ce3c4fe11cabaf16ba1fb711058411818778dceccd7723b765aaf5436d2ec1419c28ebce6b3085ff96384f80ddccbca10d992bdc997f4e7429320c310de
     HEAD_REF main
     PATCHES
         fix-windows-arm-build-error.patch

--- a/ports/blake3/vcpkg.json
+++ b/ports/blake3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blake3",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "BLAKE3 cryptographic hash function.",
   "homepage": "https://github.com/BLAKE3-team/BLAKE3",
   "license": "CC0-1.0 OR Apache-2.0",

--- a/versions/b-/blake3.json
+++ b/versions/b-/blake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6590d37b256ca15fab508c2723fb11adf7bf97db",
+      "version": "1.8.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa113d353ea9da8af087437c1ce4b4ff48ba1c66",
       "version": "1.8.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -757,7 +757,7 @@
       "port-version": 0
     },
     "blake3": {
-      "baseline": "1.8.6",
+      "baseline": "1.8.7",
       "port-version": 0
     },
     "blas": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Closes: #53505

[BLAKE3](https://github.com/BLAKE3-team/BLAKE3) Update to [1.8.7](https://github.com/BLAKE3-team/BLAKE3/releases/tag/1.8.7)

