### PR TITLE
[pagmo2] Add ipopt feature

### DIFF
--- a/ports/pagmo2/0006-config-find-libipopt.patch
+++ b/ports/pagmo2/0006-config-find-libipopt.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 610f968..d4a0854 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -460,7 +460,7 @@ if(PAGMO_WITH_NLOPT)
+     set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(NLopt 2.6 REQUIRED NO_MODULE)\n")
+ endif()
+ if(PAGMO_WITH_IPOPT)
+-    set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(pagmo_IPOPT REQUIRED COMPONENTS header)\n")
++    set(_PAGMO_CONFIG_OPTIONAL_DEPS "${_PAGMO_CONFIG_OPTIONAL_DEPS}find_package(pagmo_IPOPT REQUIRED COMPONENTS header libipopt)\n")
+ endif()
+ 
+ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pagmo-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/pagmo-config.cmake" @ONLY)

--- a/ports/pagmo2/0007-ipopt-transitive-deps.patch
+++ b/ports/pagmo2/0007-ipopt-transitive-deps.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake_modules/Findpagmo_IPOPT.cmake b/cmake_modules/Findpagmo_IPOPT.cmake
+index 626c33a..46136bd 100644
+--- a/cmake_modules/Findpagmo_IPOPT.cmake
++++ b/cmake_modules/Findpagmo_IPOPT.cmake
+@@ -53,5 +53,8 @@ if ("libipopt" IN_LIST pagmo_IPOPT_FIND_COMPONENTS)
+         message(STATUS "Path to libipopt: ${PAGMO_IPOPT_LIBRARY}")
+         add_library(pagmo::IPOPT::libipopt UNKNOWN IMPORTED)
+         set_target_properties(pagmo::IPOPT::libipopt PROPERTIES IMPORTED_LOCATION "${PAGMO_IPOPT_LIBRARY}")
++        find_package(LAPACK REQUIRED)
++        set_property(TARGET pagmo::IPOPT::libipopt APPEND PROPERTY
++            INTERFACE_LINK_LIBRARIES LAPACK::LAPACK ${CMAKE_DL_LIBS})
+     endif()
+ endif()

--- a/ports/pagmo2/0008-ipopt-header-search.patch
+++ b/ports/pagmo2/0008-ipopt-header-search.patch
@@ -1,0 +1,24 @@
+diff --git a/include/pagmo/algorithms/ipopt.hpp b/include/pagmo/algorithms/ipopt.hpp
+index 2de64f47..ff02d303 100644
+--- a/include/pagmo/algorithms/ipopt.hpp
++++ b/include/pagmo/algorithms/ipopt.hpp
+@@ -38,8 +38,19 @@ see https://www.gnu.org/licenses/. */
+ #include <tuple>
+ #include <vector>
+ 
++#if __has_include(<IpReturnCodes.hpp>) && __has_include(<IpTypes.hpp>)
+ #include <IpReturnCodes.hpp>
+ #include <IpTypes.hpp>
++#elif __has_include(<coin-or/IpReturnCodes.hpp>) && __has_include(<coin-or/IpTypes.hpp>)
++#include <coin-or/IpReturnCodes.hpp>
++#include <coin-or/IpTypes.hpp>
++#elif __has_include(<coin/IpReturnCodes.hpp>) && __has_include(<coin/IpTypes.hpp>)
++#include <coin/IpReturnCodes.hpp>
++#include <coin/IpTypes.hpp>
++#else
++#include <IpReturnCodes.hpp>
++#include <IpTypes.hpp>
++#endif
+ 
+ #include <pagmo/algorithm.hpp>
+ #include <pagmo/algorithms/not_population_based.hpp>

--- a/ports/pagmo2/0008-ipopt-header-search.patch
+++ b/ports/pagmo2/0008-ipopt-header-search.patch
@@ -1,24 +1,15 @@
 diff --git a/include/pagmo/algorithms/ipopt.hpp b/include/pagmo/algorithms/ipopt.hpp
-index 2de64f47..ff02d303 100644
+index 5fea524..d275cb0 100644
 --- a/include/pagmo/algorithms/ipopt.hpp
 +++ b/include/pagmo/algorithms/ipopt.hpp
