### PR TITLE
[libfn] Add new port

### DIFF
--- a/ports/libfn/portfile.cmake
+++ b/ports/libfn/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DLIBFN_TESTS=OFF
+        -DDISABLE_CCACHE_DETECTION=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/libfn/portfile.cmake
+++ b/ports/libfn/portfile.cmake
@@ -1,0 +1,27 @@
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libfn/functional
+    REF "v${VERSION}"
+    SHA512 294f17fac30b6f2e13d636c2c53c3bd9535faead169c022abf19e91e88f4d6655ca99ce560d4f160252eabc2ef3090ffcd6006e0b5c2ee0d6c9ccd8e0a200077
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBFN_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libfn)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libfn/usage
+++ b/ports/libfn/usage
@@ -1,0 +1,8 @@
+libfn provides CMake targets:
+
+    find_package(libfn CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE libfn::pfn)  # C++20 standard-library polyfills
+    target_link_libraries(main PRIVATE libfn::fn)   # the functional library (C++20)
+
+    # C++26 mode (std::type_order); use instead of libfn::fn, never both:
+    target_link_libraries(main PRIVATE libfn::fn_cxx26)

--- a/ports/libfn/vcpkg.json
+++ b/ports/libfn/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libfn",
+  "version-semver": "0.1.0",
+  "description": "Functional programming in C++",
+  "homepage": "https://libfn.org",
+  "license": "ISC",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5064,6 +5064,10 @@
       "baseline": "1.5.0",
       "port-version": 0
     },
+    "libfn": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "libfontenc": {
       "baseline": "1.1.9",
       "port-version": 0

--- a/versions/l-/libfn.json
+++ b/versions/l-/libfn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c85f7f027645031f393a7d8b4698bd22bfecb69",
+      "git-tree": "70295bf541b8b8cd4298b7a123cfbc580f6fcde1",
       "version-semver": "0.1.0",
       "port-version": 0
     }

--- a/versions/l-/libfn.json
+++ b/versions/l-/libfn.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8c85f7f027645031f393a7d8b4698bd22bfecb69",
+      "version-semver": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds **libfn 0.1.0**, a header-only C++20 functional-programming library. It provides composable operations such as `and_then`, `transform`, and `or_else` for `expected`- and `optional`-style vocabulary types, and polyfills selected C++23 and C++26 facilities for C++20. This is the project's first tagged release; the port is submitted by the upstream maintainer.

Homepage: https://libfn.org — source: https://github.com/libfn/functional

Tested locally on `x64-linux` by installing this port in classic mode. The clean installation completed without post-build warnings, and the pinned SHA512 matched the `v0.1.0` tag archive.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development: publicly developed on GitHub since January 2024 (more than two and a half years).
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/libfn/versions
    - [x] The project is amongst the first web search results for "libfn" or "libfn C++": it publishes its documentation at https://libfn.org, and its GitHub organisation is `libfn`.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port: the only optional build dependency (Catch2, for unit tests) is disabled via `-DLIBFN_TESTS=OFF`.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says: `version-semver` matching the upstream SemVer tag `v0.1.0`.
- [x] The license declaration in `vcpkg.json` matches what upstream says: ISC, per upstream `LICENSE.md`.
- [x] The installed as the "copyright" file matches what upstream says: upstream's `LICENSE.md`, installed via `vcpkg_install_copyright`.
- [x] The source code of the component installed comes from an authoritative source: the upstream GitHub release tag, via `vcpkg_from_github`.
- [x] The generated "usage text" is brief and accurate: a custom usage file is provided because the port exports alternative targets (`libfn::fn`, `libfn::fn_cxx26`, `libfn::pfn`) whose roles the auto-generated text cannot explain.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
