### PR TITLE
[stdexec] Fix missing <vector> include in libdispatch_queue.hpp

### DIFF
--- a/ports/stdexec/fix-libdispatch-vector-include.patch
+++ b/ports/stdexec/fix-libdispatch-vector-include.patch
@@ -1,0 +1,11 @@
+diff --git a/include/exec/libdispatch_queue.hpp b/include/exec/libdispatch_queue.hpp
+--- a/include/exec/libdispatch_queue.hpp
++++ b/include/exec/libdispatch_queue.hpp
+@@ -29,6 +29,7 @@
+ #  include "../stdexec/execution.hpp"
+ #  include "sender_for.hpp"
+ #  include <dispatch/dispatch.h>
++#  include <vector>
+ 
+ namespace experimental::execution
+ {

--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         fix-boost-asio-dependency.patch
         fix-tbb-dependency.patch
         fix-taskflow-dependency.patch
+        fix-libdispatch-vector-include.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/stdexec/vcpkg.json
+++ b/ports/stdexec/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stdexec",
   "version-date": "2026-05-25",
+  "port-version": 1,
   "description": "stdexec is an experimental reference implementation of the Senders model of asynchronous programming proposed by P2300 - std::execution for adoption into the C++ Standard.",
   "homepage": "https://github.com/NVIDIA/stdexec",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9810,7 +9810,7 @@
     },
     "stdexec": {
       "baseline": "2026-05-25",
-      "port-version": 0
+      "port-version": 1
     },
     "stdgpu": {
       "baseline": "2026-07-08",

--- a/versions/s-/stdexec.json
+++ b/versions/s-/stdexec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "139c4af74280988d79c52ebc13220fb1cc26912d",
+      "version-date": "2026-05-25",
+      "port-version": 1
+    },
+    {
       "git-tree": "7778ab6796b86b3cc458a0319610e2ebed422577",
       "version-date": "2026-05-25",
       "port-version": 0


### PR DESCRIPTION
Building stdexec 2026-05-25 on macOS with llvm >= 23 fails:

```
include/exec/libdispatch_queue.hpp:423:12: error: no template named 'vector' in namespace 'std'
```

Recent libc++ no longer transitively provides `<vector>`, and `libdispatch_queue.hpp` relies on transitive includes (it has no standard-library includes of its own) when compiled into the `parallel_scheduler` target.

Upstream main already carries the equivalent fix (`#  include <vector>` in `include/exec/libdispatch_queue.hpp`); this patch backports exactly that include to 2026-05-25 and can be dropped on the next version update.

Tested locally: `./vcpkg install stdexec:arm64-osx` builds and installs cleanly with llvm 23.1.0 on macOS arm64.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (No downloads changed.)
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary. (No changes necessary.)
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed. (No entries changed.)
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.