### PR TITLE
[nanopb] update to 0.4.9.2

### DIFF
--- a/ports/nanopb/fix-cmakelist.patch
+++ b/ports/nanopb/fix-cmakelist.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 301501d..c7e8e42 100644
+index c7e7c19..a190b71 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -16,12 +16,6 @@ option(nanopb_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
@@ -15,17 +15,17 @@ index 301501d..c7e8e42 100644
  if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
      set(CMAKE_DEBUG_POSTFIX "d")
  endif()
-@@ -44,7 +38,6 @@ endif()
- 
- # Determine Python module installation path
- if (NOT nanopb_PYTHON_INSTDIR_OVERRIDE)
--    find_package(Python REQUIRED COMPONENTS Interpreter)
-     file(TO_CMAKE_PATH "${Python_SITELIB}" PYTHON_INSTDIR)
- else()
-     set(PYTHON_INSTDIR ${nanopb_PYTHON_INSTDIR_OVERRIDE})
-@@ -54,6 +47,10 @@ message(STATUS "Python install dir: ${PYTHON_INSTDIR}")
- # Package nanopb generator as Python module 'nanopb'
+@@ -46,7 +40,6 @@ endif()
  if(nanopb_BUILD_GENERATOR)
+     # Determine Python module installation path
+     if (NOT nanopb_PYTHON_INSTDIR_OVERRIDE)
+-        find_package(Python REQUIRED COMPONENTS Interpreter)
+         file(TO_CMAKE_PATH "${Python_SITELIB}" PYTHON_INSTDIR)
+     else()
+         set(PYTHON_INSTDIR ${nanopb_PYTHON_INSTDIR_OVERRIDE})
+@@ -54,6 +47,10 @@ if(nanopb_BUILD_GENERATOR)
+     message(STATUS "Python install dir: ${PYTHON_INSTDIR}")
+ 
      # Copy Python code files related to the generator
 +    if(NOT EXISTS ${nanopb_PROTOC_PATH})
 +        message(FATAL_ERROR "protoc compiler not found")

--- a/ports/nanopb/portfile.cmake
+++ b/ports/nanopb/portfile.cmake
@@ -4,9 +4,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanopb/nanopb
     REF ${VERSION}
-    SHA512 1580c94d558f707c88d8d2ddf4aa3bf4ef244ddc07b13e02de7124da8d156fb30a6999bb3c54ff0497abb033e498fb85ea671774f2fb817f55fa64937f537c77
+    SHA512 7829ecd42243c194e4c00dd1722288af38630fcc85b77b83c599dc3b1e14d5c4e5b62de24dff07ca724c1f5bd623ee5a31815311823eb80791da84ee8c5ab232
     HEAD_REF master
-    PATCHES 
+    PATCHES
         fix-cmakelist.patch
 )
 

--- a/ports/nanopb/vcpkg.json
+++ b/ports/nanopb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanopb",
-  "version": "0.4.9.1",
+  "version": "0.4.9.2",
   "description": "A small code-size Protocol Buffers implementation in ANSI C.",
   "homepage": "https://jpa.kapsi.fi/nanopb/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6993,7 +6993,7 @@
       "port-version": 0
     },
     "nanopb": {
-      "baseline": "0.4.9.1",
+      "baseline": "0.4.9.2",
       "port-version": 0
     },
     "nanoprintf": {

--- a/versions/n-/nanopb.json
+++ b/versions/n-/nanopb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a364a8b3641fac4384059146e3d53cf767590b71",
+      "version": "0.4.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d1b06b3cb029dac845941713af21e44f2510a7db",
       "version": "0.4.9.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/nanopb/nanopb/releases/tag/nanopb-0.4.9.2