### PR TITLE
[cimg] update to 4.0.4

### DIFF
--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO GreycLab/CImg
     # Using commit id becuase upstream likes to change tags
-    REF ed8d53c7f2469c8b8e23c11cb880f42f6cb74ab9
-    SHA512 10a44ad2d8a1a93bcd38501be9cfad3840675653abfefb2c539c098653179e77cdd34aa323ae28958522dfaddee376c5cf04d6871cc600398738b98a272f320c
+    REF cfe2bf3d022b0bb0bc6944dcad6e606286084423
+    SHA512 9fcad36f6adebabcf69f453c196a60e8a61a3cacc0362d7dce4ecfe9f27d2e30dc032944c048121d4e32dd785947fb5c669a21025b6fef8b7f2230791bb831c1
     HEAD_REF master
 )
 

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cimg",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
   "homepage": "https://github.com/GreycLab/CImg",
   "license": "(CECILL-C OR CECILL-2.1) AND LicenseRef-LGPL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1753,7 +1753,7 @@
       "port-version": 0
     },
     "cimg": {
-      "baseline": "4.0.3",
+      "baseline": "4.0.4",
       "port-version": 0
     },
     "cinatra": {

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d254e5b38e6db8c0a501306568597a5eba0234ab",
+      "version": "4.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "64b61fab11a09156ec92842df0df00a9552e1cd3",
       "version": "4.0.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/GreycLab/CImg/releases/tag/v.4.0.4