### PR TITLE
[kddockwidgets] Update to 2.4.1

### DIFF
--- a/ports/kddockwidgets/portfile.cmake
+++ b/ports/kddockwidgets/portfile.cmake
@@ -15,9 +15,9 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDAB/KDDockWidgets
-    REF "v${VERSION}" 
-    SHA512 1e220c5cf608c5bb9242b530eb1e45a15dae462b126c12d253483a1213e72374baa75943d8734c5dc79e34b03b480d1a87cd59cb945996abc0ab20b5d649a5cb
-    HEAD_REF master
+    REF "v${VERSION}"
+    SHA512 578b7809e6b080be64c8b0b5e0aa1a68dca8118825cfd900a1edf1b179f30a939f8931729a529df65b56cc7a4cf1c59241ea806b87f880101bd74a40f0487f53
+    HEAD_REF main
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/src/3rdparty"
@@ -55,8 +55,10 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_install_copyright(FILE_LIST
     "${SOURCE_PATH}/LICENSE.txt"

--- a/ports/kddockwidgets/vcpkg.json
+++ b/ports/kddockwidgets/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "kddockwidgets",
-  "version": "2.4.0",
-  "port-version": 1,
+  "version": "2.4.1",
   "description": "KDAB's Dock Widget Framework for Qt",
-  "homepage": "https://www.kdab.com/development-resources/qt-tools/kddockwidgets/",
+  "homepage": "https://www.kdab.com/software-technologies/developer-tools/kddockwidgets/",
   "license": "GPL-2.0-only OR GPL-3.0-only",
   "supports": "!android & !ios",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4329,8 +4329,8 @@
       "port-version": 0
     },
     "kddockwidgets": {
-      "baseline": "2.4.0",
-      "port-version": 1
+      "baseline": "2.4.1",
+      "port-version": 0
     },
     "kdgpu": {
       "baseline": "0.10.0",

--- a/versions/k-/kddockwidgets.json
+++ b/versions/k-/kddockwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f17ca67476b53ca9d4ea1c8dbd92e54d80135e24",
+      "version": "2.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa803ca9bd420a6f6ffa59abd092011ee8ec88c5",
       "version": "2.4.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
