### PR TITLE
[aws-c-mqtt] Updated to 1.0.0

### DIFF
--- a/ports/aws-c-mqtt/portfile.cmake
+++ b/ports/aws-c-mqtt/portfile.cmake
@@ -2,15 +2,15 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-mqtt
     REF "v${VERSION}"
-    SHA512 6abe7c2aa2861334930ae2c604f66e9ca2c8a155b7b196469bb8b545cbabe0ee6f6895f13b170953a2016b484d6331b82542e96c784531bd9952c7ea1a068d4b
+    SHA512 ad0d30e758455fa0b9a2b981cabb206279d45654a8c874319b65bc38b1d1087e7698d01892cae29a4438fe481c2ac81c2ff07e8760fd4fe6cb95ddc90f3621e6
     HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-         "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
-         -DBUILD_TESTING=FALSE
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
+        -DBUILD_TESTING=FALSE
 )
 
 vcpkg_cmake_install()

--- a/ports/aws-c-mqtt/vcpkg.json
+++ b/ports/aws-c-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-mqtt",
-  "version": "0.16.2",
+  "version": "1.0.0",
   "description": "C99 implementation of the MQTT 3.1.1 specification.",
   "homepage": "https://github.com/awslabs/aws-c-mqtt",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-mqtt.json
+++ b/versions/a-/aws-c-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf76ef64568fbf615c6ddf04cfdebac556557bd7",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "aacbbc403c2b7b557debe4d1073661df5997a7fc",
       "version": "0.16.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -485,7 +485,7 @@
       "port-version": 0
     },
     "aws-c-mqtt": {
-      "baseline": "0.16.2",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-s3": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
