### PR TITLE
[mpir] support for VS 2026

### DIFF
--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -32,7 +32,7 @@ if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
     vcpkg_make_install()
 else()
     set(MSVC_VERSION 14)
-    if(VCPKG_PLATFORM_TOOLSET MATCHES "v14(1|2|3)")
+    if(VCPKG_PLATFORM_TOOLSET MATCHES "v14[0-9]")
         set(MSVC_VERSION 15)
     endif()
 

--- a/ports/mpir/vcpkg.json
+++ b/ports/mpir/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpir",
   "version": "3.0.0",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Multiple Precision Integers and Rationals",
   "homepage": "https://github.com/wbhart/mpir",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6814,7 +6814,7 @@
     },
     "mpir": {
       "baseline": "3.0.0",
-      "port-version": 12
+      "port-version": 13
     },
     "mpmcqueue": {
       "baseline": "2021-12-01",

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7ffa164a6366b51760b49e1bb4b831903be0637",
+      "version": "3.0.0",
+      "port-version": 13
+    },
+    {
       "git-tree": "71d08b7432c6eb9631acbddb9debf3c1a0ec9be4",
       "version": "3.0.0",
       "port-version": 12


### PR DESCRIPTION
Support VS 2026

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

