### PR TITLE
[quill] Unvendor fmt dependency

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 f32f99f6640e4887517da86648cba41403ad4eda59bc786f861172384506475e09d6ab10aff943f196c62940edab7896402d31e4085a550251ba42f803cf266c
     HEAD_REF master
+    PATCHES use-system-fmt.patch
 )
 
 if(VCPKG_TARGET_IS_ANDROID)

--- a/ports/quill/use-system-fmt.patch
+++ b/ports/quill/use-system-fmt.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 768c9167..c57f6101 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,6 +197,8 @@ endif ()
+ # library name
+ set(TARGET_NAME quill)
+ 
++find_package(fmt CONFIG REQUIRED)
++
+ # header files
+ set(HEADER_FILES
+         include/quill/backend/BackendManager.h
+@@ -216,20 +218,6 @@ set(HEADER_FILES
+         include/quill/backend/TransitEventBuffer.h
+         include/quill/backend/BackendUtilities.h
+ 
+-        include/quill/bundled/fmt/args.h
+-        include/quill/bundled/fmt/base.h
+-        include/quill/bundled/fmt/chrono.h
+-        include/quill/bundled/fmt/color.h
+-        include/quill/bundled/fmt/compile.h
+-        include/quill/bundled/fmt/format.h
+-        include/quill/bundled/fmt/format-inl.h
+-        include/quill/bundled/fmt/os.h
+-        include/quill/bundled/fmt/ostream.h
+-        include/quill/bundled/fmt/printf.h
+-        include/quill/bundled/fmt/ranges.h
+-        include/quill/bundled/fmt/std.h
+-        include/quill/bundled/fmt/xchar.h
+-
+         include/quill/core/Attributes.h
+         include/quill/core/BoundedSPSCQueue.h
+         include/quill/core/ChronoTimeUtils.h

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,11 +1,13 @@
 {
   "name": "quill",
   "version": "13.0.0",
+  "port-version": 1,
   "description": "Asynchronous Low Latency C++ Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "documentation": "https://quillcpp.readthedocs.io/en/latest/",
   "license": "MIT",
   "dependencies": [
+    "fmt",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8678,7 +8678,7 @@
     },
     "quill": {
       "baseline": "13.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "quirc": {
       "baseline": "1.2",

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2733ecf252bfb32f920864430e10f963dbf74041",
+      "version": "13.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0fede63e1e4462dcf52d74bf984d64c331dbc96c",
       "version": "13.0.0",
       "port-version": 0


### PR DESCRIPTION
Use vcpkg provided fmt instead of the vendored copy in the quill port.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.