### PR TITLE
Resolve correct xcode compiler path during detection for ABI hash

### DIFF
--- a/scripts/detect_compiler/CMakeLists.txt
+++ b/scripts/detect_compiler/CMakeLists.txt
@@ -11,6 +11,30 @@ endif()
 enable_language(C)
 enable_language(CXX)
 
+# CMake 4.0 stopped mapping /usr/bin compilers on macOS into the active Xcode toolchain. Those are
+# `xcrun` dispatch stubs, identical across every toolchain, so hash what they resolve to instead.
+function(resolve_apple_compiler_stub compiler_path out_var)
+    set("${out_var}" "${compiler_path}" PARENT_SCOPE)
+    if(NOT CMAKE_HOST_APPLE OR NOT compiler_path MATCHES "^/usr/bin/")
+        return()
+    endif()
+
+    get_filename_component(compiler_name "${compiler_path}" NAME)
+    execute_process(
+        COMMAND xcrun --find "${compiler_name}"
+        OUTPUT_VARIABLE RESOLVED_PATH
+        RESULT_VARIABLE XCRUN_RESULT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(XCRUN_RESULT EQUAL 0 AND RESOLVED_PATH AND EXISTS "${RESOLVED_PATH}")
+        set("${out_var}" "${RESOLVED_PATH}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+resolve_apple_compiler_stub("${CMAKE_C_COMPILER}" C_COMPILER_PATH)
+resolve_apple_compiler_stub("${CMAKE_CXX_COMPILER}" CXX_COMPILER_PATH)
+
 if(VCPKG_COMPILER_CACHE_FILE)
     if(EXISTS "${VCPKG_COMPILER_CACHE_FILE}")
         file(READ "${VCPKG_COMPILER_CACHE_FILE}" JSON_CONTENT)
@@ -41,14 +65,14 @@ if(VCPKG_COMPILER_CACHE_FILE)
         set(JSON_CONTENT "${JSON_CONTENT}" PARENT_SCOPE)
     endfunction()
 
-    get_hash("${CMAKE_C_COMPILER}" C_HASH)
-    get_hash("${CMAKE_CXX_COMPILER}" CXX_HASH)
+    get_hash("${C_COMPILER_PATH}" C_HASH)
+    get_hash("${CXX_COMPILER_PATH}" CXX_HASH)
 
     # Write updated JSON back to file
     file(WRITE "${VCPKG_COMPILER_CACHE_FILE}" "${JSON_CONTENT}")
 else()
-    file(SHA1 "${CMAKE_CXX_COMPILER}" CXX_HASH)
-    file(SHA1 "${CMAKE_C_COMPILER}" C_HASH)
+    file(SHA1 "${CXX_COMPILER_PATH}" CXX_HASH)
+    file(SHA1 "${C_COMPILER_PATH}" C_HASH)
 endif()
 string(SHA1 COMPILER_HASH "${C_HASH}${CXX_HASH}")
 
@@ -56,8 +80,8 @@ message("#COMPILER_HASH#${COMPILER_HASH}")
 message("#COMPILER_C_HASH#${C_HASH}")
 message("#COMPILER_C_VERSION#${CMAKE_C_COMPILER_VERSION}")
 message("#COMPILER_C_ID#${CMAKE_C_COMPILER_ID}")
-message("#COMPILER_C_PATH#${CMAKE_C_COMPILER}")
+message("#COMPILER_C_PATH#${C_COMPILER_PATH}")
 message("#COMPILER_CXX_HASH#${CXX_HASH}")
 message("#COMPILER_CXX_VERSION#${CMAKE_CXX_COMPILER_VERSION}")
 message("#COMPILER_CXX_ID#${CMAKE_CXX_COMPILER_ID}")
-message("#COMPILER_CXX_PATH#${CMAKE_CXX_COMPILER}")
+message("#COMPILER_CXX_PATH#${CXX_COMPILER_PATH}")


### PR DESCRIPTION
CMake 4.0 changed the compiler detection for Xcode meaning it finds the `xcrun` stub in `/usr/bin` rather than the fully resolved compiler path, see [release notes](https://cmake.org/cmake/help/v4.0/release/4.0.html#other-changes)

For vcpkg this means the compiler path it hashes is the `xcrun` stub which is unchanged when switching Xcode versions, so vcpkg does not recognise a change and doesn't rebuild anything.

Can be reproduced by running `xcode-select -s <path>` to switch active Xcode versions or in some cases by updating Xcode if it doesn't update the xcrun stub which is currently hashed

This change solves the issue by fully resolving the compiler path again, to match the previous behaviour on cmake <4.0