### PR TITLE
[numkong] Updated to 7.8.2

### DIFF
--- a/ports/numkong/portfile.cmake
+++ b/ports/numkong/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/NumKong
     REF "v${VERSION}"
-    SHA512 990c270c75ea4226dd1672591f8d0162687e942188879d811940719df57b7c2f5696a4047a70f0898cf184b425739796400d94d5ee94d57f2e063867e7e91484
+    SHA512 67673236db6f0e7b022323841dcf6a06dddbb695ec2f24d5f1a4cff9d2cf899b611d20b0c2ca9ec11fc87774a5f50c2f0ee4b6365a50fe094f2b1d56f68cd656
     HEAD_REF main
     PATCHES
         # https://github.com/ashvardanian/NumKong/pull/378

--- a/ports/numkong/vcpkg.json
+++ b/ports/numkong/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "numkong",
-  "version": "7.8.1",
+  "version": "7.8.2",
   "description": "NumKong (previously SimSIMD) delivers mixed-precision numerics that are often faster and more accurate than standard BLAS libraries",
   "homepage": "https://github.com/ashvardanian/NumKong",
   "license": "Apache-2.0",
-  "supports": "!uwp & !((arm64 | x86) & windows)",
+  "supports": "!uwp & !(x86 & windows)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/test_ports/vcpkg-ci-numkong/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-numkong/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-numkong/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-numkong/project/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.16)
+project(vcpkg-ci-numkong)
+
+find_package(unofficial-numkong CONFIG REQUIRED)
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE unofficial::numkong::nk_shared)

--- a/scripts/test_ports/vcpkg-ci-numkong/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-numkong/project/main.cpp
@@ -1,0 +1,6 @@
+#include <numkong/numkong.h>
+
+int main() {
+    const nk_capability_t caps = nk_capabilities();
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-numkong/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-numkong/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "vcpkg-ci-numkong",
+  "version-string": "ci",
+  "description": "Validates numkong",
+  "license": null,
+  "dependencies": [
+    "numkong",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7249,7 +7249,7 @@
       "port-version": 0
     },
     "numkong": {
-      "baseline": "7.8.1",
+      "baseline": "7.8.2",
       "port-version": 0
     },
     "nuraft": {

--- a/versions/n-/numkong.json
+++ b/versions/n-/numkong.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef0fe14fc790192f361625f882576eadd43558e2",
+      "version": "7.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a66e5056965dbc7fe10625ba5d6b7861726c2f9c",
       "version": "7.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
