### PR TITLE
[kubazip] Updated to 0.3.15

### DIFF
--- a/ports/kubazip/fix-project-version.patch
+++ b/ports/kubazip/fix-project-version.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index af81ac7..6cd12b6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
+ 
+ project(zip
+   LANGUAGES C
+-  VERSION "0.3.14")
++  VERSION "0.3.15")
+ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+ set(CMAKE_VERBOSE_MAKEFILE ON)
+ 

--- a/ports/kubazip/portfile.cmake
+++ b/ports/kubazip/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-name-conflict.diff
         disable-werror.patch
+        fix-project-version.patch # https://github.com/kuba--/zip/commit/dd80aeab4293d1e11e31af20fabfd538d88625ef
 )
 
 vcpkg_cmake_configure(
@@ -27,4 +28,8 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 # legacy polyfill
 file(INSTALL "${CURRENT_PORT_DIR}/kubazipConfig.cmake" "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/src/miniz.h"
+)

--- a/ports/kubazip/portfile.cmake
+++ b/ports/kubazip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kuba--/zip
     REF "v${VERSION}"
-    SHA512 e35df05d1db4542223f251b052094a8926f1e84a9051db3ff3f60cd0c3af912e0e3053852df8f24eb37b25c0be90afe058c613e9139ccfad0c3ad4d3950c2e70
+    SHA512 817da7dd6f477adeb4986d542c20b6f28bed24895b09d3a69cfddf28cc78a7259db3a5e8f879ac263b6bda11c7bb70d00d1d8b626e33b4280366c769bb30bf50
     HEAD_REF master
     PATCHES
         fix-name-conflict.diff

--- a/ports/kubazip/vcpkg.json
+++ b/ports/kubazip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubazip",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "A portable, simple zip library written in C",
   "homepage": "https://github.com/kuba--/zip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4637,7 +4637,7 @@
       "port-version": 0
     },
     "kubazip": {
-      "baseline": "0.3.14",
+      "baseline": "0.3.15",
       "port-version": 0
     },
     "kubernetes": {

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7e910944961b3a0ee72bda3532c93b177cd1030",
+      "version": "0.3.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "09cda8d314d5c4e8e6a49b51f34aa7a65272c2e6",
       "version": "0.3.14",
       "port-version": 0

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c7e910944961b3a0ee72bda3532c93b177cd1030",
+      "git-tree": "ca5503c1bd9dd8d574ddf6010ff0a88ccbd1cf29",
       "version": "0.3.15",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
