### PR TITLE
[frei0r] Updated to 3.5.0

### DIFF
--- a/ports/frei0r/m_pi.patch
+++ b/ports/frei0r/m_pi.patch
@@ -1,0 +1,15 @@
+diff --git a/src/filter/shake0scillate/shake0scillate.cpp b/src/filter/shake0scillate/shake0scillate.cpp
+index f9657db..a042fcf 100755
+--- a/src/filter/shake0scillate/shake0scillate.cpp
++++ b/src/filter/shake0scillate/shake0scillate.cpp
+@@ -17,9 +17,9 @@
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#define _USE_MATH_DEFINES
+ #include "frei0r.hpp"
+ #include <cairo.h>
+-#define _USE_MATH_DEFINES
+ #include <cmath>
+ 
+ class Shake0scillate : public frei0r::filter {

--- a/ports/frei0r/portfile.cmake
+++ b/ports/frei0r/portfile.cmake
@@ -6,11 +6,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dyne/frei0r
     REF "v${VERSION}"
-    SHA512 84b7c7d7da75c3c76b2bd68fbdf877831c45bc99f0ba306a1c7270867073b27f53595a5c6d845c5a628f72aa05f54525e02fd8000794c650e13af8e88a946550
+    SHA512 f73723a165ac42029801b895d2324ee8dcf4d9b49165458e707b6891ad88294203848d2b1cd89ffe58769f13232f9175e17040fc30905b37df29d348c36f2e1c
     HEAD_REF master
     PATCHES
         001-fix-defs.patch
         002-install-dlls-to-bin.patch
+        m_pi.patch
 )
 
 vcpkg_check_features(
@@ -23,8 +24,9 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-      ${FEATURE_OPTIONS}
-      -DWITHOUT_GAVL=ON
+        -DBUILD_TESTING=OFF
+        -DWITHOUT_GAVL=ON
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -34,4 +36,7 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/COPYING"
+)

--- a/ports/frei0r/vcpkg.json
+++ b/ports/frei0r/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "frei0r",
-  "version": "3.1.3",
+  "version": "3.5.0",
   "description": "A large collection of free and portable video plugins",
   "homepage": "https://frei0r.dyne.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3257,7 +3257,7 @@
       "port-version": 2
     },
     "frei0r": {
-      "baseline": "3.1.3",
+      "baseline": "3.5.0",
       "port-version": 0
     },
     "fribidi": {

--- a/versions/f-/frei0r.json
+++ b/versions/f-/frei0r.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f632bbb5dae28ae364116c2585cdc9d71b17fe0a",
+      "version": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d77686e181f4e3eb6a93d48520721251321c712d",
       "version": "3.1.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Closes #52301
