### PR TITLE
[lwip] Add new port

### DIFF
--- a/ports/lwip/disable-filelist-side-effects.patch
+++ b/ports/lwip/disable-filelist-side-effects.patch
@@ -1,0 +1,35 @@
+diff --git a/src/Filelists.cmake b/src/Filelists.cmake
+index 228e0f0..c0904d8 100644
+--- a/src/Filelists.cmake
++++ b/src/Filelists.cmake
+@@ -252,30 +252,6 @@ set(lwipallapps_SRCS
+     ${lwipmqtt_SRCS}
+ )
+ 
+-# Generate lwip/init.h (version info)
+-configure_file(${LWIP_DIR}/src/include/lwip/init.h.cmake.in ${LWIP_DIR}/src/include/lwip/init.h)
+-
+-# Documentation
+-set(DOXYGEN_DIR ${LWIP_DIR}/doc/doxygen)
+-set(DOXYGEN_OUTPUT_DIR output)
+-set(DOXYGEN_IN  ${LWIP_DIR}/doc/doxygen/lwip.Doxyfile.cmake.in)
+-set(DOXYGEN_OUT ${LWIP_DIR}/doc/doxygen/lwip.Doxyfile)
+-configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT})
+-
+-find_package(Doxygen)
+-if (DOXYGEN_FOUND)
+-    message(STATUS "Doxygen build started")
+-
+-    add_custom_target(lwipdocs
+-        COMMAND ${CMAKE_COMMAND} -E remove_directory ${DOXYGEN_DIR}/${DOXYGEN_OUTPUT_DIR}/html
+-        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+-        WORKING_DIRECTORY ${DOXYGEN_DIR}
+-        COMMENT "Generating API documentation with Doxygen"
+-        VERBATIM)
+-else (DOXYGEN_FOUND)
+-    message(STATUS "Doxygen needs to be installed to generate the doxygen documentation")
+-endif (DOXYGEN_FOUND)
+-
+ # lwIP libraries
+ add_library(lwipcore EXCLUDE_FROM_ALL ${lwipnoapps_SRCS})
+ target_compile_options(lwipcore PRIVATE ${LWIP_COMPILER_FLAGS})

