### PR TITLE
[roaring] update to 5.1.0

### DIFF
--- a/ports/roaring/portfile.cmake
+++ b/ports/roaring/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RoaringBitmap/CRoaring
     REF "v${VERSION}"
-    SHA512 d1651d70d34fcafd62e2ffd09f0dda67e47eab3d08894b6d690b4b273d4febd720d9aefa5eb578f6fa81be948c9b3568405cd6b5539ee2af64be7a4d2a4def19
+    SHA512 908bc679460f2df0b74fe3f1386283121c4d3ee33697b1cb54f9d08bb75f5d802ee4dd44f200ca2111b6004e093d151c4d3fbc313975022b5e40aaadc462734f
     HEAD_REF master
 )
 

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "roaring",
-  "version": "4.7.2",
+  "version": "5.1.0",
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8949,7 +8949,7 @@
       "port-version": 0
     },
     "roaring": {
-      "baseline": "4.7.2",
+      "baseline": "5.1.0",
       "port-version": 0
     },
     "robin-hood-hashing": {

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7479f896d3171df72b04992ae844f1f15c1904fe",
+      "version": "5.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9640334672983aba333513e0b0e0e6a8bf099f22",
       "version": "4.7.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/RoaringBitmap/CRoaring/releases#release-v5.1.0
