### PR TITLE
[libconfuse] Update to 3.4

### DIFF
--- a/ports/libconfuse/portfile.cmake
+++ b/ports/libconfuse/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libconfuse/libconfuse/releases/download/v${VERSION}/confuse-${VERSION}.tar.xz"
     FILENAME "libconfuse-confuse-${VERSION}.tar.xz"
-    SHA512 93cc62d98166199315f65a2f6f540a9c0d33592b69a2c6a57fd17f132aecc6ece39b9813b96c9a49ae2b66a99b7eba1188a9ce9e360e1c5fb4b973619e7088a0
+    SHA512 3b53b8bbda339f8af479219f39a14b0772e33236b2f3cd6f2cf022b03bd8a580d2dd7595232cf0524b03a5d8884ca7481bdb33c49d15b5d0ee044af5add4011f
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"

--- a/ports/libconfuse/unofficial-libconfuse-config.cmake
+++ b/ports/libconfuse/unofficial-libconfuse-config.cmake
@@ -9,8 +9,8 @@ if(NOT TARGET unofficial::libconfuse::libconfuse)
         IMPORTED_LOCATION_RELEASE "${Z_VCPKG_libconfuse_LIBRARY_RELEASE}"
         IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
     )
-    if("@VCPKG_BUILD_TYPE@" STREQUAL "")
-        find_library(Z_VCPKG_libconfuse_LIBRARY_DEBUG NAMES libconfuse PATHS "${z_vcpkg_libconfuse_prefix}/debug/lib" NO_DEFAULT_PATH REQUIRED)
+    if(EXISTS "${z_vcpkg_libconfuse_prefix}/debug/lib")
+        find_library(Z_VCPKG_libconfuse_LIBRARY_DEBUG NAMES confuse PATHS "${z_vcpkg_libconfuse_prefix}/debug/lib" NO_DEFAULT_PATH REQUIRED)
         set_property(TARGET unofficial::libconfuse::libconfuse APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
         set_target_properties(unofficial::libconfuse::libconfuse PROPERTIES
             IMPORTED_LOCATION_DEBUG "${Z_VCPKG_libconfuse_LIBRARY_DEBUG}"

--- a/ports/libconfuse/vcpkg.json
+++ b/ports/libconfuse/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libconfuse",
-  "version": "3.3",
-  "port-version": 1,
+  "version": "3.4",
   "description": "Small configuration file parser library for C",
   "homepage": "https://github.com/libconfuse/libconfuse",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4877,8 +4877,8 @@
       "port-version": 0
     },
     "libconfuse": {
-      "baseline": "3.3",
-      "port-version": 1
+      "baseline": "3.4",
+      "port-version": 0
     },
     "libcopp": {
       "baseline": "2.3.2",

--- a/versions/l-/libconfuse.json
+++ b/versions/l-/libconfuse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "782cf4a5f4bc821fe84960395e31b4ff40d22442",
+      "version": "3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "9bdde41e2aa0e21eb18d8bc5c501e257418f7a26",
       "version": "3.3",
       "port-version": 1

--- a/versions/l-/libconfuse.json
+++ b/versions/l-/libconfuse.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "782cf4a5f4bc821fe84960395e31b4ff40d22442",
+      "git-tree": "56a8cd4c02f9411693618ebe09b742de792436d3",
       "version": "3.4",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
