### PR TITLE
[minimp3] Update to 2026-07-27

### DIFF
--- a/ports/minimp3/portfile.cmake
+++ b/ports/minimp3/portfile.cmake
@@ -1,13 +1,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lieff/minimp3
-    REF afb604c06bc8beb145fecd42c0ceb5bda8795144 # committed on 2021-11-30
-    SHA512 633da0b20982f6f22c87d872c69626b2939ffb4519339cd0c090d7538308007cf633c07af57020cd2332a75c6e7b9bf3ebd5bda1af59dc96a4f0e85ce1b3f751
+    REF ea99364f61c14656440e8d77e9c233ccf3124633 # committed on 2026-07-27
+    SHA512 f05e513ccc2b4111609800676efe618addf7cbb82a91e69c8a6e5599e5b49cfcb225050b33eec39211eac35e2060b94a48d15af4db72546cacc1dfc916362dbc
     HEAD_REF master
 )
 
 file(COPY "${SOURCE_PATH}/minimp3.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 file(COPY "${SOURCE_PATH}/minimp3_ex.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/minimp3/vcpkg.json
+++ b/ports/minimp3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "minimp3",
-  "version-date": "2021-11-30",
+  "version-date": "2026-07-27",
   "description": "Minimalistic, single-header library for decoding MP3. minimp3 is designed to be small, fast (with SSE and NEON support), and accurate (ISO conformant).",
   "homepage": "https://github.com/lieff/minimp3",
   "license": "CC0-1.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6681,7 +6681,7 @@
       "port-version": 0
     },
     "minimp3": {
-      "baseline": "2021-11-30",
+      "baseline": "2026-07-27",
       "port-version": 0
     },
     "minio-cpp": {

--- a/versions/m-/minimp3.json
+++ b/versions/m-/minimp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b90dc7b82a48b1cee79435cebfe2f51cf5c8c8e6",
+      "version-date": "2026-07-27",
+      "port-version": 0
+    },
+    {
       "git-tree": "2997f9c06f0831c803fca134a599171dc2399bc4",
       "version-date": "2021-11-30",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
