### PR TITLE
[libgcrypt] Update to 1.12.3

### DIFF
--- a/ports/libgcrypt/portfile.cmake
+++ b/ports/libgcrypt/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libgcrypt/libgcrypt-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-${VERSION}.tar.bz2"
     FILENAME "libgcrypt-${VERSION}.tar.bz2"
-    SHA512 dc1a4a6c00a0d84d90c8d71f4bd121b968c80df74137d6e8867f1f4cc014a539efb5238c1a1429d7cb95e493a40718fc19252edc592ffe0f43057b372896591c
+    SHA512 84c150730af55669e35d3d9109250ae28175da1b506de84117701464ac5c7e542163977a1eb2e5df4cdaa8c723ea759aa8c004cccc98251902482aff7f847cad
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/libgcrypt/vcpkg.json
+++ b/ports/libgcrypt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgcrypt",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "A general purpose cryptographic library",
   "homepage": "https://gnupg.org/software/libgcrypt/index.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5093,7 +5093,7 @@
       "port-version": 1
     },
     "libgcrypt": {
-      "baseline": "1.12.2",
+      "baseline": "1.12.3",
       "port-version": 0
     },
     "libgd": {

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb87aba1a084551931c8824404a5ff0d28682709",
+      "version": "1.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "574d01b93c781b96bc4959dd6e8ee02311f7fb75",
       "version": "1.12.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
