### PR TITLE
[msgpack] update to 9.0.0

### DIFF
--- a/ports/msgpack/portfile.cmake
+++ b/ports/msgpack/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO msgpack/msgpack-c
     REF cpp-${VERSION}
-    SHA512 23e1fa14c9d1bcf70b74ebb6d2379691a3224022a5b5a186c48e0c3c0af54eb6c755bcbaf900024ecaafb031a450c34e207cd4d66bdfb701ffef44fc06d87915
+    SHA512 2501fc1ec9a52614ae86210545ecc8ae4b36e055018cd6bfca6543503d3c17b6a84e464c9136c881fb32bc6464cea5b38c7cc2c44c84c173f67a612cc220a2c6
     HEAD_REF cpp_master
 )
 

--- a/ports/msgpack/vcpkg.json
+++ b/ports/msgpack/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "msgpack",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.",
   "homepage": "https://github.com/msgpack/msgpack-c",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6849,7 +6849,7 @@
       "port-version": 0
     },
     "msgpack": {
-      "baseline": "8.0.0",
+      "baseline": "9.0.0",
       "port-version": 0
     },
     "msgpack-c": {

--- a/versions/m-/msgpack.json
+++ b/versions/m-/msgpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "772d7cb9b3c455e517ce8d0e53e1e0199b187988",
+      "version": "9.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bb4893fcebb0e60df065df6f09e803e3900d0b41",
       "version": "8.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/msgpack/msgpack-c/releases/tag/cpp-9.0.0
