### PR TITLE
[ecbuild] Add BSL-1.0 license for contrib modules

### DIFF
--- a/ports/ecbuild/portfile.cmake
+++ b/ports/ecbuild/portfile.cmake
@@ -12,8 +12,7 @@ file(COPY
     "${SOURCE_PATH}/cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     PATTERN "Find*.cmake" EXCLUDE
-    PATTERN "GetGitRevisionDescription.cmake" EXCLUDE
-    PATTERN "GetGitRevisionDescription.cmake.in" EXCLUDE
+    PATTERN "contrib" EXCLUDE
 )
 
 file(COPY

--- a/ports/ecbuild/portfile.cmake
+++ b/ports/ecbuild/portfile.cmake
@@ -12,6 +12,8 @@ file(COPY
     "${SOURCE_PATH}/cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     PATTERN "Find*.cmake" EXCLUDE
+    PATTERN "GetGitRevisionDescription.cmake" EXCLUDE
+    PATTERN "GetGitRevisionDescription.cmake.in" EXCLUDE
 )
 
 file(COPY

--- a/ports/ecbuild/portfile.cmake
+++ b/ports/ecbuild/portfile.cmake
@@ -8,11 +8,17 @@ vcpkg_from_github(
     HEAD_REF develop
 )
 
+vcpkg_download_distfile(
+    BSL_LICENSE
+    URLS "https://raw.githubusercontent.com/boostorg/boost/boost-1.91.0/LICENSE_1_0.txt"
+    FILENAME "boost_LICENSE_1_0.txt"
+    SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
+)
+
 file(COPY
     "${SOURCE_PATH}/cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     PATTERN "Find*.cmake" EXCLUDE
-    PATTERN "contrib" EXCLUDE
 )
 
 file(COPY
@@ -40,4 +46,5 @@ file(INSTALL
 vcpkg_install_copyright(FILE_LIST
     "${SOURCE_PATH}/LICENSE"
     "${SOURCE_PATH}/NOTICE"
+    "${BSL_LICENSE}"
 )

--- a/ports/ecbuild/portfile.cmake
+++ b/ports/ecbuild/portfile.cmake
@@ -8,13 +8,6 @@ vcpkg_from_github(
     HEAD_REF develop
 )
 
-vcpkg_download_distfile(
-    BSL_LICENSE
-    URLS "https://raw.githubusercontent.com/boostorg/boost/boost-1.91.0/LICENSE_1_0.txt"
-    FILENAME "boost_LICENSE_1_0.txt"
-    SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
-)
-
 file(COPY
     "${SOURCE_PATH}/cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
@@ -46,5 +39,5 @@ file(INSTALL
 vcpkg_install_copyright(FILE_LIST
     "${SOURCE_PATH}/LICENSE"
     "${SOURCE_PATH}/NOTICE"
-    "${BSL_LICENSE}"
+    "${SOURCE_PATH}/cmake/contrib/GetGitRevisionDescription.cmake"
 )

--- a/ports/ecbuild/vcpkg.json
+++ b/ports/ecbuild/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ecbuild",
   "version": "3.15.2",
+  "port-version": 1,
   "description": "ECMWF CMake build system and CMake macro collection",
   "homepage": "https://github.com/ecmwf/ecbuild",
   "license": null

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2770,7 +2770,7 @@
     },
     "ecbuild": {
       "baseline": "3.15.2",
-      "port-version": 0
+      "port-version": 1
     },
     "eccodes": {
       "baseline": "2.48.0",

--- a/versions/e-/ecbuild.json
+++ b/versions/e-/ecbuild.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "752c089ba0bd967e187cfe8e894972eb52aa0620",
+      "version": "3.15.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "f542ed80708bc36e3e4fc018206641445f384f17",
       "version": "3.15.2",
       "port-version": 0

--- a/versions/e-/ecbuild.json
+++ b/versions/e-/ecbuild.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e79b9cd0c08a38415cf3888f2a9417bc99b81294",
+      "git-tree": "8b81f8320f598ff2863b7ff28873fd52351a9b39",
       "version": "3.15.2",
       "port-version": 1
     },

--- a/versions/e-/ecbuild.json
+++ b/versions/e-/ecbuild.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "752c089ba0bd967e187cfe8e894972eb52aa0620",
+      "git-tree": "e79b9cd0c08a38415cf3888f2a9417bc99b81294",
       "version": "3.15.2",
       "port-version": 1
     },

--- a/versions/e-/ecbuild.json
+++ b/versions/e-/ecbuild.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8b81f8320f598ff2863b7ff28873fd52351a9b39",
+      "git-tree": "2cbd816759f1034dab2a4f90dda22ba4c767c6a3",
       "version": "3.15.2",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The ecbuild package installs GetGitRevisionDescription.cmake and GetGitRevisionDescription.cmake.in as part of its CMake modules. These files are licensed under the Boost Software License 1.0.

These modules cannot be excluded from the package because they are used by ecbuild consumers. For example, eccodes includes GetGitRevisionDescription.cmake through ecbuild_system.cmake.

This change keeps the existing ecbuild package contents unchanged and adds the upstream BSL-1.0 licensing information to the package copyright information.

This follows up on the review comment in #53610.