### PR TITLE
[gdbm] Update to 1.26

### DIFF
--- a/ports/gdbm/fix-readline-linkage.patch
+++ b/ports/gdbm/fix-readline-linkage.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index d7458e6..18fae46 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -122,7 +122,7 @@ AC_CHECK_MEMBERS([struct stat.st_blksize, struct stat.st_mtim, struct stat.st_mt
+ AM_CONDITIONAL([COMPAT_OPT], [test "$want_compat" = yes])
+ 
+ # Check for Curses libs.
+-for lib in ncurses curses termcap
++for lib in ncursesw ncurses curses termcap
+ do
+   AC_CHECK_LIB($lib, tputs, [CURSES_LIBS="-l$lib"; break])
+ done

--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix-readline-linkage.patch
 )
 
 vcpkg_list(SET options)

--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_download_distfile(ARCHIVE
          "https://ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
          "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
     FILENAME "gdbm-${VERSION}.tar.gz"
-    SHA512 401ff8c707079f21da1ac1d6f4714a87f224b6f41943078487dc891be49f51fd1ac7a32fd599aae0fad185f2c6ba7432616d328fd6aaab068eb54db9562ff7fa
+    SHA512 44aafe254f0950a8f5215d8f1337674f07b19f2a375f6eb19a7e39690028c80c3774b705c2b76b470ae74042b21f2ca77d02f6f57aa2ee50296db801220a3352
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gdbm/vcpkg.json
+++ b/ports/gdbm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdbm",
-  "version": "1.24",
-  "port-version": 1,
+  "version": "1.26",
   "description": "GDBM is a library of database functions that use extensible hashing and works similar to the standard UNIX dbm.",
   "homepage": "https://www.gnu.org.ua/software/gdbm/gdbm.html",
   "license": "GPL-3.0-only",

--- a/ports/gdbm/vcpkg.json
+++ b/ports/gdbm/vcpkg.json
@@ -3,9 +3,13 @@
   "version": "1.26",
   "description": "GDBM is a library of database functions that use extensible hashing and works similar to the standard UNIX dbm.",
   "homepage": "https://www.gnu.org.ua/software/gdbm/gdbm.html",
-  "license": "GPL-3.0-only",
+  "license": "GPL-3.0-or-later",
   "supports": "linux",
   "dependencies": [
+    {
+      "name": "gettext",
+      "host": true
+    },
     {
       "name": "vcpkg-make",
       "host": true

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -347,7 +347,6 @@ gdal[arrow,parquet](!(arm64 | x64))=cascade
 gdal[aws-ec2-windows](!windows)=cascade
 gdal[iconv]:arm64-linux=feature-fails
 gdal[libxml2]:arm64-linux=feature-fails
-gdbm[readline]:arm64-linux=feature-fails
 gdk-pixbuf[introspection]:arm64-windows=skip # needs arm64 host
 gegl:arm64-osx=fail # meson bug on osx. See https://github.com/microsoft/vcpkg/issues/44411
 geogram:arm64-linux=fail # Could NOT find Threads (missing: Threads_FOUND)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3349,8 +3349,8 @@
       "port-version": 2
     },
     "gdbm": {
-      "baseline": "1.24",
-      "port-version": 1
+      "baseline": "1.26",
+      "port-version": 0
     },
     "gdcm": {
       "baseline": "3.2.7",

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "68788cf55ea855186e14d4d1b2f7ab94b3790644",
+      "git-tree": "cbfb96824b599a83049117f7a9e6de4e99d43dfc",
       "version": "1.26",
       "port-version": 0
     },

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68788cf55ea855186e14d4d1b2f7ab94b3790644",
+      "version": "1.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "e0402af6ea114205282de7f19abbb88f45bc5bc0",
       "version": "1.24",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
