### PR TITLE
[matroska] Update to 1.7.2

### DIFF
--- a/ports/matroska/portfile.cmake
+++ b/ports/matroska/portfile.cmake
@@ -1,9 +1,17 @@
+vcpkg_download_distfile(LIBMATROSKA_BACKPORT_251_PATCH
+    URLS https://github.com/Matroska-Org/libmatroska/commit/9d2029cde9ad3218742be371f8563c1e79ad8096.patch?full_index=1
+    FILENAME libmatroska_backport_251.patch
+    SHA512 5be12bad95ba8ad6c3e75adb49742b994e7bde53e30f6dfe12eddbe702ff924762d3e1f03683223ed890be35b15a57913d685cf16c3a59b384ba00f380b26c9c
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Matroska-Org/libmatroska
-    REF release-1.7.1
-    SHA512 abb4fb4b527266944b1a59516866462498675c5e71bb679758894dff6156169d7132dddaa2e2ef6187a6dbce4a4aa377eeb75dd869268fd44933c769b34be5b9
+    REF "release-${VERSION}"
+    SHA512 3aa700786581ea9966e8354fa7177c8fc8a5d742ad753058217d0232e7933ba5812e71302aee7ccd8e86061444bc4cccd3bc972d644883ad2715c3f141fcc573
     HEAD_REF master
+    PATCHES
+        "${LIBMATROSKA_BACKPORT_251_PATCH}"
 )
 
 vcpkg_cmake_configure(
@@ -13,11 +21,12 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Matroska)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.LGPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_copy_pdbs()
-vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.LGPL"
+)

--- a/ports/matroska/vcpkg.json
+++ b/ports/matroska/vcpkg.json
@@ -1,14 +1,11 @@
 {
   "name": "matroska",
-  "version": "1.7.1",
-  "port-version": 3,
+  "version": "1.7.2",
   "description": "a C++ library to parse Matroska files (.mkv and .mka)",
   "homepage": "https://github.com/Matroska-Org/libmatroska",
+  "license": "LGPL-2.1-or-later",
   "dependencies": [
-    {
-      "name": "ebml",
-      "version>=": "1.4.4"
-    },
+    "ebml",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6537,8 +6537,8 @@
       "port-version": 0
     },
     "matroska": {
-      "baseline": "1.7.1",
-      "port-version": 3
+      "baseline": "1.7.2",
+      "port-version": 0
     },
     "mbedtls": {
       "baseline": "3.6.5",

--- a/versions/m-/matroska.json
+++ b/versions/m-/matroska.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e27d4c00bbdba8337ebaa09a90c647e8d818db4",
+      "version": "1.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c137704f5db042cc03e9530be29aa46d4cfadf05",
       "version": "1.7.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
