### PR TITLE
[sentry-native] update to 0.16.5

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 2ce19c7705c9297beadb79067716f7bf67ecdb1839d2599c63fc49e1c23622e645a346fe51b0b296b81ee78f63b316d40134cc6c7075b3707405d24bb00a97b8
+    SHA512 80007354f79dce2a7d0f1312d405bd4e147d4fe76c7a82012ce24abc9f38c5c4ebc52c343c79ba1c5faedbb7525ef814d40373c0ab63c9f31e36a608ac271ee3
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT AND Apache-2.0 AND BSD-3-Clause AND ICU",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1036,7 +1036,6 @@ rtmidi:x64-android=fail
 salome-medcoupling:x64-linux=fail
 saucer:arm64-osx=fail # std::move_only_function is not supported
 saucer:x64-linux=fail # requires gcc14 or later
-sentry-native:arm64-linux=fail
 sfgui:arm-neon-android=fail
 sfgui:arm64-android=fail
 sfgui:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9273,7 +9273,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.16.4",
+      "baseline": "0.16.5",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f9c0ee14fc6722f2720f1154ceb891b2394c2c2",
+      "version": "0.16.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "2e386a06e9289bfb83f5f737fb70a7b62d87d178",
       "version": "0.16.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
