### PR TITLE
[mas-bandwidth-serialize] update to 1.15.0

### DIFF
--- a/ports/mas-bandwidth-serialize/portfile.cmake
+++ b/ports/mas-bandwidth-serialize/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mas-bandwidth/serialize
     REF "v${VERSION}"
-    SHA512 16342bd5114c3a4bfde6479d897b49aeaccba2a3f18f3738c64e52a58957eeae29e100362e36e1d852666d72ee437513e6ea5bf7196e9d9db1e06f0fc94684bf
+    SHA512 10ee9e79eb7bd0bbb9c7f43e5ba1a0e392143f05ee716518014d8df2bd08d59babf98f6ddb381efcee8d300f097f7ac53ddddc0975502e4efb143fc5362482b1
     HEAD_REF main
 )
 

--- a/ports/mas-bandwidth-serialize/vcpkg.json
+++ b/ports/mas-bandwidth-serialize/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mas-bandwidth-serialize",
-  "version": "1.9.0",
+  "version": "1.15.0",
   "description": "A simple bitpacking serializer for C++.",
   "homepage": "https://github.com/mas-bandwidth/serialize",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6477,7 +6477,7 @@
       "port-version": 0
     },
     "mas-bandwidth-serialize": {
-      "baseline": "1.9.0",
+      "baseline": "1.15.0",
       "port-version": 0
     },
     "mas-bandwidth-yojimbo": {

--- a/versions/m-/mas-bandwidth-serialize.json
+++ b/versions/m-/mas-bandwidth-serialize.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4b7c987ec082d2922c12069c5ae204187688822",
+      "version": "1.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "13776615a4906d7e99774986c2e5a9354dbceb61",
       "version": "1.9.0",
       "port-version": 0


### PR DESCRIPTION
Updates mas-bandwidth-serialize to v1.15.0. Upstream release: https://github.com/mas-bandwidth/serialize/releases/tag/v1.15.0 - wire-bit determinism release (compressed_float now produces identical wire bits across fp-contract modes and architectures); no API break. Maintainer: glenn@mas-bandwidth.com.