### PR TITLE
[libmysofa] Updated to 1.3.5

### DIFF
--- a/ports/libmysofa/dependencies.diff
+++ b/ports/libmysofa/dependencies.diff
@@ -9,10 +9,10 @@ index 3c597fa..b09b0b7 100644
 -#Requires.private:
 +Requires.private: zlib
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index cc800b3..29e9b5d 100644
+index 37fe41f..66978a9 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -4,23 +4,19 @@ configure_file(config.h.in config.h)
+@@ -4,29 +4,13 @@ configure_file(config.h.in config.h)
  include_directories(${CMAKE_CURRENT_BINARY_DIR})
  
  if(NOT MSVC)
@@ -22,26 +22,26 @@ index cc800b3..29e9b5d 100644
 -    set(MATH "")
 -  endif()
 -  include(FindZLIB)
+-  include_directories(${ZLIB_INCLUDE_DIRS})
 +  find_library(HAVE_MATH m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
-+endif()
-+if(HAVE_MATH)
-+  set(MATH m)
-+  string(APPEND PKG_CONFIG_PRIVATELIBS " -lm")
+   set(PKG_CONFIG_PRIVATELIBS "-lm ${PKG_CONFIG_PRIVATELIBS}")
+-  set(PKG_CONFIG_PRIVATELIBS "-lz ${PKG_CONFIG_PRIVATELIBS}")
  else()
    set(MATH "")
 -  find_program(NUGET nuget)
--  if(NUGET)
+-  if(NOT NUGET)
+-    message(
+-      FATAL
+-      "Cannot find nuget command line tool.\nInstall it with e.g. choco install nuget.commandline"
+-    )
+-  else()
 -    execute_process(COMMAND ${NUGET} install zlib)
 -  endif()
 -  include_directories(
--    ${PROJECT_SOURCE_DIR}/windows/third-party/zlib-1.2.11/include/)
+-    ${PROJECT_SOURCE_DIR}/windows/third-party/zlib-1.3.1/include/)
  endif()
 +find_package(ZLIB REQUIRED)
 +set(ZLIB_LIBRARIES ZLIB::ZLIB)
  
