### PR TITLE
[aws-c-event-stream] Updated to 1.0.0

### DIFF
--- a/ports/aws-c-event-stream/portfile.cmake
+++ b/ports/aws-c-event-stream/portfile.cmake
@@ -2,14 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-event-stream
     REF "v${VERSION}"
-    SHA512 38a8ac44e4cd6325e1ff75ccc57dd6aa792ce3ad81ba767a4dcd105723a59fa0fb4a109e67c0ae8511f2fdfafd337d7b00ebf48e70717e2a5c5a427c38532a45
+    SHA512 994b6b5a7f5a154355d62d0c4b178e271e491c468971773421b2eb9845f70caba203671fce99a74526206e9ef83eefcc0ee735754abbcf1ea030679d282b3b3e
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common"
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
         -DBUILD_TESTING=FALSE
 )
 

--- a/ports/aws-c-event-stream/vcpkg.json
+++ b/ports/aws-c-event-stream/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-event-stream",
-  "version": "0.7.2",
+  "version": "1.0.0",
   "description": "C99 implementation of the vnd.amazon.event-stream content-type.",
   "homepage": "https://github.com/awslabs/aws-c-event-stream",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-event-stream.json
+++ b/versions/a-/aws-c-event-stream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "582ffd23bbcd6d7a032b09a741b5eaa75f81da6f",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b4f9c864189f308c6f3c0b73db2f2d2dd54134cf",
       "version": "0.7.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -473,7 +473,7 @@
       "port-version": 0
     },
     "aws-c-event-stream": {
-      "baseline": "0.7.2",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-http": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
