### PR TITLE
[libevdev] Update to 1.13.7

### DIFF
--- a/ports/libevdev/portfile.cmake
+++ b/ports/libevdev/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libevdev/libevdev
     REF "libevdev-${VERSION}"
-    SHA512 4e3d81af35151b965410dd382482c0971b138c2432dd6c86fc843c4c5f697c36d0c30914f11575ca85d5e5f8c79cc27f2a2cdabe3ba04b8e28aa80ecf17bdfef
+    SHA512 2c43c0b2601b84b46fa585ab3fb903e8bb3d4838c3ed2245b6a42b7ecb32f6e2c25211327414d8019994ee29724a1edb06efc7a95480ea0f5cd7589efc515343
     HEAD_REF master
 )
 
@@ -17,5 +17,9 @@ vcpkg_configure_meson(
 
 vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libevdev/vcpkg.json
+++ b/ports/libevdev/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "libevdev",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "description": "Wrapper library for evdev devices",
-  "homepage": "https://www.freedesktop.org/wiki/Software/libevdev",
+  "homepage": "https://www.freedesktop.org/wiki/Software/libevdev/",
   "license": "MIT",
   "supports": "linux",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5025,7 +5025,7 @@
       "port-version": 5
     },
     "libevdev": {
-      "baseline": "1.13.6",
+      "baseline": "1.13.7",
       "port-version": 0
     },
     "libevent": {

--- a/versions/l-/libevdev.json
+++ b/versions/l-/libevdev.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5f35ea850aec1371addb4f3facfb0688a667e72",
+      "version": "1.13.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "57ce5037418bb6149d54369f90cdd405a5cd340a",
       "version": "1.13.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