--if(NOT MSVC)
-+if(1)
-+elseif(0) # redundant
-   if(NOT WIN32)
-     find_library(MATH m)
-   else()
+ set(libsrc
+     hrtf/reader.c

--- a/ports/libmysofa/dependencies.diff
+++ b/ports/libmysofa/dependencies.diff
@@ -1,20 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d830c6..214a82f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,10 @@ set(CPACK_PACKAGE_VERSION_PATCH "3")
+ set(CPACK_DEBIAN_PACKAGE_DEPENDS "zlib1g")
+ 
+ set(PKG_CONFIG_PRIVATELIBS "")
++set(PKG_CONFIG_LIBNAME mysofa)
++if(WIN32 AND BUILD_SHARED_LIBS)
++  set(PKG_CONFIG_LIBNAME mysofa_shared)
++endif()
+ 
+ set(PROJECT_VERSION
+     "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
 diff --git a/libmysofa.pc.cmake b/libmysofa.pc.cmake
-index 3c597fa..b09b0b7 100644
+index 3c597fa..091ce79 100644
 --- a/libmysofa.pc.cmake
 +++ b/libmysofa.pc.cmake
-@@ -8,4 +8,4 @@ Libs: -L${libdir} -lmysofa
+@@ -4,8 +4,8 @@ Version: @PROJECT_VERSION@
+ Requires: @PKG_CONFIG_REQUIRES@
+ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+-Libs: -L${libdir} -lmysofa
++Libs: -L${libdir} -l@PKG_CONFIG_LIBNAME@
  Cflags: -I${includedir}
  
  Libs.private: @PKG_CONFIG_PRIVATELIBS@
 -#Requires.private:
 +Requires.private: zlib
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 37fe41f..66978a9 100644
+index 37fe41f..3df874e 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -4,29 +4,13 @@ configure_file(config.h.in config.h)
+@@ -3,30 +3,16 @@ set(CMAKE_C_STANDARD 99)
+ configure_file(config.h.in config.h)
  include_directories(${CMAKE_CURRENT_BINARY_DIR})
  
++set(MATH "")
  if(NOT MSVC)
 -  if(NOT WIN32)
 -    find_library(MATH m)
@@ -23,11 +45,10 @@ index 37fe41f..66978a9 100644
 -  endif()
 -  include(FindZLIB)
 -  include_directories(${ZLIB_INCLUDE_DIRS})
-+  find_library(HAVE_MATH m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
-   set(PKG_CONFIG_PRIVATELIBS "-lm ${PKG_CONFIG_PRIVATELIBS}")
+-  set(PKG_CONFIG_PRIVATELIBS "-lm ${PKG_CONFIG_PRIVATELIBS}")
 -  set(PKG_CONFIG_PRIVATELIBS "-lz ${PKG_CONFIG_PRIVATELIBS}")
- else()
-   set(MATH "")
+-else()
+-  set(MATH "")
 -  find_program(NUGET nuget)
 -  if(NOT NUGET)
 -    message(
@@ -36,7 +57,11 @@ index 37fe41f..66978a9 100644
 -    )
 -  else()
 -    execute_process(COMMAND ${NUGET} install zlib)
--  endif()
++  find_library(HAVE_MATH m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++  if(HAVE_MATH)
++    set(MATH m)
++    string(APPEND PKG_CONFIG_PRIVATELIBS " -lm")
+   endif()
 -  include_directories(
 -    ${PROJECT_SOURCE_DIR}/windows/third-party/zlib-1.3.1/include/)
  endif()

--- a/ports/libmysofa/fix-package-version.diff
+++ b/ports/libmysofa/fix-package-version.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d830c6..90bb680 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,7 @@ set(CPACK_GENERATOR "DEB")
+ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "IOhannes m zmölnig")
+ set(CPACK_PACKAGE_VERSION_MAJOR "1")
+ set(CPACK_PACKAGE_VERSION_MINOR "3")
+-set(CPACK_PACKAGE_VERSION_PATCH "3")
++set(CPACK_PACKAGE_VERSION_PATCH "5")
+ set(CPACK_DEBIAN_PACKAGE_DEPENDS "zlib1g")
+ 
+ set(PKG_CONFIG_PRIVATELIBS "")

--- a/ports/libmysofa/portfile.cmake
+++ b/ports/libmysofa/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         dependencies.diff
+        fix-package-version.diff
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/windows/third-party")
 
@@ -32,4 +33,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/src/resampler/speex_resampler.c"
+        "${SOURCE_PATH}/src/hrtf/kdtree.c"
+)

--- a/ports/libmysofa/portfile.cmake
+++ b/ports/libmysofa/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hoene/libmysofa
     REF "v${VERSION}"
-    SHA512 58bd056678503491292a8a9b6b3f43451995a2c0a16735e4ae474d2d3e49bd7b3d6ef3dbfd0ce78e30d9f70887dd9cac60a8fae05ece0c167414f8ac4d3d5514
+    SHA512 83f9b592b92984108ae1c43257d569320bf1b2c7b919563be2b92b0ec5396a4b2b9ad8dca579a2ad224c560c055fba8e77ca65d222e1944618a2819a0a8aa63c
     HEAD_REF main
     PATCHES
         dependencies.diff

--- a/ports/libmysofa/vcpkg.json
+++ b/ports/libmysofa/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmysofa",
-  "version": "1.3.4",
-  "port-version": 1,
+  "version": "1.3.5",
   "description": "Reader for AES SOFA files to get better HRTFs (Head-Relative Transfer Functions)",
   "homepage": "https://github.com/hoene/libmysofa",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5401,8 +5401,8 @@
       "port-version": 3
     },
     "libmysofa": {
-      "baseline": "1.3.4",
-      "port-version": 1
+      "baseline": "1.3.5",
+      "port-version": 0
     },
     "libmysql": {
       "baseline": "8.0.46",

--- a/versions/l-/libmysofa.json
+++ b/versions/l-/libmysofa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c97104c484df4bcc22831e7dad0bb27a33b1c2f3",
+      "version": "1.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "cea6a1df1f1abdabbe88ded1d501b0b4825ca812",
       "version": "1.3.4",
       "port-version": 1

--- a/versions/l-/libmysofa.json
+++ b/versions/l-/libmysofa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c97104c484df4bcc22831e7dad0bb27a33b1c2f3",
+      "git-tree": "bc37834cc754461022eb70ca6f167fdd491f634c",
       "version": "1.3.5",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
