### PR TITLE
[aws-c-s3] Updated to 1.0.0

### DIFF
--- a/ports/aws-c-s3/portfile.cmake
+++ b/ports/aws-c-s3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-s3
     REF "v${VERSION}"
-    SHA512 0a28013378acab14e7dee20fe491492924525ab158fb9b0b5fafbee642493aef0d07253bac61be749c5efe8c902c44bb28ce0c3cda83417baf0f504723b9c6b5
+    SHA512 9e4aa743f3ecb6fbc5e2375d9b95346ee4b9eef286d002ec762e27d63dc0cdee1316a3ca85bc80100431808d823ff289c7d757c0b7d6a6746bbad68d0ceb4f5b
     HEAD_REF main
 )
 
@@ -14,7 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
         -DBUILD_TESTING=FALSE
         ${FEATURE_OPTIONS}
 )

--- a/ports/aws-c-s3/vcpkg.json
+++ b/ports/aws-c-s3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-s3",
-  "version": "0.13.7",
+  "version": "1.0.0",
   "description": "C99 library implementation for communicating with the S3 service, designed for maximizing throughput on high bandwidth EC2 instances.",
   "homepage": "https://github.com/awslabs/aws-c-s3",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-s3.json
+++ b/versions/a-/aws-c-s3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7492c2dcf0f8e21cf0d63e8043f2e58b7f35846",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "02d2d70fed84926435f7b3847885ae70ecafc8a0",
       "version": "0.13.7",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -489,7 +489,7 @@
       "port-version": 0
     },
     "aws-c-s3": {
-      "baseline": "0.13.7",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-c-sdkutils": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
