### PR TITLE
[libxi] Update to 1.8.3

### DIFF
--- a/ports/libxi/portfile.cmake
+++ b/ports/libxi/portfile.cmake
@@ -1,15 +1,19 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO "lib/libxi"
-    REF "libXi-${VERSION}"
-    SHA512 3928777184c89f93182d5d6b0d8e37e0ec797c37c0e73305ac843a8c874c3c1261e37338d61edf526e9ca74120bf6dcc1832760ebe9af2550e9f8279dd2f6f6f
-    HEAD_REF master
+vcpkg_download_distfile(
+    LIBXCOMPOSITE_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libXi-${VERSION}.tar.xz"
+    FILENAME "libXi-${VERSION}.tar.xz"
+    SHA512 5fb8273424467c102d3bab01cb273169038ff6fae739f6873ca357be8890c4fd30ba2952bca2759249458796df53ad130e2c9c3674b385602afd13c718faf79a
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXCOMPOSITE_ARCHIVE}"
     PATCHES
         fix-configure.patch
 )
@@ -23,15 +27,17 @@ endif()
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
-    OPTIONS ${OPTIONS}
+    OPTIONS
+        --with-asciidoc=no
+        --with-fop=no
+        --with-xmlto=no
+        --with-xsltproc=no
+        ${OPTIONS}
 )
 
 vcpkg_make_install()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
-endif()

--- a/ports/libxi/vcpkg.json
+++ b/ports/libxi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxi",
-  "version": "1.8.2",
-  "port-version": 1,
+  "version": "1.8.3",
   "description": "Xlib library for the X Input Extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxi",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6049,8 +6049,8 @@
       "port-version": 1
     },
     "libxi": {
-      "baseline": "1.8.2",
-      "port-version": 1
+      "baseline": "1.8.3",
+      "port-version": 0
     },
     "libxinerama": {
       "baseline": "1.1.6",

--- a/versions/l-/libxi.json
+++ b/versions/l-/libxi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c14b2203322c535e34619b9df113464c01d5e3db",
+      "version": "1.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "dfc35ed795b37e9b865964c406720a5f14ac8b4f",
       "version": "1.8.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
