### PR TITLE
[libdvdnav] Drop redundant pkgconfig setup

### DIFF
--- a/ports/libdvdnav/portfile.cmake
+++ b/ports/libdvdnav/portfile.cmake
@@ -11,10 +11,6 @@ vcpkg_from_gitlab(
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/msvc/include/inttypes.h")
 
-vcpkg_find_acquire_program(PKGCONFIG)
-cmake_path(GET PKGCONFIG PARENT_PATH pkgconfig_dir)
-vcpkg_add_to_path("${pkgconfig_dir}")
-
 set(cppflags "")
 if(VCPKG_TARGET_IS_WINDOWS)
     # PATH_MAX from msvc/libdvdcss.vcxproj

--- a/ports/libdvdnav/vcpkg.json
+++ b/ports/libdvdnav/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libdvdnav",
   "version-semver": "6.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library to navigate DVD disks",
   "homepage": "https://www.videolan.org/developers/libdvdnav.html",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4982,7 +4982,7 @@
     },
     "libdvdnav": {
       "baseline": "6.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libdvdread": {
       "baseline": "6.1.3",

--- a/versions/l-/libdvdnav.json
+++ b/versions/l-/libdvdnav.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea128c8493d652ee47a9aa9338bc0758360929b8",
+      "version-semver": "6.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5fd0c2de55cf6764503207c726483c1ece3109f1",
       "version-semver": "6.1.1",
       "port-version": 1


### PR DESCRIPTION
vcpkg-make does pkgconfig setup.
Cherry-picked from https://github.com/microsoft/vcpkg/pull/53320.