### PR TITLE
Update slick logger 1.2.0

### DIFF
--- a/ports/coinbase-advanced-cpp/disable-config-fetchcontent-fallback.patch
+++ b/ports/coinbase-advanced-cpp/disable-config-fetchcontent-fallback.patch
@@ -1,69 +1,27 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 998f666..2738a32 100644
+index c4148db..ccabb6c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -21,15 +21,15 @@ find_package(nlohmann_json CONFIG REQUIRED)
+@@ -21,8 +21,8 @@ find_package(nlohmann_json CONFIG REQUIRED)
  find_package(OpenSSL CONFIG REQUIRED)
  find_package(jwt-cpp CONFIG REQUIRED)
  
--find_package(slick-net 3.0.0 CONFIG QUIET)
+-find_package(slick-net 3.1.0 CONFIG QUIET)
 -if (NOT slick-net_FOUND)
--    message(STATUS "fetching slick-net...")
--    include(FetchContent)
--    set(BUILD_SLICK_NET_EXAMPLES OFF CACHE BOOL "" FORCE)
--    set(BUILD_SLICK_NET_TESTS OFF CACHE BOOL "" FORCE)
--    FetchContent_Declare(
--        slick-net
--        GIT_REPOSITORY https://github.com/SlickQuant/slick-net.git
-+find_package(slick-net 3.0.0 CONFIG REQUIRED)
++find_package(slick-net CONFIG REQUIRED)
 +if (FALSE)
-+    message(STATUS "fetching slick-net...")
-+    include(FetchContent)
-+    set(BUILD_SLICK_NET_EXAMPLES OFF CACHE BOOL "" FORCE)
-+    set(BUILD_SLICK_NET_TESTS OFF CACHE BOOL "" FORCE)
-+    FetchContent_Declare(
-+        slick-net
-+        GIT_REPOSITORY https://github.com/SlickQuant/slick-net.git
-         GIT_TAG v3.0.0
-     )
-     FetchContent_MakeAvailable(slick-net)
-@@ -50,7 +50,7 @@ target_include_directories(coinbase-advanced-cpp PUBLIC
-     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-     $<INSTALL_INTERFACE:include>
- )
--target_link_libraries(coinbase-advanced-cpp PUBLIC slick::net jwt-cpp::jwt-cpp)
-+target_link_libraries(coinbase-advanced-cpp PUBLIC slick::net jwt-cpp::jwt-cpp)
- 
- # PRIVATE precompiled headers for faster static library compilation
- target_precompile_headers(coinbase-advanced-cpp PRIVATE
+     message(STATUS "fetching slick-net...")
+     include(FetchContent)
+     set(BUILD_SLICK_NET_EXAMPLES OFF CACHE BOOL "" FORCE)
 diff --git a/cmake/coinbase-advanced-cppConfig.cmake.in b/cmake/coinbase-advanced-cppConfig.cmake.in
-index dfd8267..0cf7b1f 100644
+index bb101f7..0cf7b1f 100644
 --- a/cmake/coinbase-advanced-cppConfig.cmake.in
 +++ b/cmake/coinbase-advanced-cppConfig.cmake.in
-@@ -2,23 +2,10 @@
- 
- include(CMakeFindDependencyMacro)
- 
--find_dependency(nlohmann_json CONFIG REQUIRED)
--find_dependency(OpenSSL CONFIG REQUIRED)
--find_dependency(jwt-cpp CONFIG REQUIRED)
--
--find_dependency(slick-net 3.0.0 CONFIG QUIET)
--if(NOT slick-net_FOUND)
--    message(STATUS "Fetching slick-net...")
--    include(FetchContent)
--    set(BUILD_SLICK_NET_EXAMPLES OFF CACHE BOOL "" FORCE)
--    set(BUILD_SLICK_NET_TESTS OFF CACHE BOOL "" FORCE)
--    FetchContent_Declare(
--        slick-net
--        GIT_REPOSITORY https://github.com/SlickQuant/slick-net.git
--        GIT_TAG v3.0.0
--    )
--    FetchContent_MakeAvailable(slick-net)
--endif()
-+find_dependency(nlohmann_json CONFIG)
-+find_dependency(OpenSSL CONFIG)
-+find_dependency(jwt-cpp CONFIG)
+@@ -5,7 +5,7 @@ include(CMakeFindDependencyMacro)
+ find_dependency(nlohmann_json CONFIG)
+ find_dependency(OpenSSL CONFIG)
+ find_dependency(jwt-cpp CONFIG)
+-find_dependency(slick-net 3.0.0 CONFIG)
 +find_dependency(slick-net CONFIG)
  
  include("${CMAKE_CURRENT_LIST_DIR}/coinbase-advanced-cppTargets.cmake")

--- a/ports/coinbase-advanced-cpp/portfile.cmake
+++ b/ports/coinbase-advanced-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/coinbase-advanced-cpp
     REF "v${VERSION}"
-    SHA512 6d7425668a1f7c0517bd766f61fb9e4e2223ec5b2946934d2667ddd07c25b5d788b22bbbbabd761dd06394b9de491c5cc05effd5c77595423d5063ae244f1d38
+    SHA512 b938d9dd0b1b0a6de0bc33b8c8003d1594a294fc81b9a42c4f1cf4b254a261e42f91df8dbb07ad586f642e524b67ea3bca07652e8dc3aca2df9d4ca9fda5959b
     HEAD_REF main
     PATCHES
         disable-config-fetchcontent-fallback.patch # also https://github.com/SlickQuant/coinbase-advanced-cpp/pull/1

--- a/ports/coinbase-advanced-cpp/vcpkg.json
+++ b/ports/coinbase-advanced-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase-advanced-cpp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "C++20 SDK for the Coinbase Advanced API (REST + WebSocket).",
   "homepage": "https://github.com/SlickQuant/coinbase-advanced-cpp",
   "license": "MIT",

--- a/ports/slick-logger/portfile.cmake
+++ b/ports/slick-logger/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-logger
     REF "v${VERSION}"
-    SHA512 00159e819ac974fa568aab0475d539ac8949fe999ec280c21ace271e510204a2413edc298281dfc51c699e2eb8be8ace5003e3daa7e88e394cf13bc0f6da2bce
+    SHA512 4b721d3c1fd130e1af0d5e327be4ef24e15556ba1c871124afd2db79f6a986057be02ab925137ed8c578cf16c4070b3d837d6d4b338bac4777b0dea6b9c801d0
     HEAD_REF main
     PATCHES
       slick-queue.patch

--- a/ports/slick-logger/slick-queue.patch
+++ b/ports/slick-logger/slick-queue.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e3c0913..efbb93b 100644
+index c47da23..03e2f1e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -7,9 +7,9 @@ project(slick-logger
- set(CMAKE_CXX_STANDARD 20)
- set(CMAKE_CXX_STANDARD_REQUIRED ON)
+@@ -9,9 +9,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
  
--find_package(slick-queue 1.2.2 CONFIG QUIET)
+ # 1.5.0 or newer is required: multi-process logging relies on the slick-shm based
+ # shared-memory implementation introduced in slick-queue 1.3.0.
+-find_package(slick-queue 1.5.0 CONFIG QUIET)
 +find_package(slick-queue CONFIG REQUIRED)
  
 -if (NOT slick-queue_FOUND)
@@ -15,14 +15,14 @@ index e3c0913..efbb93b 100644
      include(FetchContent)
  
 diff --git a/cmake/slick-loggerConfig.cmake.in b/cmake/slick-loggerConfig.cmake.in
-index 7ea75d1..4c30d13 100644
+index d7160a7..4c30d13 100644
 --- a/cmake/slick-loggerConfig.cmake.in
 +++ b/cmake/slick-loggerConfig.cmake.in
 @@ -3,7 +3,7 @@
  include(CMakeFindDependencyMacro)
  
  # Find slick-queue dependency
--find_dependency(slick-queue 1.2.2 CONFIG)
+-find_dependency(slick-queue 1.5.0 CONFIG)
 +find_dependency(slick-queue CONFIG)
  
  include("${CMAKE_CURRENT_LIST_DIR}/slick-loggerTargets.cmake")

--- a/ports/slick-logger/vcpkg.json
+++ b/ports/slick-logger/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-logger",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "A high-performance, cross-platform header-only logging library for C++20 using a multi-producer, multi-consumer ring buffer with multi-sink support and log rotation capabilities",
   "homepage": "https://github.com/SlickQuant/slick-logger",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9453,7 +9453,7 @@
       "port-version": 0
     },
     "slick-logger": {
-      "baseline": "1.1.4",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "slick-net": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1921,7 +1921,7 @@
       "port-version": 1
     },
     "coinbase-advanced-cpp": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "coinutils": {

--- a/versions/c-/coinbase-advanced-cpp.json
+++ b/versions/c-/coinbase-advanced-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68e51cce3495fda41c4b9614a96765ad13d0fb11",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cecf48d1ba0e92996783777734fa6b453eb1ef14",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/s-/slick-logger.json
+++ b/versions/s-/slick-logger.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2dd8e6e4dbf5e5548f7ed3a34d9b1a1f28a8b61",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6bf887666668a0da3a337ebe77d71ca6584effe1",
       "version": "1.1.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
