### PR TITLE
[libosdp] update to 3.2.7

### DIFF
--- a/ports/libosdp/portfile.cmake
+++ b/ports/libosdp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osdp-dev/libosdp
     REF "v${VERSION}"
-    SHA512 6994d6d54d237d6783a9ad4bdd2f60afedcbcef2bf89b498101aa121b1aeea4108d35da639ced853c0c4bce2782a533ad00215706fa42822e7ea8acf023c65b9
+    SHA512 1035146f7527d405210e908b494e2d7bfc69216515ac59a05c502abf62c32451d13ef76549ca205b291cb3ccfddd42205c3d70b593dd1baf2351019a1732600f
     HEAD_REF master
     PATCHES
         fix-export-macros.patch
@@ -15,8 +15,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH UTILS_SOURCE_PATH
     REPO osdp-dev/c-utils
-    REF "33c08a2bf9ff7fb295677c28174180dec690270a"
-    SHA512 27c5841525d043983bffd1f8ca642dff649d98759db191a224662d149fa1d316518e0043b602177e07519720152896cbb7f15a82b37f3e8390caf4f5a73b6dc9
+    REF "86de31f9b3bf08ffbd1bde3e8cf66614e58a66f4"
+    SHA512 e5ffe68d9c7f102bcacd12167aa9c73f3012c2ec194ac6c8aeb4681f8384cf403fdc1ee4f8e4c198ce23acd1510504fa67c76bfb5da26fb0eea3d674d1bf253e
     HEAD_REF master
 )
 

--- a/ports/libosdp/vcpkg.json
+++ b/ports/libosdp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libosdp",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "An cross-platform open source implementation of IEC 60839-11-5 Open Supervised Device Protocol (OSDP)",
   "homepage": "https://github.com/osdp-dev/libosdp",
   "documentation": "https://doc.osdp.dev",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5493,7 +5493,7 @@
       "port-version": 0
     },
     "libosdp": {
-      "baseline": "3.2.6",
+      "baseline": "3.2.7",
       "port-version": 0
     },
     "libosip2": {

--- a/versions/l-/libosdp.json
+++ b/versions/l-/libosdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "952f0179705e51e8a34df90b1d2a7726b2980055",
+      "version": "3.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "76c5d8e03d3942f070336efdc405901ee562dd27",
       "version": "3.2.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/osdp-dev/libosdp/releases/tag/v3.2.7
