### PR TITLE
[sdl3] Update to version 3.4.16

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
     REF "release-${VERSION}"
-    SHA512 6e6f91cde7dffec527af8a9b0162e9fb7997ec2b6770d3002c662cd75e5cd01afd2fb5f5cadfa2496c86e67ed22e876d99ebdf60b9ea7431a3a3caf5686d0f8f
+    SHA512 d815b28f72d60e4d83e31d878bcf2dd52089353637a4ffd0fd094deaafaaa5b5ee797caad9eeb952f6c28a2bbe26253092c294ce1aefbeb92d85469f35229ed1
     HEAD_REF main
     PATCHES
         fix-freebsd.patch

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3",
-  "version": "3.4.14",
+  "version": "3.4.16",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0 AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9221,7 +9221,7 @@
       "port-version": 0
     },
     "sdl3": {
-      "baseline": "3.4.14",
+      "baseline": "3.4.16",
       "port-version": 0
     },
     "sdl3-image": {

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0345eab430390a0758a40d2062eda9cb43f670c",
+      "version": "3.4.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "60d73b127885c8a9fdd1055996490cbfb9b2be18",
       "version": "3.4.14",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.