### PR TITLE
[alibabacloud-oss-cpp-sdk-v2] Update to 0.2.0

### DIFF
--- a/ports/alibabacloud-oss-cpp-sdk-v2/portfile.cmake
+++ b/ports/alibabacloud-oss-cpp-sdk-v2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aliyun/alibabacloud-oss-cpp-sdk-v2
     REF "${VERSION}"
-    SHA512 a0a0dcb11fe57a86d43a6a0cd9bbaab4dfbb20ca8e7a18f3adca59993513482773730f85b2ee8c1da642bc0bc6891d9e18a7ef885e1a138b50bcd683e3c0f2f2
+    SHA512 e50229d8db547b779a706810b4e4fc7aca6cf2ec0e7bbe54f14add79c5545dff121224093906efca38c70a7c7ac7b5d3f910aa53280d0072473d21a74f7b18ed
     HEAD_REF main
 )
 

--- a/ports/alibabacloud-oss-cpp-sdk-v2/vcpkg.json
+++ b/ports/alibabacloud-oss-cpp-sdk-v2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-oss-cpp-sdk-v2",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Alibaba Cloud OSS SDK for C++ v2",
   "homepage": "https://github.com/aliyun/alibabacloud-oss-cpp-sdk-v2",
   "license": "Apache-2.0 AND Zlib AND BSL-1.0",

--- a/versions/a-/alibabacloud-oss-cpp-sdk-v2.json
+++ b/versions/a-/alibabacloud-oss-cpp-sdk-v2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0604f6ea65b59aa3d7d0643a7bf8d8030be29dd",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d3721710a1489cdfcd732487c7a8c7a7e8f76c37",
       "version": "0.1.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,7 +89,7 @@
       "port-version": 0
     },
     "alibabacloud-oss-cpp-sdk-v2": {
-      "baseline": "0.1.2",
+      "baseline": "0.2.0",
       "port-version": 0
     },
     "aliyun-oss-c-sdk": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
