### PR TITLE
[aws-c-auth] Update to 1.0.0

### DIFF
--- a/ports/aws-c-auth/portfile.cmake
+++ b/ports/aws-c-auth/portfile.cmake
@@ -2,14 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-auth
     REF "v${VERSION}"
-    SHA512 72893b7edb0c91ac7bce7bec42e7149d1f8274f27287b26207f4a91aefaac3da6c325a14ee3267755f8e2b096604a8570374d5d0707f85cf1840c435043e874b
+    SHA512 6ff5e408a3c9d88eb4f0b6b711eb98acdba94f8677f15297e44636de1a2a3d352aaa8cd264693cf1d757a3b58d6bf05e5182cb7b80956c8531c53be34d9f8f73
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
         -DBUILD_TESTING=FALSE
 )
 

--- a/ports/aws-c-auth/vcpkg.json
+++ b/ports/aws-c-auth/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-auth",
-  "version": "0.10.5",
+  "version": "1.0.0",
   "description": "C99 library implementation of AWS client-side authentication: standard credentials providers and signing.",
   "homepage": "https://github.com/awslabs/aws-c-auth",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-auth.json
+++ b/versions/a-/aws-c-auth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7052ba597d808512c85ce0f811b25a99e4f91bb",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f256aa109bcaa353a15b8b33b75a574e0b0e658",
       "version": "0.10.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -457,7 +457,7 @@
       "port-version": 0
     },
     "aws-c-auth": {
-      "baseline": "0.10.5",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-cal": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Requires #53648