--- a/ports/lwip/portfile.cmake
+++ b/ports/lwip/portfile.cmake
@@ -1,0 +1,40 @@
+string(REPLACE "." "_" LWIP_VERSION_UNDERSCORE "${VERSION}")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lwip-tcpip/lwip
+    REF "STABLE-${LWIP_VERSION_UNDERSCORE}_RELEASE"
+    SHA512 50da620efa071b8ed0180941d0873e4cc6784d03b028ed08a717a0d3dc7212fc843686a2fe5b19275f95d770927913b401a52ef40c94eec545f78906216123df
+    HEAD_REF master
+    PATCHES
+        disable-filelist-side-effects.patch
+)
+
+# lwIP is configured by the consuming application through lwipopts.h and a
+# platform-specific port. Consequently, its sources must be compiled as part
+# of the application instead of as a preconfigured library in this port.
+file(
+    INSTALL
+        "${SOURCE_PATH}/src"
+        "${SOURCE_PATH}/contrib"
+        "${SOURCE_PATH}/BUILDING"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+# Install a conventional copy of the public headers as well. The copy under
+# share/lwip is retained because the upstream Filelists.cmake expects the
+# original source-tree layout.
+file(
+    INSTALL "${SOURCE_PATH}/src/include/"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+    FILES_MATCHING PATTERN "*.h"
+)
+
+file(
+    INSTALL
+        "${CMAKE_CURRENT_LIST_DIR}/unofficial-lwip-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-lwip"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/lwip/unofficial-lwip-config.cmake
+++ b/ports/lwip/unofficial-lwip-config.cmake
@@ -1,0 +1,29 @@
+if(NOT DEFINED LWIP_INCLUDE_DIRS)
+    message(FATAL_ERROR
+        "Set LWIP_INCLUDE_DIRS to the directories containing lwipopts.h and "
+        "the platform port headers before calling find_package(unofficial-lwip)."
+    )
+endif()
+
+get_filename_component(LWIP_DIR "${CMAKE_CURRENT_LIST_DIR}/../lwip" ABSOLUTE)
+set(LWIP_CONTRIB_DIR "${LWIP_DIR}/contrib")
+get_filename_component(_LWIP_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+list(PREPEND LWIP_INCLUDE_DIRS "${_LWIP_PREFIX}/include")
+unset(_LWIP_PREFIX)
+
+include("${LWIP_DIR}/src/Filelists.cmake")
+
+# The upstream targets use private include directories because their examples
+# add the same directories directly to each application. Expose them publicly
+# for conventional find_package()/target_link_libraries() consumption.
+target_include_directories(lwipcore PUBLIC ${LWIP_INCLUDE_DIRS})
+target_include_directories(lwipallapps PUBLIC ${LWIP_INCLUDE_DIRS})
+target_link_libraries(lwipallapps PUBLIC lwipcore)
+
+if(NOT TARGET unofficial::lwip::core)
+    add_library(unofficial::lwip::core ALIAS lwipcore)
+endif()
+
+if(NOT TARGET unofficial::lwip::apps)
+    add_library(unofficial::lwip::apps ALIAS lwipallapps)
+endif()

--- a/ports/lwip/usage
+++ b/ports/lwip/usage
@@ -1,0 +1,22 @@
+lwIP must be configured for the target platform by the consuming application.
+Set LWIP_INCLUDE_DIRS to directories containing your lwipopts.h and platform
+port headers before finding the package:
+
+    set(LWIP_INCLUDE_DIRS
+        "${CMAKE_CURRENT_SOURCE_DIR}/config"
+        "${CMAKE_CURRENT_SOURCE_DIR}/port/include"
+    )
+    find_package(unofficial-lwip CONFIG REQUIRED)
+
+    target_sources(main PRIVATE
+        # For example: the platform's sys_arch.c implementation.
+        "${CMAKE_CURRENT_SOURCE_DIR}/port/sys_arch.c"
+    )
+    target_link_libraries(main PRIVATE unofficial::lwip::core)
+
+Link to unofficial::lwip::apps instead when the built-in application
+implementations are needed; it also links to unofficial::lwip::core.
+
+The package also provides LWIP_DIR and the upstream source lists. Optional
+contrib libraries and the supplied Unix/Windows ports can be included from
+${LWIP_DIR}/contrib; see ${LWIP_DIR}/BUILDING for upstream integration details.

--- a/ports/lwip/vcpkg.json
+++ b/ports/lwip/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "lwip",
+  "version": "2.2.1",
+  "description": "lwIP is a small independent implementation of the TCP/IP protocol suite.",
+  "homepage": "https://github.com/lwip-tcpip/lwip",
+  "license": "BSD-3-Clause"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6344,6 +6344,10 @@
       "baseline": "1.18.10",
       "port-version": 1
     },
+    "lwip": {
+      "baseline": "2.2.1",
+      "port-version": 0
+    },
     "lwlog": {
       "baseline": "1.5.0",
       "port-version": 0

--- a/versions/l-/lwip.json
+++ b/versions/l-/lwip.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8fefbeddafaf1bff2dba3b81493d177223d06aaa",
+      "version": "2.2.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add [lwIP](https://github.com/lwip-tcpip/lwip) [2.2.1](https://github.com/lwip-tcpip/lwip/releases/tag/STABLE-2_2_1_RELEASE) as a new source port.

[lwIP](https://github.com/lwip-tcpip/lwip) is configured by each consuming application through `lwipopts.h` and platform-specific port headers and implementations. Therefore, this port installs the upstream core and contrib sources instead of producing a preconfigured binary library. It also:

- installs the public headers under the conventional `include` directory;
- provides the `unofficial::lwip::core` and `unofficial::lwip::apps` CMake targets;
- requires consumers to set `LWIP_INCLUDE_DIRS` before `find_package(unofficial-lwip CONFIG REQUIRED)` so their configuration and platform port headers are used; and
- includes usage guidance for supplying platform-specific sources such as `sys_arch.c`.

The patch removes configure-time side effects from upstream's `src/Filelists.cmake`: regeneration of `lwip/init.h` in the installed source tree and optional Doxygen discovery/documentation target creation. It does not change lwIP's runtime behavior.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/lwip/versions
    - [ ] The project is amongst the first web search results for "lwip" or "lwip C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the `GitHubOrg-GitHubRepo` form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
