### PR TITLE
[gauche] New port

### DIFF
--- a/ports/gauche/portfile.cmake
+++ b/ports/gauche/portfile.cmake
@@ -1,0 +1,34 @@
+# The library exports no symbols explicitly, so a shared build would produce an
+# import library with nothing in it on Windows.
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Project-OSRM/gauche-rs
+    REF "v${VERSION}"
+    SHA512 eefae5bed6bfab30af646f182eaebafbf9120e4cd4ad0bb9b50c36bbcb5760c2378d28f468494e7acbc89a304edb64e39af96c3de7239d3a3f810411443cbce3
+    HEAD_REF main
+)
+
+# The CMake project lives in cpp/ but compiles the transpiled C sources from the
+# sibling c/ directory, so the whole repository has to be extracted.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/cpp"
+    OPTIONS
+        -DGAUCHE_BUILD_EXAMPLES=OFF
+        -DGAUCHE_ENABLE_LTO=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/gauche)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# The library embeds w2c2's header-only runtime, which is separately licensed.
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE"
+    "${SOURCE_PATH}/c/w2c2/LICENSE"
+)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/gauche/usage
+++ b/ports/gauche/usage
@@ -1,0 +1,4 @@
+gauche provides CMake targets:
+
+    find_package(gauche CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE gauche::gauche_cpp)

--- a/ports/gauche/vcpkg.json
+++ b/ports/gauche/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "gauche",
+  "version": "0.1.0",
+  "description": "Left-hand traffic area classifier for point, line, and bbox queries over OSM driving-side data",
+  "homepage": "https://github.com/Project-OSRM/gauche-rs",
+  "license": "BSD-2-Clause AND MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/gauche/vcpkg.json
+++ b/ports/gauche/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Left-hand traffic area classifier for point, line, and bbox queries over OSM driving-side data",
   "homepage": "https://github.com/Project-OSRM/gauche-rs",
   "license": "BSD-2-Clause AND MIT",
-  "supports": "!uwp",
+  "supports": "!windows",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/gauche/vcpkg.json
+++ b/ports/gauche/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "name": "gauche",
+  "name": "project-osrm-gauche-rs",
   "version": "0.1.0",
   "description": "Left-hand traffic area classifier for point, line, and bbox queries over OSM driving-side data",
   "homepage": "https://github.com/Project-OSRM/gauche-rs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3348,6 +3348,10 @@
       "baseline": "2018-01-04",
       "port-version": 4
     },
+    "gauche": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "gaussianlib": {
       "baseline": "2024-11-03",
       "port-version": 0

--- a/versions/g-/gauche.json
+++ b/versions/g-/gauche.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f0a562df5a14132b336fe2ddca648c6b84d842d6",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a port for [gauche](https://github.com/Project-OSRM/gauche-rs), a left-hand traffic area classifier used by [OSRM](https://github.com/Project-OSRM/osrm-backend). It answers point, line, and bbox queries against OpenStreetMap driving-side data and is fully self-contained: the dataset is compiled into the library, so there are no runtime data files and no dependencies beyond a C11 and C++20 toolchain.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are `REQUIRED`, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The copyright file in `${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright` is created and matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/handling-usage-files.md) for context.
- [x] The versions database is updated (`vcpkg x-add-version --all`).
- [x] Only one version is added to each modified port's versions file.

### Notes

**Static only.** The library declares no export macros, so `vcpkg_check_linkage(ONLY_STATIC_LIBRARY)`.

**`SOURCE_PATH` is `cpp/`, not the repository root.** The CMake project lives in `cpp/`, but it compiles transpiled C sources from the sibling `c/` directory, so the whole repository is extracted and only the subdirectory is configured.

**Two licenses.** The project is BSD-2-Clause. It also embeds `w2c2_base.h`, the header-only runtime from [w2c2](https://github.com/turbolent/w2c2) (MIT), so `license` is `BSD-2-Clause AND MIT` and `vcpkg_install_copyright` lists both files.

**`supports`** is `!uwp`. I could only test macOS locally (`x64-osx` natively, `arm64-osx` cross-compiled); both build clean and pass post-build validation, and a consumer project links `gauche::gauche_cpp` and returns correct results. I have not been able to test Windows, Linux, or Android, so I would appreciate CI telling me what needs narrowing.

One thing reviewers may want to know: most of the library is machine-generated C transpiled from WebAssembly, so `c/gauche_ffi.c` is a single ~93k-line translation unit. It compiles in about 20 seconds with AppleClang; MSVC may be slower, but `w2c2_base.h` carries explicit MSVC support and guards its builtins with `__has_builtin`.