### PR TITLE
[usd] Add custom usage file with CMake and plugin deployment guidance

### DIFF
--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -89,7 +89,6 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         )
     foreach(debug_target IN LISTS debug_targets)
         file(READ "${debug_target}" contents)
-        string(REPLACE "\${_IMPORT_PREFIX}/usd" "\${_IMPORT_PREFIX}/debug/usd" contents "${contents}")
         string(REPLACE "\${_IMPORT_PREFIX}/plugin" "\${_IMPORT_PREFIX}/debug/plugin" contents "${contents}")
         file(WRITE "${debug_target}" "${contents}")
     endforeach()
@@ -130,3 +129,5 @@ endif()
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE.txt)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/usd/usage
+++ b/ports/usd/usage
@@ -1,0 +1,39 @@
+usd provides CMake targets:
+
+  find_package(pxr CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE usd sdf usdGeom)
+
+  # pxr exports many library targets (usd, sdf, tf, gf, usdGeom, usdShade,
+  # usdLux, ...) without a namespace prefix. Link only the libraries your
+  # application needs.
+
+USD discovers plugins at runtime via plugInfo.json registries. When deploying
+an application, copy the USD libraries and plugin directories from the vcpkg
+installed tree. The paths below are the release paths; the debug artifacts are
+installed under debug/ (debug/bin/*.dll, debug/lib/usd/, debug/plugin/usd/,
+...):
+
+  Windows:
+    bin/*.dll         (USD libraries you linked against, and their dependencies)
+    bin/usd/          (top-level plugInfo.json and core library resource registries)
+    plugin/usd/       (MODULE plugin DLLs)
+
+  Unix:
+    lib/*.so*         (USD libraries you linked against, and their dependencies;
+                       .dylib on macOS)
+    lib/usd/          (top-level plugInfo.json and core library resource registries)
+    plugin/usd/       (MODULE plugin shared objects)
+
+Keep the relative layout of these directories intact: Plug anchors its default
+search paths to the directory holding the loaded USD libraries and looks for
+"<that directory>/usd/" and "<that directory>/../plugin/usd/". Set the
+PXR_PLUGINPATH_NAME environment variable if your application uses a different
+layout.
+
+On Windows, the top-level plugInfo.json must be deployed under bin/usd/ next to
+the USD libraries so Plug can discover core library plugins.
+
+Optional port features install additional MODULE plugins under plugin/usd/.
+For example, imaging adds Hydra and imaging plugins, and usd[imaging,openimageio]
+adds the hioOiio image I/O plugin. The hioOiio plugin is only built when imaging
+is enabled, so openimageio alone does not install it.

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "usd",
   "version": "26.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenUSD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10542,7 +10542,7 @@
     },
     "usd": {
       "baseline": "26.8",
-      "port-version": 1
+      "port-version": 2
     },
     "usearch": {
       "baseline": "2.25.3",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc84012554f407e8c6ca5dd1a57f04d27e0cc374",
+      "version": "26.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "6e450855d40c813b9e8e936f1ea3794ac419d744",
       "version": "26.8",
       "port-version": 1


### PR DESCRIPTION
This PR includes:
1. Add a custom `ports/usd/usage` file because auto-generated usage only mentions `TBB::tbb` and omits USD library targets.
2. Document `find_package(pxr CONFIG REQUIRED)`, typical link targets, and runtime plugin/`plugInfo.json` deployment requirements (including Windows).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
