### PR TITLE
[aws-c-http] Updated to 1.0.0

### DIFF
--- a/ports/aws-c-http/portfile.cmake
+++ b/ports/aws-c-http/portfile.cmake
@@ -2,14 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-http
     REF "v${VERSION}"
-    SHA512 311b778df5a2d5dea7c8933d8fa1cdd2c4f8b11ec5f022c14d2487ba1fe039b19ef3f77d8aaaf159721912ac6b434532535a9ad6dd30ab6183d74b8c38fde0ad
+    SHA512 6236e6713f44d87446f4a521d5044d9c46b06bc5738bbf38c112aeff9a222427a52c8acb57eabff55c229de41dce8380b6cc04a8970a78cc378a63240e31ecc3
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
         -DBUILD_TESTING=FALSE
 )
 

--- a/ports/aws-c-http/vcpkg.json
+++ b/ports/aws-c-http/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-http",
-  "version": "0.11.1",
+  "version": "1.0.0",
   "description": "C99 implementation of the HTTP/1.1 and HTTP/2 specifications",
   "homepage": "https://github.com/awslabs/aws-c-http",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-http.json
+++ b/versions/a-/aws-c-http.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "613c90c3def9f796bc8910b07e54c870d8f721c5",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "172e893e8efff99979282a03764419d42f6ec1f3",
       "version": "0.11.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -477,7 +477,7 @@
       "port-version": 0
     },
     "aws-c-http": {
-      "baseline": "0.11.1",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-io": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
