### PR TITLE
[libgta] Update to 1.2.1

### DIFF
--- a/ports/libgta/portfile.cmake
+++ b/ports/libgta/portfile.cmake
@@ -1,35 +1,32 @@
-set(LIBGTA_VERSION 1.0.8)
-set(LIBGTA_HASH 99ec3d6317c9a12cf440a60bb989cc7a3fe35e0a1da3e65206e5cd52b69fb860850e61ea0f819511ef48ddc87c468c0ded710409990627096738886e1b358423)
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://download.savannah.nongnu.org/releases/gta/libgta-1.0.8.tar.xz"
-    FILENAME "libgta-${LIBGTA_VERSION}.tar.xz"
-    SHA512 ${LIBGTA_HASH})
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
-    SOURCE_BASE "${LIBGTA_VERSION}"
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO marlam/gta
+	REF "libgta-${VERSION}"
+	SHA512 e64a1e2a64538ae16a5ac1f1bdf43932e14d9db95a88e358d9ce6182b03ec423b5205888e0a0ac15f9ab07957c67245151ebe8e2e13800047fc48a44c2f5fde7
+	HEAD_REF master
+    PATCHES
+        version.patch
 )
+string(APPEND SOURCE_PATH "/libgta")
+
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIBS)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static"  ENABLE_STATIC_LIBS)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DGTA_BUILD_SHARED_LIB=${ENABLE_SHARED_LIBS}
-            -DGTA_BUILD_STATIC_LIB=${ENABLE_STATIC_LIBS}
-            -DGTA_BUILD_DOCUMENTATION=OFF
+    OPTIONS
+        -DGTA_BUILD_SHARED_LIB=${ENABLE_SHARED_LIBS}
+        -DGTA_BUILD_STATIC_LIB=${ENABLE_STATIC_LIBS}
+        -DGTA_BUILD_DOCUMENTATION=OFF
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/GTA-${VERSION}" PACKAGE_NAME "GTA")
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
-endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/libgta/vcpkg.json
+++ b/ports/libgta/vcpkg.json
@@ -1,16 +1,16 @@
 {
   "name": "libgta",
-  "version": "1.0.8",
-  "port-version": 5,
+  "version": "1.2.1",
   "description": "Libgta is a portable library that implements the Generic Tagged Array (GTA) file format.",
   "homepage": "https://download.savannah.nongnu.org/releases/gta",
   "dependencies": [
-    "bzip2",
-    "liblzma",
     {
       "name": "vcpkg-cmake",
       "host": true
     },
-    "zlib"
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/libgta/version.patch
+++ b/ports/libgta/version.patch
@@ -1,0 +1,15 @@
+diff --git a/libgta/CMakeLists.txt b/libgta/CMakeLists.txt
+index 7f587d2..0431d53 100644
+--- a/libgta/CMakeLists.txt
++++ b/libgta/CMakeLists.txt
+@@ -18,8 +18,8 @@ option(GTA_BUILD_DOCUMENTATION "Build API reference documentation (requires Doxy
+ # libgta version
+ set(GTA_VERSION_MAJOR "1")
+ set(GTA_VERSION_MINOR "2")
+-set(GTA_VERSION_PATCH "0")
+-set(GTA_VERSION 1.2.0)
++set(GTA_VERSION_PATCH "1")
++set(GTA_VERSION 1.2.1)
+ set(GTA_VERSION_NUMBER 0x010200)
+ set(GTA_LIB_VERSION "1.0.0")
+ set(GTA_LIB_SOVERSION "1")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5137,8 +5137,8 @@
       "port-version": 0
     },
     "libgta": {
-      "baseline": "1.0.8",
-      "port-version": 5
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "libguarded": {
       "baseline": "2.0.1",

--- a/versions/l-/libgta.json
+++ b/versions/l-/libgta.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae967e42321a0f1cc9945c57cad57d485bed407d",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad7c16c2d14fa0d5a68a29c2a1cf3708897578ca",
       "version": "1.0.8",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Came across this port today, as an other dependency required it and the download server didn't wanted to work as expected. New versions are also not present anymore on this server, so switch to vcpkg (even on the website are prepared archives available)