### PR TITLE
[crow] Add option to use crow with boost-asio

### DIFF
--- a/ports/crow/portfile.cmake
+++ b/ports/crow/portfile.cmake
@@ -1,10 +1,18 @@
+set(CROW_PATCHES remove-cpm.patch)
+set(USE_BOOST_ASIO OFF)
+
+if("boost-asio" IN_LIST FEATURES)
+    set(CROW_PATCHES)
+    set(USE_BOOST_ASIO ON)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CrowCpp/crow
     REF "v${VERSION}"
     SHA512 c270425953d84c5f01d884df32b154d9b9794e3611137522e8b80d28739b3f71b3b1f3974c1b039277c87e369c99178ff301eaa141026840a9d62553d4fee078
     HEAD_REF master
-    PATCHES remove-cpm.patch
+    PATCHES ${CROW_PATCHES}
 )
 
 vcpkg_cmake_configure(
@@ -13,6 +21,7 @@ vcpkg_cmake_configure(
         -DCROW_BUILD_EXAMPLES=OFF
         -DCROW_BUILD_TESTS=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
+        -DCROW_USE_BOOST=${USE_BOOST_ASIO}
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Crow)

--- a/ports/crow/vcpkg.json
+++ b/ports/crow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "crow",
   "version": "1.3.3",
+  "port-version": 1,
   "description": "Very fast and easy to use C++ micro web framework",
   "homepage": "https://github.com/CrowCpp/crow",
   "license": "BSD-3-Clause",
@@ -14,5 +15,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "boost-asio": {
+      "description": "Use Boost.Asio instead of standalone Asio",
+      "dependencies": [
+        "boost-asio"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2230,7 +2230,7 @@
     },
     "crow": {
       "baseline": "1.3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "cryptopp": {
       "baseline": "2026-03-02",

--- a/versions/c-/crow.json
+++ b/versions/c-/crow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a48750997d376c31502da6f9532493a8982da2d4",
+      "version": "1.3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "fb6204902c08a6522b4b2cd1ce7080f2fb4b30f2",
       "version": "1.3.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes the choice between asio and boost-asio

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


