### PR TITLE
[geos] Update to 3.15.0

### DIFF
--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,20 +1,13 @@
-vcpkg_download_distfile(PR1453
-    URLS "https://github.com/libgeos/geos/commit/4226b5a034d249e64385d3dac7e69774ff30d6f3.patch?full_index=1"
-    FILENAME "geos-pr-1453.patch"
-    SHA512 31a24f6feff44af2cb4b923845e4496ca77d78dbe18a170c4deaae8973581c5e8c5430e033b63c2cda3ee8926d1e31007625fbace22b87fd5cde3bd43bd3caaf
-)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.osgeo.org/geos/geos-${VERSION}.tar.bz2"
     FILENAME "geos-${VERSION}.tar.bz2"
-    SHA512 a5a27c34249a6b7fa8bc5d6d557f278bcc3a81ca188f9f543bee7afb6e47d9f8a545e676c5884c0651530bccd24eb929feaaf95cda8e73b033296073e6626f0d
+    SHA512 ac5890dfc92fdebc667cc96a89cf7886873c5867dde79fb45966e6ed294d40e4dbd11c9b6a147d47441dcb50404da496df477ff7b757ef13de79f843ba1e400e
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     SOURCE_BASE "v${VERSION}"
     PATCHES
         fix-exported-config.patch
-        "${PR1453}"
 )
 
 vcpkg_cmake_configure(
@@ -57,4 +50,10 @@ endif()
 vcpkg_copy_pdbs()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/COPYING"
+        "${SOURCE_PATH}/src/deps/ryu/LICENSE"
+        "${SOURCE_PATH}/src/deps/ryu/LICENSE-Apache2"
+        "${SOURCE_PATH}/src/deps/ryu/LICENSE-Boost"
+)

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "geos",
-  "version": "3.14.1",
-  "port-version": 1,
+  "version": "3.15.0",
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
-  "license": "LGPL-2.1-only",
+  "license": "LGPL-2.1-only AND (Apache-2.0 OR BSL-1.0)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3397,8 +3397,8 @@
       "port-version": 0
     },
     "geos": {
-      "baseline": "3.14.1",
-      "port-version": 1
+      "baseline": "3.15.0",
+      "port-version": 0
     },
     "geotrans": {
       "baseline": "3.10",

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33861c592f324010946a1fbc2b57babe44ca3525",
+      "version": "3.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f8307773c80c9a161550351a4b1ecb7278f8b4bf",
       "version": "3.14.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
