### PR TITLE
[lief] Update to 1.0.0

### DIFF
--- a/ports/lief/fix-cmakelists.patch
+++ b/ports/lief/fix-cmakelists.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1b9d3701..dc7557fd 100644
+index 334f6f83..7dd28e3c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -313,7 +313,9 @@ else()
-     ${CMAKE_CURRENT_BINARY_DIR}/include/LIEF/third-party/internal/span.hpp)
+@@ -301,7 +301,9 @@ else()
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/LIEF/third-party/internal/)
  endif()
  
 -target_link_libraries(LIB_LIEF PRIVATE lief_spdlog)
@@ -13,7 +13,7 @@ index 1b9d3701..dc7557fd 100644
  
  if(ANDROID AND LIEF_LOGGING)
    target_link_libraries(LIB_LIEF PUBLIC log)
-@@ -503,11 +505,11 @@ if(LIEF_INSTALL)
+@@ -507,11 +509,11 @@ if(LIEF_INSTALL)
    endif()
  
    install(

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
-    REF ${VERSION}
-    SHA512 3638269782215c7d24dc76a8e4178f5792dfeb97ea02f8b1bb2d33a199a4595478c2642f82c083fbdff4cd768e4da8c0fef0806865081239047fe5446437f4f2
-    HEAD_REF master
+    REF "${VERSION}"
+    SHA512 35d86d23306be0d9713fe6feb4632d83945a3e81557d12c6bdc23164818981dea30483d9ed7fdd5f8ba91803ceec716244f43527221e407f4b8fae021743e6a3
+    HEAD_REF main
     PATCHES
         fix-cmakelists.patch
         fix-liefconfig-cmake-in.patch

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lief",
-  "version-semver": "0.17.6",
+  "version-semver": "1.0.0",
   "description": "LIEF - Library to Instrument Executable Formats",
   "homepage": "https://lief.quarkslab.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6149,7 +6149,7 @@
       "port-version": 0
     },
     "lief": {
-      "baseline": "0.17.6",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "lightgbm": {

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b352c7b57dc2cc288d8219454de5e0b7e83ef5f9",
+      "version-semver": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5b30a6de1ec358078aac5507e19e11061b46a6ae",
       "version-semver": "0.17.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Requires MbedTLS >= 4.0.0