### PR TITLE
[libxkbcommon] Update to 1.13.2

### DIFF
--- a/ports/libxkbcommon/disable-test.patch
+++ b/ports/libxkbcommon/disable-test.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 92483c54..26230102 100644
+index 2066cbc9..07602e63 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -853,6 +853,7 @@ configure_file(input: 'test/xkeyboard-config-test.py.in',
+@@ -866,6 +866,7 @@ configure_file(input: 'test/xkeyboard-config-test.py.in',
                 configuration: xkct_config)
  
  # Tests
@@ -10,7 +10,7 @@ index 92483c54..26230102 100644
  test_env = environment()
  test_env.set('XKB_LOG_LEVEL', 'debug')
  test_env.set('XKB_LOG_VERBOSITY', '10')
-@@ -1372,6 +1373,7 @@ if get_option('enable-x11')
+@@ -1387,6 +1388,7 @@ if get_option('enable-x11')
        env: bench_env,
    )
  endif
@@ -18,13 +18,12 @@ index 92483c54..26230102 100644
  
  
  # Documentation.
-@@ -1505,7 +1507,9 @@ if meson.version().version_compare('>=0.62.0')
-       'rules': get_option('default-rules'),
-       'variant': get_option('default-variant'),
-     }, section: 'Defaults')
+@@ -1519,6 +1521,8 @@ summary({
+     'rules': get_option('default-rules'),
+     'variant': get_option('default-variant'),
+ }, section: 'Defaults')
 +if false
-     summary({
-       'merge-modes': has_merge_modes_tests,
-     }, section: 'Tests')
- endif
+ summary({
+     'merge-modes': has_merge_modes_tests,
+ }, section: 'Tests')
 +endif

--- a/ports/libxkbcommon/portfile.cmake
+++ b/ports/libxkbcommon/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xkbcommon/libxkbcommon
     REF "xkbcommon-${VERSION}"
-    SHA512 450c33fe26af6b847cf7516685d0df63c2ba0126887e27595c40fe80e4d0487009aa6cdf38ff1270d595c7900cbf3c11e7aa4f9cff80fa361742b5ebb10d83bd
+    SHA512 261af9e02ad533bb6560e2711171812c7d92094db8b54eaa19b477ab68270e6d62b315e18d42527ca9c944e87f36f063d003d74aeb4829b21ecb96ab1b0c1ce7
     HEAD_REF master
     PATCHES
         disable-test.patch

--- a/ports/libxkbcommon/vcpkg.json
+++ b/ports/libxkbcommon/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxkbcommon",
-  "version": "1.13.1",
-  "port-version": 1,
+  "version": "1.13.2",
   "description": "keymap handling library for toolkits and window systems",
   "homepage": "https://xkbcommon.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6041,8 +6041,8 @@
       "port-version": 1
     },
     "libxkbcommon": {
-      "baseline": "1.13.1",
-      "port-version": 1
+      "baseline": "1.13.2",
+      "port-version": 0
     },
     "libxkbfile": {
       "baseline": "1.1.3",

--- a/versions/l-/libxkbcommon.json
+++ b/versions/l-/libxkbcommon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "347cc471a785b8cfe6f1b8629dfe66a85c53590c",
+      "version": "1.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d93863d6cc55eddaaf8b2099b2ef0a1e8ae0ab7",
       "version": "1.13.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.