### PR TITLE
[liborigin] Update to 3.0.4

### DIFF
--- a/ports/liborigin/portfile.cmake
+++ b/ports/liborigin/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${LIB_OPTION}
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
 )
 
 vcpkg_cmake_build()

--- a/ports/liborigin/portfile.cmake
+++ b/ports/liborigin/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO liborigin
     REF liborigin/3.0
-    FILENAME liborigin-${VERSION}.tar.gz
-    SHA512 44157e1a5c71d7344e58c4702a43fd315978bff74992e1d7c568517c0685f617062777c791d6089872197d30f20cc06617aa4bd31d6a458df97b27eacf2f0f19
+    FILENAME "liborigin-${VERSION}.tar.gz"
+    SHA512 3b0d02c39bd4d0faa28808feb943c6dd696532b9391bc0a2fd55732931a18c8d1a66e38f520ad6cbdaecb0c33149a5e2b873403cc8a663b46e0f5a7db3d2b14f
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -12,7 +12,8 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${LIB_OPTION}
+    OPTIONS
+        ${LIB_OPTION}
 )
 
 vcpkg_cmake_build()
@@ -23,7 +24,9 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_tools(TOOL_NAMES opj2dat AUTO_CLEAN)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/liborigin/vcpkg.json
+++ b/ports/liborigin/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.0.4",
   "description": "A library for reading OriginLab OPJ project files.",
   "homepage": "https://sourceforge.net/projects/liborigin/",
-  "license": "GPL-2.0-or-later",
+  "license": "GPL-3.0-only",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/liborigin/vcpkg.json
+++ b/ports/liborigin/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liborigin",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A library for reading OriginLab OPJ project files.",
   "homepage": "https://sourceforge.net/projects/liborigin/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5489,7 +5489,7 @@
       "port-version": 0
     },
     "liborigin": {
-      "baseline": "3.0.3",
+      "baseline": "3.0.4",
       "port-version": 0
     },
     "libosdp": {

--- a/versions/l-/liborigin.json
+++ b/versions/l-/liborigin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc41c3df1dbf926327a919f5b8fed28f0358fde9",
+      "version": "3.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "92e85debf95656205186d96dfae6d44a9d6059ba",
       "version": "3.0.3",
       "port-version": 0

--- a/versions/l-/liborigin.json
+++ b/versions/l-/liborigin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc41c3df1dbf926327a919f5b8fed28f0358fde9",
+      "git-tree": "a778411b519e9baaa180a738202e5b9903bcc9a3",
       "version": "3.0.4",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
