### PR TITLE
[ace] Upgrade to ACE 8.0.7 and TAO 4.0.7

### DIFF
--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -8,14 +8,14 @@ if("tao" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE%2BTAO-src-${VERSION}.tar.gz"
         FILENAME "ACE-TAO-src-${VERSION}.tar.gz"
-        SHA512 955fa4de8df23fb0b91c3d7b3d6a23c2e16b15d16305efda874688bfa1cd3c9f6f7997d2cc19585daab1781bba7daca397179453d652edfc06b513f6028518c6
+        SHA512 b2fa92611742a5752e36e9a7af6c8e44b4c7aa9dd5aa145cb08cf60f9bb7c2b04c52017c1b5870bc01d293afa8c33f8cf7ad21698178900cf22283ff25f052c4
     )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 eb7ac914438136cf98a3952bdd1d43543729019812b13509a6d805465f9016ec866dc6f07aed0a489555d3ac54c1ebe931ffd74a0687e29086bc5b063ab25cbc
+        SHA512 82d248887280848f1839a9808f7015afa0c354ff096bfaa411e14de4ef657a0193a3f4be85a67a72e0b5b461eaddc8605d9953bbcd75bbbc564beafe0935a530
     )
 endif()
 

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ace",
-  "version": "8.0.6",
+  "version": "8.0.7",
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/ports/ace/zlib.patch
+++ b/ports/ace/zlib.patch
@@ -1,15 +1,10 @@
 diff --git a/MPC/config/zlib.mpb b/MPC/config/zlib.mpb
-index 731935a..af8ee02 100644
+index 8edc952e..af8ee020 100644
 --- a/MPC/config/zlib.mpb
 +++ b/MPC/config/zlib.mpb
-@@ -14,9 +14,16 @@ feature(zlib) {
-   macros   += ZLIB
- 
-   specific(prop:windows) {
--    Debug::lit_libs += zlibd
--    Release::lit_libs += zlib
-+    Debug::lit_libs += zd
-+    Release::lit_libs += z
+@@ -17,6 +17,13 @@ feature(zlib) {
+     Debug::lit_libs += zd
+     Release::lit_libs += z
    } else {
 -    lit_libs += z
 +    Debug::lit_libs += zd

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76aceafae21b4305fb499facc028b1269cee5b2c",
+      "version": "8.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "7e3ab66fd54d2cb0695689595627cf0af27fea0f",
       "version": "8.0.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -29,7 +29,7 @@
       "port-version": 1
     },
     "ace": {
-      "baseline": "8.0.6",
+      "baseline": "8.0.7",
       "port-version": 0
     },
     "acl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
