### PR TITLE
[geos] Backport MSVC segfault fix

### DIFF
--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(PR1453
+    URLS "https://github.com/libgeos/geos/commit/4226b5a034d249e64385d3dac7e69774ff30d6f3.patch?full_index=1"
+    FILENAME "geos-pr-1453.patch"
+    SHA512 31a24f6feff44af2cb4b923845e4496ca77d78dbe18a170c4deaae8973581c5e8c5430e033b63c2cda3ee8926d1e31007625fbace22b87fd5cde3bd43bd3caaf
+)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.osgeo.org/geos/geos-${VERSION}.tar.bz2"
     FILENAME "geos-${VERSION}.tar.bz2"
@@ -8,6 +14,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     SOURCE_BASE "v${VERSION}"
     PATCHES
         fix-exported-config.patch
+        "${PR1453}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "geos",
   "version": "3.14.1",
+  "port-version": 1,
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3386,7 +3386,7 @@
     },
     "geos": {
       "baseline": "3.14.1",
-      "port-version": 0
+      "port-version": 1
     },
     "geotrans": {
       "baseline": "3.10",

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8307773c80c9a161550351a4b1ecb7278f8b4bf",
+      "version": "3.14.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d2882448391784c2bcc1c90c98aba75c8b0a76f7",
       "version": "3.14.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
