### PR TITLE
[ngtcp2] Add boringssl feature

### DIFF
--- a/ports/ngtcp2/0001-boringssl-cmake-integration.patch
+++ b/ports/ngtcp2/0001-boringssl-cmake-integration.patch
@@ -1,0 +1,89 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9f94b9c..0b4aabc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,6 +143,12 @@ endif()
+ if(ENABLE_OPENSSL OR ENABLE_PICOTLS)
+   find_package(OpenSSL 1.1.1 REQUIRED)
+ endif()
++if(ENABLE_BORINGSSL)
++  find_package(OpenSSL CONFIG REQUIRED)
++  get_target_property(BORINGSSL_INCLUDE_DIR OpenSSL::Crypto
++    INTERFACE_INCLUDE_DIRECTORIES)
++  set(BORINGSSL_LIBRARIES OpenSSL::SSL)
++endif()
+ if(ENABLE_WOLFSSL)
+   find_package(wolfssl 5.5.0 REQUIRED)
+ endif()
+diff --git a/crypto/boringssl/CMakeLists.txt b/crypto/boringssl/CMakeLists.txt
+index 60d2d41..fcd951a 100644
+--- a/crypto/boringssl/CMakeLists.txt
++++ b/crypto/boringssl/CMakeLists.txt
+@@ -29,20 +29,36 @@ set(ngtcp2_crypto_boringssl_SOURCES
+ )
+ 
+ set(ngtcp2_crypto_boringssl_INCLUDE_DIRS
+-  "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/includes"
+-  "${CMAKE_CURRENT_BINARY_DIR}/../../lib/includes"
+-  "${CMAKE_CURRENT_SOURCE_DIR}/../../lib"
+-  "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto/includes"
+-  "${CMAKE_CURRENT_BINARY_DIR}/../../crypto/includes"
+-  "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto"
+-  "${CMAKE_CURRENT_BINARY_DIR}/../../crypto"
+-  "${BORINGSSL_INCLUDE_DIRS}"
++  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>"
++  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/crypto/includes>"
++  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/crypto/includes>"
++  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/crypto>"
++  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/crypto>"
+ )
+ 
+ foreach(name libngtcp2_crypto_boringssl.pc)
+   configure_file("${name}.in" "${name}" @ONLY)
+ endforeach()
+ 
++# Public shared library
++if(ENABLE_SHARED_LIB)
++  add_library(ngtcp2_crypto_boringssl SHARED ${ngtcp2_crypto_boringssl_SOURCES})
++  set_target_properties(ngtcp2_crypto_boringssl PROPERTIES
++    COMPILE_FLAGS "${WARNCFLAGS}"
++    C_VISIBILITY_PRESET hidden
++    POSITION_INDEPENDENT_CODE ON
++  )
++  target_include_directories(ngtcp2_crypto_boringssl PUBLIC
++    ${ngtcp2_crypto_boringssl_INCLUDE_DIRS})
++  target_link_libraries(ngtcp2_crypto_boringssl PUBLIC ngtcp2 OpenSSL::SSL)
++
++  install(TARGETS ngtcp2_crypto_boringssl
++    EXPORT "${PROJECT_NAME}Targets"
++    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++endif()
++
+ if(ENABLE_STATIC_LIB)
+   # Public static library
+   add_library(ngtcp2_crypto_boringssl_static STATIC ${ngtcp2_crypto_boringssl_SOURCES})
+@@ -55,8 +71,11 @@ if(ENABLE_STATIC_LIB)
+     "-DNGTCP2_STATICLIB")
+   target_include_directories(ngtcp2_crypto_boringssl_static PUBLIC
+     ${ngtcp2_crypto_boringssl_INCLUDE_DIRS})
++  target_link_libraries(ngtcp2_crypto_boringssl_static PUBLIC
++    ngtcp2_static OpenSSL::SSL)
+ 
+   install(TARGETS ngtcp2_crypto_boringssl_static
++    EXPORT "${PROJECT_NAME}Targets"
+     DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ endif()
+ 
+diff --git a/lib/config.cmake.in b/lib/config.cmake.in
+index fffcd51..a672c7c 100644
+--- a/lib/config.cmake.in
++++ b/lib/config.cmake.in
+@@ -1,5 +1,5 @@
+ include(CMakeFindDependencyMacro)
+-if("@HAVE_OSSL@")
++if("@HAVE_OSSL@" OR "@HAVE_BORINGSSL@")
+     find_dependency(OpenSSL)
+ endif()
+ 

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 06307676fc94e97ec48953edca31d49d320ea12a46a3b8418f1b23dcbe0232677ce9d910dfcada5a71a5a9857fa92872b0231e320380f09c789ad8792211cc2f
     HEAD_REF main
+    PATCHES
+        0001-boringssl-cmake-integration.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
@@ -11,6 +13,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        boringssl ENABLE_BORINGSSL
         wolfssl  ENABLE_WOLFSSL
         gnutls   ENABLE_GNUTLS
         openssl  ENABLE_OPENSSL
@@ -22,9 +25,8 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
         "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
+        -DENABLE_LIB_ONLY=ON
         -DBUILD_TESTING=OFF
-        -DCMAKE_DISABLE_FIND_PACKAGE_Libev=ON
-        -DCMAKE_DISABLE_FIND_PACKAGE_Libnghttp3=ON
         -DCMAKE_INSTALL_DOCDIR=share/ngtcp2
 )
 vcpkg_cmake_install()

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.25.0",
+  "port-version": 1,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",
@@ -15,6 +16,12 @@
     }
   ],
   "features": {
+    "boringssl": {
+      "description": "Compile with BoringSSL",
+      "dependencies": [
+        "boringssl"
+      ]
+    },
     "gnutls": {
       "description": "Compile with gnutls",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7130,7 +7130,7 @@
     },
     "ngtcp2": {
       "baseline": "1.25.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccc06d612f09287ce0a9f8ca7047f13c08740e87",
+      "version": "1.25.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0946f540eed131b49d2bb77759a0e352096b1747",
       "version": "1.25.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

[ngtcp2](https://github.com/ngtcp2/ngtcp2) add [boringssl](https://github.com/google/boringssl) feature

The feature enables ngtcp2's BoringSSL crypto backend and exports consumable CMake targets for both linkage types:

- `ngtcp2::ngtcp2_crypto_boringssl_static`
- `ngtcp2::ngtcp2_crypto_boringssl`

Validated `ngtcp2[boringssl]` with both `arm64-osx` and `arm64-osx-dynamic`. A standalone CMake consumer using `find_package(ngtcp2 CONFIG REQUIRED)` also builds and links successfully with each target.