-@@ -38,8 +38,19 @@ see https://www.gnu.org/licenses/. */
+@@ -38,8 +38,8 @@ see https://www.gnu.org/licenses/. */
  #include <tuple>
  #include <vector>
  
-+#if __has_include(<IpReturnCodes.hpp>) && __has_include(<IpTypes.hpp>)
- #include <IpReturnCodes.hpp>
- #include <IpTypes.hpp>
-+#elif __has_include(<coin-or/IpReturnCodes.hpp>) && __has_include(<coin-or/IpTypes.hpp>)
+-#include <IpReturnCodes.hpp>
+-#include <IpTypes.hpp>
 +#include <coin-or/IpReturnCodes.hpp>
 +#include <coin-or/IpTypes.hpp>
-+#elif __has_include(<coin/IpReturnCodes.hpp>) && __has_include(<coin/IpTypes.hpp>)
-+#include <coin/IpReturnCodes.hpp>
-+#include <coin/IpTypes.hpp>
-+#else
-+#include <IpReturnCodes.hpp>
-+#include <IpTypes.hpp>
-+#endif
  
  #include <pagmo/algorithm.hpp>
  #include <pagmo/algorithms/not_population_based.hpp>

--- a/ports/pagmo2/portfile.cmake
+++ b/ports/pagmo2/portfile.cmake
@@ -10,8 +10,9 @@ vcpkg_from_github(
         0003-disable-werror.patch
         0004-support-eigen3-5.patch
         0005-avoid-stdext-checked-array-iterator.diff # ~= https://github.com/esa/pagmo2/commit/d4daedc9f865bf9e926946c21e62c4a4eebf353e
-        0006-config-find-libipopt.patch
-        0007-ipopt-transitive-deps.patch # coin-or-ipopt provides no cmake config
+        0006-config-find-libipopt.patch # https://github.com/esa/pagmo2/pull/636
+        0007-ipopt-transitive-deps.patch # https://github.com/esa/pagmo2/pull/636
+        0008-ipopt-header-search.patch # https://github.com/esa/pagmo2/pull/636
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/pagmo2/portfile.cmake
+++ b/ports/pagmo2/portfile.cmake
@@ -10,9 +10,9 @@ vcpkg_from_github(
         0003-disable-werror.patch
         0004-support-eigen3-5.patch
         0005-avoid-stdext-checked-array-iterator.diff # ~= https://github.com/esa/pagmo2/commit/d4daedc9f865bf9e926946c21e62c4a4eebf353e
-        0006-config-find-libipopt.patch # https://github.com/esa/pagmo2/pull/636
-        0007-ipopt-transitive-deps.patch # https://github.com/esa/pagmo2/pull/636
-        0008-ipopt-header-search.patch # https://github.com/esa/pagmo2/pull/636
+        0006-config-find-libipopt.patch
+        0007-ipopt-transitive-deps.patch # coin-or-ipopt provides no cmake config
+        0008-ipopt-header-search.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/pagmo2/portfile.cmake
+++ b/ports/pagmo2/portfile.cmake
@@ -10,10 +10,13 @@ vcpkg_from_github(
         0003-disable-werror.patch
         0004-support-eigen3-5.patch
         0005-avoid-stdext-checked-array-iterator.diff # ~= https://github.com/esa/pagmo2/commit/d4daedc9f865bf9e926946c21e62c4a4eebf353e
+        0006-config-find-libipopt.patch
+        0007-ipopt-transitive-deps.patch # coin-or-ipopt provides no cmake config
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        ipopt PAGMO_WITH_IPOPT
         nlopt PAGMO_WITH_NLOPT
 )
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PAGMO_BUILD_STATIC_LIBRARY)

--- a/ports/pagmo2/vcpkg.json
+++ b/ports/pagmo2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pagmo2",
   "version": "2.19.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A C++ platform to perform parallel computations of optimization tasks (global and local) via the asynchronous generalized island model.",
   "homepage": "https://esa.github.io/pagmo2/",
   "license": "GPL-3.0-or-later OR LGPL-3.0-or-later",
@@ -23,6 +23,12 @@
     }
   ],
   "features": {
+    "ipopt": {
+      "description": "Enable the Ipopt wrappers",
+      "dependencies": [
+        "coin-or-ipopt"
+      ]
+    },
     "nlopt": {
       "description": "Enable the NLopt wrappers",
       "dependencies": [

--- a/ports/pagmo2/vcpkg.json
+++ b/ports/pagmo2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pagmo2",
   "version": "2.19.1",
-  "port-version": 4,
+  "port-version": 3,
   "description": "A C++ platform to perform parallel computations of optimization tasks (global and local) via the asynchronous generalized island model.",
   "homepage": "https://esa.github.io/pagmo2/",
   "license": "GPL-3.0-or-later OR LGPL-3.0-or-later",

--- a/ports/pagmo2/vcpkg.json
+++ b/ports/pagmo2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pagmo2",
   "version": "2.19.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A C++ platform to perform parallel computations of optimization tasks (global and local) via the asynchronous generalized island model.",
   "homepage": "https://esa.github.io/pagmo2/",
   "license": "GPL-3.0-or-later OR LGPL-3.0-or-later",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -996,6 +996,7 @@ osg[tools]:arm64-linux=cascade
 osg-qt:arm64-linux=cascade
 osgearth:arm64-linux=cascade
 osgearth[tools]:arm64-osx=feature-fails # Undefined _NSSearchPathForDirectoriesInDomains
+pagmo2[ipopt](android | uwp)=cascade # coin-or-ipopt -> lapack (!android), coinutils (!uwp)
 pango[introspection]:arm64-windows=skip # needs arm64 host
 pangolin:arm64-linux=cascade
 pangolin[core,eigen,examples,ffmpeg,gui,jpeg,lz4,module,openexr,openni2,png,realsense,tiff,tools,vars,video,zstd]:x64-windows-static-md=combination-fails

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7686,7 +7686,7 @@
     },
     "pagmo2": {
       "baseline": "2.19.1",
-      "port-version": 2
+      "port-version": 3
     },
     "paho-mqtt": {
       "baseline": "1.3.16",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7686,7 +7686,7 @@
     },
     "pagmo2": {
       "baseline": "2.19.1",
-      "port-version": 4
+      "port-version": 3
     },
     "paho-mqtt": {
       "baseline": "1.3.16",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7686,7 +7686,7 @@
     },
     "pagmo2": {
       "baseline": "2.19.1",
-      "port-version": 3
+      "port-version": 4
     },
     "paho-mqtt": {
       "baseline": "1.3.16",

--- a/versions/p-/pagmo2.json
+++ b/versions/p-/pagmo2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b322b4125040c958cbc3edefa34630524d3c9068",
+      "version": "2.19.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "17bc4e5d8d8c28446f414b23555c22c615b3703a",
       "version": "2.19.1",
       "port-version": 2

--- a/versions/p-/pagmo2.json
+++ b/versions/p-/pagmo2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "16673835de8855254377e324021bda8d7697536d",
+      "git-tree": "8e98bd04ba6700b1afd44c2377e47008bf711723",
       "version": "2.19.1",
       "port-version": 4
     },

--- a/versions/p-/pagmo2.json
+++ b/versions/p-/pagmo2.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "8e98bd04ba6700b1afd44c2377e47008bf711723",
+      "git-tree": "5a928918bc9a30e492e9b65795cb8cb18084da7b",
       "version": "2.19.1",
-      "port-version": 4
+      "port-version": 3
     },
     {
       "git-tree": "17bc4e5d8d8c28446f414b23555c22c615b3703a",

--- a/versions/p-/pagmo2.json
+++ b/versions/p-/pagmo2.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "b322b4125040c958cbc3edefa34630524d3c9068",
+      "git-tree": "16673835de8855254377e324021bda8d7697536d",
       "version": "2.19.1",
-      "port-version": 3
+      "port-version": 4
     },
     {
       "git-tree": "17bc4e5d8d8c28446f414b23555c22c615b3703a",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
