### PR TITLE
[amgcl] Add new port (1.5.0)

### DIFF
--- a/ports/amgcl/portfile.cmake
+++ b/ports/amgcl/portfile.cmake
@@ -1,0 +1,19 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ddemidov/amgcl
+    REF "${VERSION}"
+    SHA512 c0faa4894dfb797404afa749bde14721be3bf828c6bbf9538eb7caea180bfca9bcf2952a420cce2914ce532203065b5b739188bc000005801a84120bba4e7e33
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/amgcl/cmake")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/amgcl/vcpkg.json
+++ b/ports/amgcl/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "amgcl",
+  "version": "1.5.0",
+  "description": "Header-only library for solving large sparse linear systems with algebraic multigrid (AMG) method",
+  "homepage": "https://amgcl.readthedocs.io",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/amgcl.json
+++ b/versions/a-/amgcl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2c40cfe82c36d779dd1c4a915b8ef364072feccf",
+      "version": "1.5.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -124,6 +124,10 @@
       "baseline": "1.5.2",
       "port-version": 0
     },
+    "amgcl": {
+      "baseline": "1.5.0",
+      "port-version": 0
+    },
     "ampl-asl": {
       "baseline": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [x] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://repology.org/project/amgcl

Adding this as explicit port, so we can devendor it from geogram. Usage file is necessary due to https://github.com/microsoft/vcpkg-tool/issues/2110