### PR TITLE
[avro] Update to 1.12.2

### DIFF
--- a/ports/avro-c/portfile.cmake
+++ b/ports/avro-c/portfile.cmake
@@ -6,7 +6,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/avro/avro-${VERSION}/avro-src-${VERSION}.tar.gz"
     FILENAME "avro-src-${VERSION}.tar.gz"
-    SHA512 0d86bfece0f12f8bc424e27e71e3e6b828c4280fa1a6d7dc7e0d58bff2351f2c1fd3ccb98c1291dfc6c67d9cb5a0bdb7bb9f36ba5bd6b26fa9545f358db42663
+    SHA512 a31ad410d75c0e7f58fc9d9b7e7989dae12f328524806f6d64fdae22ddb9112fe2adc5fb74ee83df2135b87bd6618e8765a823220b2a0a162d1684192b9926da
 )
 
 vcpkg_extract_source_archive(

--- a/ports/avro-c/portfile.cmake
+++ b/ports/avro-c/portfile.cmake
@@ -43,4 +43,8 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND NOT VCPKG_TARGET_IS_WINDOWS)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/lang/c/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/lang/c/LICENSE"
+        "${SOURCE_PATH}/lang/c/NOTICE"
+)

--- a/ports/avro-c/vcpkg.json
+++ b/ports/avro-c/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "avro-c",
-  "version": "1.12.1",
-  "port-version": 1,
+  "version": "1.12.2",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/ports/avro-c/vcpkg.json
+++ b/ports/avro-c/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.12.2",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain",
   "supports": "!uwp",
   "dependencies": [
     "jansson",

--- a/ports/avro-cpp/fix-cmake.patch
+++ b/ports/avro-cpp/fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
-index 6800d330f..c9ec221d9 100644
+index 6800d33..c9ec221 100644
 --- a/lang/c++/CMakeLists.txt
 +++ b/lang/c++/CMakeLists.txt
 @@ -70,12 +70,12 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
@@ -18,3 +18,24 @@ index 6800d330f..c9ec221d9 100644
  endif ()
  
  if (AVRO_BUILD_TESTS OR AVRO_USE_BOOST)
+diff --git a/lang/c++/cmake/avro-cpp-config.cmake.in b/lang/c++/cmake/avro-cpp-config.cmake.in
+index c943f33..7e7f150 100644
+--- a/lang/c++/cmake/avro-cpp-config.cmake.in
++++ b/lang/c++/cmake/avro-cpp-config.cmake.in
+@@ -58,7 +58,14 @@ endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/avro-cpp-targets.cmake")
+ 
+-add_library(avro-cpp::avrocpp_static ALIAS avro-cpp::avrocpp_s)
+-add_library(avro-cpp::avrocpp_shared ALIAS avro-cpp::avrocpp)
++if(TARGET avro-cpp::avrocpp)
++    add_library(avro-cpp::avrocpp_shared ALIAS avro-cpp::avrocpp)
++endif()
++if(TARGET avro-cpp::avrocpp_s)
++    add_library(avro-cpp::avrocpp_static ALIAS avro-cpp::avrocpp_s)
++    if(NOT TARGET avro-cpp::avrocpp)
++        add_library(avro-cpp::avrocpp ALIAS avro-cpp::avrocpp_s)
++    endif()
++endif()
+ 
+ check_required_components(avro-cpp)

--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/avro/avro-${VERSION}/avro-src-${VERSION}.tar.gz"
     FILENAME "avro-src-${VERSION}.tar.gz"
-    SHA512 0d86bfece0f12f8bc424e27e71e3e6b828c4280fa1a6d7dc7e0d58bff2351f2c1fd3ccb98c1291dfc6c67d9cb5a0bdb7bb9f36ba5bd6b26fa9545f358db42663
+    SHA512 a31ad410d75c0e7f58fc9d9b7e7989dae12f328524806f6d64fdae22ddb9112fe2adc5fb74ee83df2135b87bd6618e8765a823220b2a0a162d1684192b9926da
 )
 
 vcpkg_extract_source_archive(

--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tools              AVRO_BUILD_EXECUTABLES
     INVERTED_FEATURES
         snappy             CMAKE_DISABLE_FIND_PACKAGE_Snappy
+        zstd               CMAKE_DISABLE_FIND_PACKAGE_zstd
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
@@ -39,5 +40,9 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/lang/c++/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/lang/c++/LICENSE"
+        "${SOURCE_PATH}/lang/c++/NOTICE"
+)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -26,6 +26,12 @@
     },
     "tools": {
       "description": "Build extra executables"
+    },
+    "zstd": {
+      "description": "Support zstd for compression",
+      "dependencies": [
+        "zstd"
+      ]
     }
   }
 }

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "avro-cpp",
-  "version": "1.12.1",
-  "port-version": 1,
+  "version": "1.12.2",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-c.json
+++ b/versions/a-/avro-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb9db38bae61eb012004c8da785bf525e9f72f98",
+      "version": "1.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6d12f4efe5aee0efe4ff61710e6cbc3100cec7a4",
       "version": "1.12.1",
       "port-version": 1

--- a/versions/a-/avro-c.json
+++ b/versions/a-/avro-c.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb9db38bae61eb012004c8da785bf525e9f72f98",
+      "git-tree": "36c44c8159d1b3da50dfa24407a5b1741b6c0ae9",
       "version": "1.12.2",
       "port-version": 0
     },

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48d873019dff4be3e050f003518002985bda36f7",
+      "version": "1.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2f85aad132aa9fd6a464be359fa7359b9633c780",
       "version": "1.12.1",
       "port-version": 1

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "48d873019dff4be3e050f003518002985bda36f7",
+      "git-tree": "a733c4fc611e69bf4af6b12244d3007e38bb8736",
       "version": "1.12.2",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -445,12 +445,12 @@
       "port-version": 0
     },
     "avro-c": {
-      "baseline": "1.12.1",
-      "port-version": 1
+      "baseline": "1.12.2",
+      "port-version": 0
     },
     "avro-cpp": {
-      "baseline": "1.12.1",
-      "port-version": 1
+      "baseline": "1.12.2",
+      "port-version": 0
     },
     "awlib": {
       "baseline": "2026-08-07",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.