### PR TITLE
[libmeshb] Add new port (8.2)

### DIFF
--- a/ports/libmeshb/disable_examples_utilities.patch
+++ b/ports/libmeshb/disable_examples_utilities.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b47613c..514d1a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,11 +77,13 @@ endif ()
+ include_directories (BEFORE ${LIBMESHB_SRC})
+ include_directories (BEFORE ${LIBMESHB_UTILS})
+ add_subdirectory (sources)
++if(0)
+ add_subdirectory (examples)
+ add_subdirectory (utilities)
++endif()
+ 
+-install (FILES LICENSE.txt copyright.txt DESTINATION share/libMeshb)
+-install (DIRECTORY sample_meshes DESTINATION share/libMeshb)
++#install (FILES LICENSE.txt copyright.txt DESTINATION share/libMeshb)
++#install (DIRECTORY sample_meshes DESTINATION share/libMeshb)
+ 
+ 
+ #############################

--- a/ports/libmeshb/portfile.cmake
+++ b/ports/libmeshb/portfile.cmake
@@ -1,0 +1,32 @@
+if(VERSION MATCHES "^([0-9]+)\\.([0-9])$")
+    set(TAG_VERSION "${CMAKE_MATCH_1}.0${CMAKE_MATCH_2}")
+else()
+    set(TAG_VERSION "${VERSION}")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LoicMarechal/libMeshb
+    REF "v${TAG_VERSION}"
+    SHA512 c9b9548c325490b0625e4de84e4b5aad412635c7f512326eb2ef27fc4b98de28d661a0076ac5c31c64d74dea2e5dfd1222b19f0d7b22d313144ce8d35a78bfbf
+    PATCHES
+        disable_examples_utilities.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libMeshb")
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+)
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/copyright.txt"
+        "${SOURCE_PATH}/LICENSE.txt"
+)

--- a/ports/libmeshb/vcpkg.json
+++ b/ports/libmeshb/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libmeshb",
+  "version": "8.2",
+  "description": "Library to handle the *.meshb file format.",
+  "homepage": "https://github.com/LoicMarechal/libMeshb",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5336,6 +5336,10 @@
       "baseline": "1.1.4",
       "port-version": 0
     },
+    "libmeshb": {
+      "baseline": "8.2",
+      "port-version": 0
+    },
     "libmicrodns": {
       "baseline": "0.2.0",
       "port-version": 2

--- a/versions/l-/libmeshb.json
+++ b/versions/l-/libmeshb.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d2c34ee49a7dfe8e731036a1196924867cfe4f8b",
+      "version": "8.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [x] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://repology.org/project/libmeshb

Adding this as explicit port, so we can devendor it from geogram.