### PR TITLE
[appstream,libsystemd] Fix gperf host exe suffix

### DIFF
--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_configure_meson(
       -Dsvg-support=false
       -Dgir=false
     ADDITIONAL_BINARIES
-       gperf='${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}'
+       gperf='${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${VCPKG_HOST_EXECUTABLE_SUFFIX}'
        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
        glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
 )

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "appstream",
   "version": "1.0.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Tools and libraries to work with AppStream metadata",
   "homepage": "https://www.freedesktop.org/software/appstream/docs",
   "license": "LGPL-2.1-or-later",

--- a/ports/libsystemd/portfile.cmake
+++ b/ports/libsystemd/portfile.cmake
@@ -70,7 +70,7 @@ vcpkg_configure_meson(
     -Dxz=enabled
     -Dzstd=enabled
   ADDITIONAL_BINARIES
-    "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}']"
+    "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${VCPKG_HOST_EXECUTABLE_SUFFIX}']"
 )
 
 vcpkg_install_meson()

--- a/ports/libsystemd/vcpkg.json
+++ b/ports/libsystemd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsystemd",
   "version": "260.2",
+  "port-version": 1,
   "description": "System and Service Manager",
   "homepage": "https://github.com/systemd/systemd",
   "license": null,

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2182b86b07b1485610687ea2ba45a79a558ae8c8",
+      "version": "1.0.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "ec534369136985b55e67821d956d3c8934ca9035",
       "version": "1.0.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -194,7 +194,7 @@
     },
     "appstream": {
       "baseline": "1.0.6",
-      "port-version": 1
+      "port-version": 2
     },
     "appstream-glib": {
       "baseline": "0.8.3",
@@ -5782,7 +5782,7 @@
     },
     "libsystemd": {
       "baseline": "260.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libtar": {
       "baseline": "1.2.20",

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1072db3cabd1e7588178438f5fb44d717c100f47",
+      "version": "260.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "48f7900671bc8214fd530c415f8660b7ed4f0e2b",
       "version": "260.2",
       "port-version": 0


### PR DESCRIPTION
Spotted once, enumerated with `git grep '[^_]HOST_EXECUTABLE_SUFFIX'`.