### PR TITLE
[aws-checksums] Updated to 1.0.0

### DIFF
--- a/ports/aws-checksums/portfile.cmake
+++ b/ports/aws-checksums/portfile.cmake
@@ -38,4 +38,8 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/source/external/xxhash.h"
+)

--- a/ports/aws-checksums/portfile.cmake
+++ b/ports/aws-checksums/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-checksums
     REF "v${VERSION}"
-    SHA512 217e0f9d0a12f1640056c08e0e03b91802623fc4762c573cd2679d6cb32192d619d19a4c750ccd5b2127583d09b640f78a5bb314dd1c641a83d61e1b9cfbb550
+    SHA512 c77c62aaad6932ca5fe8baf3c01562f3144198d1133ebc8d1c9e124d7b6a0bc69800362a6913967c87cea734e8ceb4b756f29349036477b19b7e50f6ef387376
     HEAD_REF main
     PATCHES
         fix-cmake-config.patch
@@ -18,7 +18,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSTATIC_CRT=${STATIC_CRT_LNK}
-        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        "-DCMAKE_PREFIX_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common/modules" # use extra cmake files
         -DBUILD_TESTING=FALSE
 )
 

--- a/ports/aws-checksums/vcpkg.json
+++ b/ports/aws-checksums/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-checksums",
-  "version": "0.2.11",
+  "version": "1.0.0",
   "description": "Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations.",
   "homepage": "https://github.com/awslabs/aws-checksums",
   "license": "Apache-2.0",

--- a/ports/aws-checksums/vcpkg.json
+++ b/ports/aws-checksums/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations.",
   "homepage": "https://github.com/awslabs/aws-checksums",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0 AND BSD-2-Clause",
   "dependencies": [
     "aws-c-common",
     {

--- a/versions/a-/aws-checksums.json
+++ b/versions/a-/aws-checksums.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28cca9feeb72e253b431019238cb0caaf11f599b",
+      "git-tree": "9eb13e772ebbdae0631ae033b256cbe18984b435",
       "version": "1.0.0",
       "port-version": 0
     },

--- a/versions/a-/aws-checksums.json
+++ b/versions/a-/aws-checksums.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28cca9feeb72e253b431019238cb0caaf11f599b",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9794989895de6f4c52c4cc72732db31b27e96a5e",
       "version": "0.2.11",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -497,7 +497,7 @@
       "port-version": 0
     },
     "aws-checksums": {
-      "baseline": "0.2.11",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "aws-crt-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
