### PR TITLE
[aws-c-compression] Updated to 1.0.0

### DIFF
--- a/ports/aws-c-compression/portfile.cmake
+++ b/ports/aws-c-compression/portfile.cmake
@@ -2,14 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-compression
     REF "v${VERSION}"
-    SHA512 78e9aab97a95245e5d84b3fb7e3a7dcc392c1f8eb310892306f72a13382cf847c2a85304c52a5f4e19a63523a31020577dec8bea41e0e211712668fbfa77a38e
+    SHA512 631773691b321f112df5413dc2366fb4e8c422b35912cc20b73a1a3857722fdbcf6b6ab59edd63b1244a3f8db08d0bbee2003ca1cd6d5576833c4145fbd40904
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
         -DBUILD_TESTING=FALSE
 )
 

--- a/ports/aws-c-compression/vcpkg.json
+++ b/ports/aws-c-compression/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-compression",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "description": "C99 implementation of huffman encoding/decoding",
   "homepage": "https://github.com/awslabs/aws-c-compression",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-compression.json
+++ b/versions/a-/aws-c-compression.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e7fc37feeca83c12d18ef7216c264189aa36ff5",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "76061ad61733758777f314b2b83f3e76de9a7ad0",
       "version": "0.3.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -469,7 +469,7 @@
       "port-version": 0
     },
     "aws-c-compression": {
-      "baseline": "0.3.3",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-event-stream": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
