### PR TITLE
[anari] Updated to 0.16.0

### DIFF
--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -1,12 +1,12 @@
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO KhronosGroup/ANARI-SDK
-  REF "v${VERSION}"
-  SHA512 504be3b6e8b33def5c43e0c59927da0fccd8c9356f384ceab20740e49a26f6e2e62b142893afec028ce61207741de9e72d9a496b7981109f290bb580552a0965
-  HEAD_REF next_release
-  PATCHES anari-lib-maybe-static-lib.patch
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/ANARI-SDK
+    REF "v${VERSION}"
+    SHA512 c5827d637f51267454ccd905aa5349f99e7c8347b412bcbedbe4c552657812b544a7be88737d2d4cd3cfcc8f8a23550365d128a47536425e3f4a6442e11841ca
+    HEAD_REF next_release
+    PATCHES anari-lib-maybe-static-lib.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -28,25 +28,26 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-file(GLOB ANARI_CMAKE_CONFIG_FILE RELATIVE ${CURRENT_PACKAGES_DIR} "${CURRENT_PACKAGES_DIR}/lib/cmake/*/anariConfig.cmake")
+file(GLOB ANARI_CMAKE_CONFIG_FILE RELATIVE "${CURRENT_PACKAGES_DIR}" "${CURRENT_PACKAGES_DIR}/lib/cmake/*/anariConfig.cmake")
 cmake_path(GET ANARI_CMAKE_CONFIG_FILE PARENT_PATH ANARI_CMAKE_CONFIG_DIR)
 vcpkg_cmake_config_fixup(
-  CONFIG_PATH ${ANARI_CMAKE_CONFIG_DIR}
+    CONFIG_PATH "${ANARI_CMAKE_CONFIG_DIR}"
 )
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 vcpkg_replace_string(
-  "${CURRENT_PACKAGES_DIR}/share/anari/anariConfig.cmake"
-  "  \${CMAKE_CURRENT_LIST_DIR}/../../../share/anari"
-  "  \${CMAKE_CURRENT_LIST_DIR}/../../share/anari"
+    "${CURRENT_PACKAGES_DIR}/share/anari/anariConfig.cmake"
+    "  \${CMAKE_CURRENT_LIST_DIR}/../../../share/anari"
+    "  \${CMAKE_CURRENT_LIST_DIR}/../../share/anari"
 )
 
 file(REMOVE_RECURSE
-  "${CURRENT_PACKAGES_DIR}/debug/include"
-  "${CURRENT_PACKAGES_DIR}/debug/share"
-  "${CURRENT_PACKAGES_DIR}/share/anari/code_gen/__pycache__"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/anari/code_gen/__pycache__"
 )
 
 vcpkg_install_copyright(
-  FILE_LIST "${SOURCE_PATH}/LICENSE"
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
 )

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "anari",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -84,7 +84,6 @@ allegro5:arm64-linux=fail
 allegro5:arm64-windows=fail # Fails with "fatal error LNK1322: cannot avoid potential ARM hazard" even with /Gy
 ampl-asl:arm64-linux=fail
 ampl-mp:arm64-linux=cascade
-anari:arm64-linux=cascade
 appstream-glib:arm64-linux=cascade
 apr:arm-neon-android=fail
 apr:arm64-android=fail

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ad33c1e409c40e9e87e7fdbb2191dbf92e6fbf1",
+      "version": "0.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f8711e4f387cebff0f79132b29c4ddb09a63f77e",
       "version": "0.15.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -137,7 +137,7 @@
       "port-version": 0
     },
     "anari": {
-      "baseline": "0.15.0",
+      "baseline": "0.16.0",
       "port-version": 0
     },
     "anax": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
