### PR TITLE
[libxfont] Update to 2.0.9

### DIFF
--- a/ports/libxfont/build.patch
+++ b/ports/libxfont/build.patch
@@ -1,9 +1,13 @@
 diff --git a/Makefile.am b/Makefile.am
-index 5af2e237a..e75fd1755 100644
---- a/Makefile.am	
+index 07a0e25..6327418 100644
+--- a/Makefile.am
 +++ b/Makefile.am
-@@ -159,14 +159,14 @@ endif
- EXTRA_DIST = src/builtins/buildfont README.md
+@@ -154,17 +154,17 @@ libXfont2_la_SOURCES +=			\
+ 	src/fc/fstrans.c
+ endif
+ 
+-EXTRA_DIST = src/builtins/buildfont README.md
++# EXTRA_DIST = src/builtins/buildfont README.md
  
  # Test utilities
 -EXTRA_DIST += test/utils/README
@@ -20,11 +24,28 @@ index 5af2e237a..e75fd1755 100644
 +# lsfontdir_SOURCES = test/utils/lsfontdir.c $(TEST_UTIL_SRCS)
 +# lsfontdir_LDADD = libXfont2.la $(LTLIBOBJS)
  
+ # Security regression tests
+ TESTS =
+@@ -248,11 +248,11 @@ clean-local:
+ 	-rmdir $(TEST_FONT_DIRS) test/data 2>/dev/null || true
+ endif HAVE_PYTHON
+ 
+-EXTRA_DIST += test/gen_evil_pcf_repad.py		\
+-	      test/gen_evil_pcf_props.py		\
+-	      test/gen_evil_pcf_bitmapscale.py	\
+-	      test/gen_evil_pcf_encoding.py	\
+-	      test/gen_evil_pcf_norepad.py
++# EXTRA_DIST += test/gen_evil_pcf_repad.py		\
++#	      test/gen_evil_pcf_props.py		\
++#	      test/gen_evil_pcf_bitmapscale.py	\
++#	      test/gen_evil_pcf_encoding.py	\
++#	      test/gen_evil_pcf_norepad.py
+ 
  
  MAINTAINERCLEANFILES = ChangeLog INSTALL
 diff --git a/include/X11/fonts/fontmisc.h b/include/X11/fonts/fontmisc.h
-index 06e49f5f0..6b68dfcb8 100644
---- a/include/X11/fonts/fontmisc.h	
+index 06e49f5..6b68dfc 100644
+--- a/include/X11/fonts/fontmisc.h
 +++ b/include/X11/fonts/fontmisc.h
 @@ -34,7 +34,9 @@ in this Software without prior written authorization from The Open Group.
  #include <X11/Xfuncs.h>

--- a/ports/libxfont/portfile.cmake
+++ b/ports/libxfont/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_download_distfile(
     LIBXFONT2_ARCHIVE
     URLS "https://www.x.org/archive/individual/lib/libXfont2-${VERSION}.tar.xz"
     FILENAME "libXfont2-${VERSION}.tar.xz"
-    SHA512 f703127df5d5b1093c9b73e019153ed7799523573d52e61d344209f0acfd4df42e11be12bdd1880479c47c2b70de581a4f2ef74e199e9b1ac438f426593d56b0
+    SHA512 ccd6d6abf6aa814a940d137813dba638f8259c3672abf00808d82df033c1026ae29d40c9068da4f112637338ad0d0fc15818a4afa9369a626c8f17e466b4fa72
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libxfont/vcpkg.json
+++ b/ports/libxfont/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxfont",
-  "version": "2.0.7",
+  "version": "2.0.9",
   "description": "X font handling library for server & utilities",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxfont",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6041,7 +6041,7 @@
       "port-version": 1
     },
     "libxfont": {
-      "baseline": "2.0.7",
+      "baseline": "2.0.9",
       "port-version": 0
     },
     "libxft": {

--- a/versions/l-/libxfont.json
+++ b/versions/l-/libxfont.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "457777af5915a46370e64db7513dfc539f0e1a8a",
+      "version": "2.0.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f2ba49916df62b4408426e3bd2846549bb8083f",
       "version": "2.0.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
