### PR TITLE
[boringssl] Add decrepit feature

### DIFF
--- a/ports/boringssl/0002-install-decrepit.patch
+++ b/ports/boringssl/0002-install-decrepit.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87e554c..c6fd3d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,6 +35,7 @@ include(CTest)
+ include(GNUInstallDirs)
+ 
+ set(INSTALL_ENABLED 1)
++option(BORINGSSL_INSTALL_DECREPIT "Install the decrepit library" OFF)
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT CMAKE_CROSSCOMPILING AND
+    BUILD_TESTING)
+@@ -874,6 +875,9 @@ endif()
+ 
+ if(INSTALL_ENABLED)
+   install(TARGETS crypto ssl EXPORT OpenSSLTargets)
++  if(BORINGSSL_INSTALL_DECREPIT)
++    install(TARGETS decrepit EXPORT OpenSSLTargets)
++  endif()
+   install(TARGETS bssl)
+   install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+   install(EXPORT OpenSSLTargets

--- a/ports/boringssl/portfile.cmake
+++ b/ports/boringssl/portfile.cmake
@@ -22,6 +22,12 @@ vcpkg_from_github(
   HEAD_REF master
   PATCHES
     0001-remove-WX-Werror.patch
+    0002-install-decrepit.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    decrepit BORINGSSL_INSTALL_DECREPIT
 )
 
 set(BORINGSSL_OPTIONS
@@ -41,6 +47,7 @@ vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
     ${BORINGSSL_OPTIONS}
+    ${FEATURE_OPTIONS}
   OPTIONS_DEBUG
     ${CMAKE_CONFIGURE_OPTIONS_DEBUG}
 )

--- a/ports/boringssl/usage
+++ b/ports/boringssl/usage
@@ -2,3 +2,7 @@ boringssl can be found via the built-in CMake find-module:
 
     find_package(OpenSSL REQUIRED)
     target_link_libraries(main PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+
+The decrepit feature additionally provides the legacy cryptography library:
+
+    target_link_libraries(main PRIVATE OpenSSL::decrepit)

--- a/ports/boringssl/usage
+++ b/ports/boringssl/usage
@@ -3,6 +3,8 @@ boringssl can be found via the built-in CMake find-module:
     find_package(OpenSSL REQUIRED)
     target_link_libraries(main PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
-The decrepit feature additionally provides the legacy cryptography library:
+When using the decrepit feature, use the installed CMake config package
+to access the OpenSSL::decrepit target:
 
-    target_link_libraries(main PRIVATE OpenSSL::decrepit)
+    find_package(OpenSSL CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE OpenSSL::SSL OpenSSL::Crypto OpenSSL::decrepit)

--- a/ports/boringssl/vcpkg.json
+++ b/ports/boringssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boringssl",
   "version-date": "2026-08-13",
+  "port-version": 1,
   "description": "BoringSSL is a fork of OpenSSL developed by Google",
   "homepage": "https://boringssl.googlesource.com/boringssl",
   "license": "Apache-2.0",
@@ -13,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "decrepit": {
+      "description": "Build and install BoringSSL decrepit legacy cryptography library"
+    }
+  }
 }

--- a/versions/b-/boringssl.json
+++ b/versions/b-/boringssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "413207fa353a1a2255cfa7fdb32ffdb41f8a6e04",
+      "version-date": "2026-08-13",
+      "port-version": 1
+    },
+    {
       "git-tree": "0514434abff4fe192c6b1e26a985543c3e50ab50",
       "version-date": "2026-08-13",
       "port-version": 0

--- a/versions/b-/boringssl.json
+++ b/versions/b-/boringssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "413207fa353a1a2255cfa7fdb32ffdb41f8a6e04",
+      "git-tree": "ab72145d317749f63a95af40560bcae4fed0c611",
       "version-date": "2026-08-13",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1462,7 +1462,7 @@
     },
     "boringssl": {
       "baseline": "2026-08-13",
-      "port-version": 0
+      "port-version": 1
     },
     "botan": {
       "baseline": "3.12.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

[boringssl](https://github.com/google/boringssl) add [decrepit](https://github.com/google/boringssl/tree/0.20260813.0/decrepit) feature

