### PR TITLE
[librats] update to 2.3.7

### DIFF
--- a/ports/librats/portfile.cmake
+++ b/ports/librats/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO librats/librats
     REF "${VERSION}"
-    SHA512 f45c070236fcbd3aee3df195431d1b819c9a30eb373f02827d30931ccd29c71baf142c7ad1d350a5f80798d8af8299ee92a9022ad41cdfec66ea0a94f4af458d
+    SHA512 35a82456a734a6bd7baac4f013c44d01ae76fb78fe2ab43fd546c8bde4aa7690d1ad233e447e8cecf4d30126d1cb9b3c54f1a5493367ccfa388a80ac8d25952b
     HEAD_REF master
 )
 

--- a/ports/librats/vcpkg.json
+++ b/ports/librats/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "librats",
-  "version": "2.2.0",
+  "version": "2.3.7",
   "description": "C++17 peer-to-peer networking library: encrypted P2P (Noise XX), DHT/mDNS discovery, NAT traversal (STUN/UPnP/NAT-PMP), GossipSub pub/sub, file transfer, optional BitTorrent.",
   "homepage": "https://github.com/librats/librats",
   "license": "MIT AND BSD-3-Clause AND BSD-2-Clause AND BSD-1-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5609,7 +5609,7 @@
       "port-version": 0
     },
     "librats": {
-      "baseline": "2.2.0",
+      "baseline": "2.3.7",
       "port-version": 0
     },
     "libraw": {

--- a/versions/l-/librats.json
+++ b/versions/l-/librats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b9fefa39217df80f788a275d4d96c5b1c0fb637",
+      "version": "2.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "7023f23ce139866bf05210cdc6a1906ea7e5ca32",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
