### PR TITLE
[casadi] Update to 3.8.0

### DIFF
--- a/ports/casadi/fmu-guard-fmi3.patch
+++ b/ports/casadi/fmu-guard-fmi3.patch
@@ -1,0 +1,17 @@
+diff --git a/casadi/core/fmu.cpp b/casadi/core/fmu.cpp
+index 3fc0082..e60b78f 100644
+--- a/casadi/core/fmu.cpp
++++ b/casadi/core/fmu.cpp
+@@ -778,7 +778,12 @@ Dict FmuInternal::compile_fmu(const std::string& name, const Dict& files, const
+   // Augment the file map with the compiled binary
+   // (FMI-3 layout: binaries/<dll_infix>/<modelIdentifier><suffix>)
+   Dict ret = files;
++#ifdef WITH_FMI3
+   ret[dll] = "binaries/" + Fmu3::dll_infix() + "/" + name + dll_suffix();
++#else  // WITH_FMI3
++  // Fmu3 is only compiled when FMI 3 support is enabled
++  casadi_error("CasADi was not compiled with WITH_FMI3=ON.");
++#endif  // WITH_FMI3
+   return ret;
+ }
+ 

--- a/ports/casadi/portfile.cmake
+++ b/ports/casadi/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO casadi/casadi
     REF "${VERSION}"
-    SHA512 ebd1d91f18b29620c8898fd014e35eefce2d621f9a698a14454b478cded78087bffa3651d808908a16ed8864571c7ddae99e387e53cb79a451ca60a8d690c8bb
+    SHA512 9706f0209333ff6636ec5fe545feaf9cb730e86356667d4f01ff922f8ed55094426f83a60ac54ea080143d879da8d1cb77bdfbd8c8eced757addfacbb03efc57
     HEAD_REF main
+    PATCHES
+        fmu-guard-fmi3.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -28,6 +30,12 @@ vcpkg_cmake_configure(
      -DENABLE_SHARED=${ENABLE_SHARED}
      -DWITH_DEEPBIND=${WITH_DEEPBIND}
      -DWITH_SELFCONTAINED=OFF
+     # CasADi compiles the vendored FMI standard headers (BSD-2-Clause) into the
+     # core library by default. They are not available as a separate package, so
+     # disable FMI import rather than redistribute third-party code from this port.
+     -DWITH_FMI2=OFF
+     -DWITH_FMI3=OFF
+     -DWITH_EXAMPLES=OFF
      -DWITH_TINYXML=OFF
      -DWITH_BUILD_TINYXML=OFF
      -DWITH_QPOASES=OFF
@@ -46,8 +54,6 @@ vcpkg_cmake_config_fixup()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
 vcpkg_fixup_pkgconfig()
-
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_copy_tools(TOOL_NAMES casadi-cli AUTO_CLEAN)

--- a/ports/casadi/usage
+++ b/ports/casadi/usage
@@ -1,4 +1,0 @@
-casadi provides CMake targets:
-
-  find_package(casadi CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE casadi::casadi)

--- a/ports/casadi/vcpkg.json
+++ b/ports/casadi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "casadi",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "description": "CasADi is a symbolic framework for numeric optimization implementing automatic differentiation in forward and reverse modes on sparse matrix-valued computational graphs. It supports self-contained C-code generation and interfaces state-of-the-art codes such as SUNDIALS, IPOPT etc. It can be used from C++, Python or Matlab/Octave.",
   "homepage": "https://web.casadi.org",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1621,7 +1621,7 @@
       "port-version": 0
     },
     "casadi": {
-      "baseline": "3.7.2",
+      "baseline": "3.8.0",
       "port-version": 0
     },
     "casclib": {

--- a/versions/c-/casadi.json
+++ b/versions/c-/casadi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57b079f64fbce90263313091f45b6ddaf732a0cc",
+      "version": "3.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec672097caf5dfd8a61b67b88000ffe18b78d31a",
       "version": "3.7.2",
       "port-version": 0


### PR DESCRIPTION
Updates casadi to 3.8.0.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

### Notes on this update

`-DWITH_EXAMPLES=OFF` is new. 3.8.0 added `install(TARGETS ${CASADI_CPP_EXAMPLE_TARGETS} RUNTIME ...)` to `docs/examples/cplusplus/CMakeLists.txt`, which 3.7.2 did not have; without this the port installs `callback.exe`, `daebuilder.exe`, `test_linsol.exe` and friends into `bin/` and fails post-build validation on Windows.

`ports/casadi/portfile.cmake` and `ports/casadi/usage` were converted from CRLF to LF — they were already CRLF on master, and "Check For Common Mistakes" fails on them once the PR touches this port. This is why the portfile shows as fully rewritten in the diff.

### Addressing review feedback

**FMI licensing.** Fixed by disabling the feature rather than redistributing the headers: `-DWITH_FMI2=OFF -DWITH_FMI3=OFF`. This follows the "avoid building vendored third-party code" half of the comment — the FMI standard headers are not available as a separate package, so there is nothing to depend on instead. With this, the port compiles no vendored third-party code at all (SUNDIALS, CSparse, TinyXML and qpOASES were already off), and `LGPL-3.0-only` remains accurate, so no SPDX change is needed.

Verified: `fmu2.cpp`/`fmu3.cpp` are no longer compiled, no `fmi*` headers are installed, and the feature summary lists `dynamic-loading` under disabled features. Users who need FMU import get a clear `casadi_error("CasADi was not compiled with WITH_FMI3=ON.")` rather than a silent failure.

This required one patch: `WITH_FMI3=OFF` does not build in 3.8.0, because `FmuInternal::compile_fmu` in `casadi/core/fmu.cpp` calls `Fmu3::dll_infix()` outside any `#ifdef WITH_FMI3`, giving `error: 'Fmu3' has not been declared`. `fmu-guard-fmi3.patch` guards that one use in the same style the rest of the file already uses. I will upstream this to casadi/casadi.

**Usage.** Removed the custom `usage` file, so `vcpkg print-usage` now advertises both integrations:

```
casadi provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(casadi CONFIG REQUIRED)
  target_link_libraries(main PRIVATE casadi::casadi)

casadi provides pkg-config modules:

  # CasADi is a symbolic framework for automatic differentation and numeric optimization
  casadi
```

Thanks for jgillis#1 — I took the usage change from it, but went the disable route on FMI instead of packaging the BSD-2-Clause notice, so I did not merge it directly. Happy to switch to the notice-packaging approach instead if you would rather keep FMI import available in the port.
