### PR TITLE
[eccodes] Updated to 2.48.2

### DIFF
--- a/ports/eccodes/portfile.cmake
+++ b/ports/eccodes/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ecmwf/eccodes
     REF "${VERSION}"
-    SHA512 f1532d72fe572ab306c7c556e035d950fef5490bab9a6fcfdf2df8b50bb91bfebecd2eeacf887a2883062f6af96345927112675c16225c37a5336633cbe7daee
+    SHA512 aadef999f43492326dd9e590f3e16f3e4e0e5f9fb8cd253b47d8398d9cb8e58cac7b0692978489fd2db9be866333530c6792b8898a872b176810f5d9000e8927
     HEAD_REF develop
     PATCHES
         fix-netcdf-linkage.patch

--- a/ports/eccodes/vcpkg.json
+++ b/ports/eccodes/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "eccodes",
-  "version": "2.48.0",
-  "port-version": 1,
+  "version": "2.48.2",
   "description": "ECMWF GRIB, BUFR and GTS decoding and encoding library and tools",
   "homepage": "https://github.com/ecmwf/eccodes",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2781,8 +2781,8 @@
       "port-version": 1
     },
     "eccodes": {
-      "baseline": "2.48.0",
-      "port-version": 1
+      "baseline": "2.48.2",
+      "port-version": 0
     },
     "ecm": {
       "baseline": "6.29.0",

--- a/versions/e-/eccodes.json
+++ b/versions/e-/eccodes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30879522e517365d6600f6e0ed5e1e755ba117d7",
+      "version": "2.48.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "64840128a033dbea7ed8c9f2b036e8bcbfefbc12",
       "version": "2.48.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
