### PR TITLE
[rtabmap-res-tool] Update to 0.23.8

### DIFF
--- a/ports/rtabmap-res-tool/portfile.cmake
+++ b/ports/rtabmap-res-tool/portfile.cmake
@@ -6,8 +6,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO introlab/rtabmap
-    REF ${VERSION}
-    SHA512 9bcd0f359e0ee8060cf7088761544a3f7d38aadb37df820958f0811aa7b8edbfaf00f00d9472a8bf46261d4e5d868f9c10785263aaabaf374b6e5aa5237d70b0
+    REF "${VERSION}"
+    SHA512 b18515a1215d76592f748c6d18c4c7cd6311739be411dfbc787d11d69729b1193265d5970816cef2b5b5dc9f4418547896d7749fd76137c0888e1dcb7de66fca
     HEAD_REF master
 )
 file(COPY "${CURRENT_PORT_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -21,9 +21,12 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/include"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
 
+# We don't use vcpkg_copy_tools here, as some platforms need rtabmap-res_tool-${UTILITE_VERSION}, aside from rtabmap-res_tool
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
 file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 

--- a/ports/rtabmap-res-tool/portfile.cmake
+++ b/ports/rtabmap-res-tool/portfile.cmake
@@ -30,4 +30,8 @@ file(REMOVE_RECURSE
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
 file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/utilite/resource_generator/main.cpp"
+)

--- a/ports/rtabmap-res-tool/vcpkg.json
+++ b/ports/rtabmap-res-tool/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.23.8",
   "description": "Real-Time Appearance-Based Mapping, resource generator",
   "homepage": "https://introlab.github.io/rtabmap/",
-  "license": "BSD-3-Clause",
+  "license": "BSD-3-Clause AND LGPL-3.0-or-later",
   "supports": "native",
   "dependencies": [
     {

--- a/ports/rtabmap-res-tool/vcpkg.json
+++ b/ports/rtabmap-res-tool/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rtabmap-res-tool",
-  "version": "0.23.2",
+  "version": "0.23.8",
   "description": "Real-Time Appearance-Based Mapping, resource generator",
   "homepage": "https://introlab.github.io/rtabmap/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9013,7 +9013,7 @@
       "port-version": 0
     },
     "rtabmap-res-tool": {
-      "baseline": "0.23.2",
+      "baseline": "0.23.8",
       "port-version": 0
     },
     "rtaudio": {

--- a/versions/r-/rtabmap-res-tool.json
+++ b/versions/r-/rtabmap-res-tool.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "afda6b7c7968424dccadcbeeee448947280ad58c",
+      "git-tree": "0be839430c53891d22475bb8dacb887c73262a29",
       "version": "0.23.8",
       "port-version": 0
     },

--- a/versions/r-/rtabmap-res-tool.json
+++ b/versions/r-/rtabmap-res-tool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afda6b7c7968424dccadcbeeee448947280ad58c",
+      "version": "0.23.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8e610eae2d8c418506f21d191f687f28d1ec5c1",
       "version": "0.23.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The tool has it's own version number (`UTILITE_VERSION` => `0.3.0`). As this was either overlooked in #37651 or a conscious decision was made to use the main project's version number, and since we can't go back in version number anyway, I'm not changing anything here (comment added to preempt any potential AI comments regarding this😅 ).
