### PR TITLE
[aws-c-common] Updated to 1.0.0

### DIFF
--- a/ports/aws-c-common/disable-internal-crt-option.patch
+++ b/ports/aws-c-common/disable-internal-crt-option.patch
@@ -1,12 +1,12 @@
 diff --git a/cmake/AwsCFlags.cmake b/cmake/AwsCFlags.cmake
-index 470f6db..537536b 100644
+index c0acbba8..05cd2105 100644
 --- a/cmake/AwsCFlags.cmake
 +++ b/cmake/AwsCFlags.cmake
-@@ -82,15 +82,6 @@ function(aws_set_common_properties target)
+@@ -81,15 +81,6 @@ function(aws_set_common_properties target)
              list(APPEND AWS_C_FLAGS /DAWS_SUPPORT_WIN7=1)
          endif()
-
--        # Set MSVC runtime libary.
+ 
+-        # Set MSVC runtime library.
 -        # Note: there are other ways of doing this if we bump our CMake minimum to 3.14+
 -        # See: https://cmake.org/cmake/help/latest/policy/CMP0091.html
 -        if (AWS_STATIC_MSVC_RUNTIME_LIBRARY OR STATIC_CRT)
@@ -17,4 +17,4 @@ index 470f6db..537536b 100644
 -
      else()
          list(APPEND AWS_C_FLAGS -Wall -Wstrict-prototypes)
-
+ 

--- a/ports/aws-c-common/portfile.cmake
+++ b/ports/aws-c-common/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-common
     REF "v${VERSION}"
-    SHA512 65affea21d00afaabef7b54a2c1384136f4dd4a918634fca11d8ffbd053586f0c5897c0345f985b931cd6a76c3d6cad2d4f66ecb8297175431a62366cba91195
+    SHA512 f9cd67637383d86353cef7d230051aad67574f9b5c72d6260713f9d8b1139d730ce56d3cc8b646bc0344d99c8cae79d3cfca86c1994207c1b74b9bb814645f4b
     HEAD_REF master
     PATCHES
         disable-internal-crt-option.patch # Disable internal crt option because vcpkg contains crt processing flow

--- a/ports/aws-c-common/vcpkg.json
+++ b/ports/aws-c-common/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-common",
-  "version": "0.14.5",
+  "version": "1.0.0",
   "description": "AWS common library for C",
   "homepage": "https://github.com/awslabs/aws-c-common",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT",

--- a/versions/a-/aws-c-common.json
+++ b/versions/a-/aws-c-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4b4f45d42ae3a7ce2c5040af18cc9bb1b0113a6",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ca9531ec50c3532f55c3ca45682d9aca7bc300f1",
       "version": "0.14.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -465,7 +465,7 @@
       "port-version": 0
     },
     "aws-c-common": {
-      "baseline": "0.14.5",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-compression": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
