### PR TITLE
[libheif] Updated to 1.23.2

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif
     REF "v${VERSION}"
-    SHA512 ebb0bf74d6d1ae2d39a7cefcec0f4a04006fee330e147c49c863f6d4febb45e82ccebf36cc4e30812bd3591918ee8964fbde9a3a4793c5f60eaf30a0e011add0
+    SHA512 d34ccd40d7f7cc48ff8ceddafd8f7c7004ab0df2a657237fcc715c4bcc453a41946d7db542d32b781875868ee116c451b4b63daaf073530245ec7b117ae60e27
     HEAD_REF master
     PATCHES
         cxx-linkage-pkgconfig.diff

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5165,7 +5165,7 @@
       "port-version": 6
     },
     "libheif": {
-      "baseline": "1.23.1",
+      "baseline": "1.23.2",
       "port-version": 0
     },
     "libhsplasma": {

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da740142258a17ed12fa5f9a4576f729134539dd",
+      "version": "1.23.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a4d0b31b548a530cf2dd30307bc1fb912644d45",
       "version": "1.23.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
