### PR TITLE
[ironpress] New port

### DIFF
--- a/ports/ironpress/IronpressConfig.cmake.in
+++ b/ports/ironpress/IronpressConfig.cmake.in
@@ -1,0 +1,75 @@
+get_filename_component(_ironpress_prefix "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
+if(NOT TARGET Ironpress::C)
+    add_library(Ironpress::C @IRONPRESS_LIBRARY_TYPE@ IMPORTED)
+    set_target_properties(
+        Ironpress::C
+        PROPERTIES
+            IMPORTED_CONFIGURATIONS "DEBUG;RELEASE"
+            INTERFACE_INCLUDE_DIRECTORIES "${_ironpress_prefix}/include"
+            MAP_IMPORTED_CONFIG_MINSIZEREL RELEASE
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE
+    )
+
+    if(WIN32 AND "@IRONPRESS_LIBRARY_TYPE@" STREQUAL "SHARED")
+        set_target_properties(
+            Ironpress::C
+            PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${_ironpress_prefix}/bin/ironpress_ffi.dll"
+                IMPORTED_LOCATION_DEBUG "${_ironpress_prefix}/debug/bin/ironpress_ffi.dll"
+                IMPORTED_IMPLIB_RELEASE "${_ironpress_prefix}/lib/ironpress_ffi.dll.lib"
+                IMPORTED_IMPLIB_DEBUG "${_ironpress_prefix}/debug/lib/ironpress_ffi.dll.lib"
+        )
+    elseif(WIN32)
+        set_target_properties(
+            Ironpress::C
+            PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${_ironpress_prefix}/lib/ironpress_ffi.lib"
+                IMPORTED_LOCATION_DEBUG "${_ironpress_prefix}/debug/lib/ironpress_ffi.lib"
+                INTERFACE_LINK_LIBRARIES "kernel32;ntdll;userenv;ws2_32;dbghelp"
+        )
+    elseif(APPLE AND "@IRONPRESS_LIBRARY_TYPE@" STREQUAL "SHARED")
+        set_target_properties(
+            Ironpress::C
+            PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${_ironpress_prefix}/lib/libironpress_ffi.dylib"
+                IMPORTED_LOCATION_DEBUG "${_ironpress_prefix}/debug/lib/libironpress_ffi.dylib"
+        )
+    elseif(APPLE)
+        set_target_properties(
+            Ironpress::C
+            PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${_ironpress_prefix}/lib/libironpress_ffi.a"
+                IMPORTED_LOCATION_DEBUG "${_ironpress_prefix}/debug/lib/libironpress_ffi.a"
+                INTERFACE_LINK_LIBRARIES "iconv;m"
+        )
+    elseif("@IRONPRESS_LIBRARY_TYPE@" STREQUAL "SHARED")
+        set_target_properties(
+            Ironpress::C
+            PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${_ironpress_prefix}/lib/libironpress_ffi.so"
+                IMPORTED_LOCATION_DEBUG "${_ironpress_prefix}/debug/lib/libironpress_ffi.so"
+        )
+    else()
+        find_package(Threads REQUIRED)
+        set_target_properties(
+            Ironpress::C
+            PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${_ironpress_prefix}/lib/libironpress_ffi.a"
+                IMPORTED_LOCATION_DEBUG "${_ironpress_prefix}/debug/lib/libironpress_ffi.a"
+                INTERFACE_LINK_LIBRARIES "${CMAKE_DL_LIBS};Threads::Threads;m"
+        )
+    endif()
+endif()
+
+if(NOT TARGET Ironpress::CXX)
+    add_library(Ironpress::CXX INTERFACE IMPORTED)
+    set_target_properties(
+        Ironpress::CXX
+        PROPERTIES
+            INTERFACE_COMPILE_FEATURES cxx_std_17
+            INTERFACE_LINK_LIBRARIES Ironpress::C
+    )
+endif()
+
+unset(_ironpress_prefix)

--- a/ports/ironpress/portfile.cmake
+++ b/ports/ironpress/portfile.cmake
@@ -1,0 +1,103 @@
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(IRONPRESS_PLATFORM "windows-x86_64")
+    set(IRONPRESS_ARCHIVE_EXTENSION "zip")
+    set(IRONPRESS_ARCHIVE_SHA512 df6995f5a71e68d84698c284c01c6cc49f7872e7d3978e6754577170b38faa0aa3453313d259be23a8de28413112be4ff2945a36fcf89923a11931bf9976844c)
+elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(IRONPRESS_PLATFORM "macos-aarch64")
+    set(IRONPRESS_ARCHIVE_EXTENSION "tar.gz")
+    set(IRONPRESS_ARCHIVE_SHA512 aff20683e56ae0f6b45f2d1a2e3a4caf32f6cb4f0aa8e113c645e7461340908606601a860c337a4fb511f6921d2d9436aa9f0598ba2e80b499f9b5688434cb63)
+elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(IRONPRESS_PLATFORM "macos-x86_64")
+    set(IRONPRESS_ARCHIVE_EXTENSION "tar.gz")
+    set(IRONPRESS_ARCHIVE_SHA512 0dcd46928bc824dce491a35c4fa99e9c69e665de0b47e0f4e2aa55a75666ac27d648fe0db0880e448543df22f73a1264daf425c4667fa20aa24e581aec0e13f1)
+elseif(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(IRONPRESS_PLATFORM "linux-aarch64")
+    set(IRONPRESS_ARCHIVE_EXTENSION "tar.gz")
+    set(IRONPRESS_ARCHIVE_SHA512 952bccb581fc5dc48f699f77f22d812f74611fc485b2e53bc981b853e94a8cb8bcb4ca1d0e1e093f3baca13d1ad46ce0b6ce2c7213741be6bb752b4553409ebb)
+elseif(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(IRONPRESS_PLATFORM "linux-x86_64")
+    set(IRONPRESS_ARCHIVE_EXTENSION "tar.gz")
+    set(IRONPRESS_ARCHIVE_SHA512 9fd3110c0c3038576bf9b8e92c0e47b41933c290398a3ee28586ffb272594f88f9231f4ba83141e06eef14cee05a39490719c0638dd3f49bccda8858789cacff)
+else()
+    message(FATAL_ERROR "Ironpress has no native archive for ${TARGET_TRIPLET}.")
+endif()
+
+set(IRONPRESS_ARCHIVE "ironpress-c-${VERSION}-${IRONPRESS_PLATFORM}.${IRONPRESS_ARCHIVE_EXTENSION}")
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "https://github.com/gastongouron/ironpress/releases/download/v${VERSION}/${IRONPRESS_ARCHIVE}"
+    FILENAME "${IRONPRESS_ARCHIVE}"
+    SHA512 "${IRONPRESS_ARCHIVE_SHA512}"
+)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+# Ironpress publishes release-mode native archives. The same artifact backs
+# Debug consumers, so Windows' debug CRT check does not apply to this package.
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(VCPKG_POLICY_SKIP_CRT_LINKAGE_CHECK enabled)
+endif()
+
+file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+function(ironpress_install_library destination)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        if(VCPKG_TARGET_IS_WINDOWS)
+            file(INSTALL "${SOURCE_PATH}/lib/ironpress_ffi.dll"
+                DESTINATION "${CURRENT_PACKAGES_DIR}/${destination}bin")
+            file(INSTALL "${SOURCE_PATH}/lib/ironpress_ffi.dll.lib"
+                DESTINATION "${CURRENT_PACKAGES_DIR}/${destination}lib")
+        elseif(VCPKG_TARGET_IS_OSX)
+            file(INSTALL "${SOURCE_PATH}/lib/libironpress_ffi.dylib"
+                DESTINATION "${CURRENT_PACKAGES_DIR}/${destination}lib")
+        else()
+            file(INSTALL "${SOURCE_PATH}/lib/libironpress_ffi.so"
+                DESTINATION "${CURRENT_PACKAGES_DIR}/${destination}lib")
+        endif()
+    elseif(VCPKG_TARGET_IS_WINDOWS)
+        file(INSTALL "${SOURCE_PATH}/lib/ironpress_ffi.lib"
+            DESTINATION "${CURRENT_PACKAGES_DIR}/${destination}lib")
+    else()
+        file(INSTALL "${SOURCE_PATH}/lib/libironpress_ffi.a"
+            DESTINATION "${CURRENT_PACKAGES_DIR}/${destination}lib")
+    endif()
+endfunction()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    ironpress_install_library("")
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    ironpress_install_library("debug/")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(IRONPRESS_LIBRARY_TYPE SHARED)
+else()
+    set(IRONPRESS_LIBRARY_TYPE STATIC)
+endif()
+configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/IronpressConfig.cmake.in"
+    "${CURRENT_PACKAGES_DIR}/share/ironpress/IronpressConfig.cmake"
+    @ONLY
+)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CURRENT_PACKAGES_DIR}/share/ironpress/IronpressConfigVersion.cmake"
+    VERSION "${VERSION}"
+    COMPATIBILITY SameMajorVersion
+)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/ironpress")
+
+string(CONCAT IRONPRESS_LICENSE_COMMENT
+    "The prebuilt Ironpress library contains statically linked Rust dependencies. "
+    "Their licenses and copyright notices can be obtained by checking out "
+    "https://github.com/gastongouron/ironpress/tree/v${VERSION} and running "
+    "cargo-about against bindings/c/Cargo.toml."
+)
+vcpkg_install_copyright(
+    COMMENT "${IRONPRESS_LICENSE_COMMENT}"
+    FILE_LIST "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/ironpress/usage
+++ b/ports/ironpress/usage
@@ -1,0 +1,7 @@
+ironpress provides C and C++ CMake targets:
+
+    find_package(Ironpress CONFIG REQUIRED)
+    target_link_libraries(your_c_target PRIVATE Ironpress::C)
+    target_link_libraries(your_cpp_target PRIVATE Ironpress::CXX)
+
+Select static or dynamic linkage through the vcpkg triplet.

--- a/ports/ironpress/vcpkg.json
+++ b/ports/ironpress/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "ironpress",
+  "version": "1.6.0",
+  "description": "In-process HTML, CSS, and Markdown to PDF renderer",
+  "homepage": "https://github.com/gastongouron/ironpress",
+  "license": "MIT",
+  "supports": "(windows & x64 & !uwp & !mingw) | (osx & (x64 | arm64)) | (linux & (x64 | arm64))"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4100,6 +4100,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "ironpress": {
+      "baseline": "1.6.0",
+      "port-version": 0
+    },
     "irrlicht": {
       "baseline": "1.8.5",
       "port-version": 2

--- a/versions/i-/ironpress.json
+++ b/versions/i-/ironpress.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8bb2510fae548d319ec26024819ea27b1cd2896d",
+      "version": "1.6.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds Ironpress 1.6.0 as a new native C and C++ port.

The port consumes the official release archives instead of requiring a Rust
toolchain. It provides static or shared linkage through `Ironpress::C` and
`Ironpress::CXX`.

Supported release artifacts:

- Linux x64 and arm64
- macOS x64 and arm64
- Windows x64

Local verification on macOS arm64:

- `vcpkg install ironpress:arm64-osx`
- `vcpkg install ironpress:arm64-osx-dynamic`
- C and C++ consumers in Release and Debug
- direct C and C++ linking in static and dynamic modes
- every consumer rendered and validated a `%PDF` result
- `vcpkg format-manifest` and `vcpkg x-add-version ironpress`

Project maturity: Ironpress has 722 GitHub stars, a stable native ABI at
v1.6.0, active releases, and packages in the Rust, npm, PyPI, RubyGems,
NuGet, and Maven ecosystems. Its public development started on 2026-03-14,
so it is just under the six-month age criterion; this PR is therefore a draft.

Name association: `ironpress` is the exact upstream project, repository,
crate, package, C namespace, and CMake package name. The upstream repository
is the first result for the web search `Ironpress C++ PDF renderer`.

Tracks https://github.com/gastongouron/ironpress/issues/242.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [x] Some other reason: stable ABI, broad public distribution, 722 stars, and an actively tested release matrix
- [x] The packaged project shows strong association with the chosen port name.
    - [ ] The project is in Repology: https://repology.org/project/ironpress/versions
    - [x] The project is amongst the first web search results for "Ironpress" or "Ironpress C++". See the explanation above.
    - [ ] The port name follows the `GitHubOrg-GitHubRepo` form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. The port installs official prebuilt artifacts and performs no dependency probing.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed `copyright` file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated usage text is brief and accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version ironpress` and committing the result.
- [x] Exactly one version is added in each modified versions file.
