### PR TITLE
[libsm] remove dependency from xtrans

### DIFF
--- a/ports/libsm/portfile.cmake
+++ b/ports/libsm/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${LIBSM_ARCHIVE}"
     PATCHES
         msvc.patch
-        xtrans.patch
+        xtrans.patch # https://gitlab.freedesktop.org/xorg/lib/libsm/-/commit/d65819505c31f74ffc731003029702576eb9811d
 )
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")

--- a/ports/libsm/vcpkg.json
+++ b/ports/libsm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsm",
   "version": "1.2.6",
-  "port-version": 2,
+  "port-version": 3,
   "description": "X Session Management Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libsm",
   "license": null,

--- a/ports/libsm/xtrans.patch
+++ b/ports/libsm/xtrans.patch
@@ -1,13 +1,32 @@
 diff --git a/configure.ac b/configure.ac
-index 7d274a5..3761020 100644
+index 7d274a5f71f2626b9dbce243c7ad4fdb8057321f..e65dad7e7adb66207383773eebdc45fc3ef9cca0 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -59,7 +59,7 @@ XTRANS_CONNECTION_FLAGS
+@@ -53,13 +53,13 @@ AM_CONDITIONAL(WITH_LIBUUID, test x"$HAVE_LIBUUID" = xyes)
+ # If UUID support is not found, fall back to using network addresses
+ # to generate client ids
+ AS_IF([test x"$HAVE_LIBUUID" != xyes && test x"$ac_cv_func_uuid_create" != xyes],
+-      [genid_module="xtrans"
++      [
+ # Needed to check for TCP & IPv6 support and set flags appropriately
+ XTRANS_CONNECTION_FLAGS
  AC_CHECK_FUNCS([getaddrinfo]) ])
  
  # Obtain compiler/linker options for dependencies
 -PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto $genid_module])
-+PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto xtrans])
++PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto])
  
  
  AC_CONFIG_FILES([Makefile
+diff --git a/src/sm_manager.c b/src/sm_manager.c
+index e792021d8b905cd39ef7ca27c81cbddc968568db..5986de8666d66ca65df3a0306749434f0fef8ee9 100644
+--- a/src/sm_manager.c
++++ b/src/sm_manager.c
+@@ -33,7 +33,6 @@ in this Software without prior written authorization from The Open Group.
+ #endif
+ #include <X11/SM/SMlib.h>
+ #include "SMlibint.h"
+-#include <X11/Xtrans/Xtrans.h>
+ 
+ static Status
+ _SmsProtocolSetupProc (IceConn    iceConn,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5710,7 +5710,7 @@
     },
     "libsm": {
       "baseline": "1.2.6",
-      "port-version": 2
+      "port-version": 3
     },
     "libsmacker": {
       "baseline": "1.2.0",

--- a/versions/l-/libsm.json
+++ b/versions/l-/libsm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb292687199644a57cf5fb17e2e345bc0210fac8",
+      "version": "1.2.6",
+      "port-version": 3
+    },
+    {
       "git-tree": "60bd08be9e8d1ab410500b8ec10a632bc6fe17f8",
       "version": "1.2.6",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
