### PR TITLE
[json-c] pull in memory leak fix (fixed in json-c/json-c#936)

### DIFF
--- a/ports/json-c/json_object_put-leak.patch
+++ b/ports/json-c/json_object_put-leak.patch
@@ -1,0 +1,30 @@
+diff --git a/json_object.c b/json_object.c
+index 0a61967..71cd25b 100644
+--- a/json_object.c
++++ b/json_object.c
+@@ -303,6 +303,7 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
+ 
+ 	if (jso->_user_delete)
+ 		jso->_user_delete(jso, jso->_userdata);
++	jso->_user_delete = NULL;
+ 
+ 	switch (jso->o_type)
+ 	{
+@@ -435,11 +436,16 @@ int json_object_put(struct json_object *jso)
+ 		// All slots are cleared, now pop back up to the parent
+ 		{
+ 			json_object *parent = jso->_delete_parent;
++			int rc;
+ 			// jso is a child that's already been detached from its parent
+ 			// so we need to actually free it now
+ 			assert(jso->_ref_count == 0);
+ 			jso->_ref_count++;   // We're the exclusive owner of jso, non-atomic add is ok.
+-			assert(_json_object_put_maybe_free(jso, 1) == 0);
++			// Note: the call must not be inside assert(), or it gets
++			// compiled out when NDEBUG is defined and the memory leaks.
++			rc = _json_object_put_maybe_free(jso, 1);
++			assert(rc == 0);
++			(void)rc;
+ 			jso = parent;
+ 			// iteration will be reset at the top of the loop
+ 		}

--- a/ports/json-c/portfile.cmake
+++ b/ports/json-c/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_github(
 
     SHA512 3be9058351acb3d9a66c7ae850391ebaa80472b42ee3f013f8b655743eb41b55513e0546c6798399af98ed049b80d11c93286ea3f5af26dc5f199905a28c4db1
     HEAD_REF master
+    PATCHES
+        json_object_put-leak.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" JSON_BUILD_STATIC)

--- a/ports/json-c/vcpkg.json
+++ b/ports/json-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "json-c",
   "version": "0.19-20260627",
+  "port-version": 1,
   "description": "A JSON implementation in C",
   "homepage": "https://github.com/json-c/json-c",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4206,7 +4206,7 @@
     },
     "json-c": {
       "baseline": "0.19-20260627",
-      "port-version": 0
+      "port-version": 1
     },
     "json-dto": {
       "baseline": "0.3.4",

--- a/versions/j-/json-c.json
+++ b/versions/j-/json-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25deea1a1a70dd1ede2798be21060e5dddd08347",
+      "version": "0.19-20260627",
+      "port-version": 1
+    },
+    {
       "git-tree": "68b65400a836e7b30a59787525ec31c5bc5ac39b",
       "version": "0.19-20260627",
       "port-version": 0


### PR DESCRIPTION
pulls in the fix from json-c/json-c#936

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
