### PR TITLE
[gumbo] update to 0.14.0

### DIFF
--- a/ports/gumbo/CMakeLists.txt
+++ b/ports/gumbo/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.8.0)
 project(gumbo)
 
 set(gumbo_public_headers
-  src/gumbo.h 
+  src/gumbo.h
   src/tag_enum.h
 )
 
@@ -19,6 +19,7 @@ set(gumbo_srcs
   src/utf8.c
   src/util.c
   src/vector.c
+  src/char_ref_gperf.c
 )
 
 include_directories(src)

--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(ARCHIVE
     FILENAME "gumbo-${VERSION}.tar.gz"
     # Codeberg re-packs the same tag without changing the version string; refresh
     # the hash when download fails with "hash mismatch" (observed 2026-08-02).
-    SHA512 9f59965e68ba2e4f5884d52c4126b62cdbefee158816334e317a0d07f10ba927be653490c69fc5b0f52eed1decf0a51715bb726aa84546a2d04cde5805e4a399
+    SHA512 612b570bfa4029272bc4b8d4ff43f6023e03a2a2ac6ba299fa6d0818dc112df84ef98908ef9102801dbf847e93cc6e1f8c976e2f9f782199d6785cb28db8dbb5
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gumbo",
-  "version": "0.13.2",
-  "port-version": 1,
+  "version": "0.14.0",
   "description": "An HTML5 parsing library in pure C99",
   "homepage": "https://codeberg.org/gumbo-parser/gumbo-parser",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3685,8 +3685,8 @@
       "port-version": 0
     },
     "gumbo": {
-      "baseline": "0.13.2",
-      "port-version": 1
+      "baseline": "0.14.0",
+      "port-version": 0
     },
     "gz-cmake": {
       "baseline": "4.3.0",

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "267e23abe1f689c719314e2f87048495f5d0d33e",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b7030795a1f65570f41612dcbfae98b91224149",
       "version": "0.13.2",
       "port-version": 1

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "267e23abe1f689c719314e2f87048495f5d0d33e",
+      "git-tree": "81ec0cbaa350338fbdc331b6874f4ae0edcb1543",
       "version": "0.14.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://codeberg.org/gumbo-parser/gumbo-parser/releases/tag/0.14.0

src/char_ref_gperf.c has been introduced since 0.14.0.

