### PR TITLE
[cleishm-thermo-cpp] Updated to 2.1.1

### DIFF
--- a/ports/cleishm-thermo-cpp/portfile.cmake
+++ b/ports/cleishm-thermo-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cleishm/thermo-cpp
     REF "v${VERSION}"
-    SHA512 45b8801f95990b7290ac8230fba81965364e3166fa5d71585c680f04db816469dbeca41683dc1d5fae7e6214a090d36bdb4e6f32ded23bf95aeffd74f74b8194
+    SHA512 25e71945580c35b9161cba6a8c9c84f4473b17bd258fc95c18c99f0bd7fb9fcd11a40ce70404cec0a6823f7989af374789b14f5bc6588fc82f374fd4a105fa87
     HEAD_REF main
     PATCHES
         001-fix-flags.patch
@@ -18,8 +18,10 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME thermo CONFIG_PATH lib/cmake/thermo)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/cleishm-thermo-cpp/vcpkg.json
+++ b/ports/cleishm-thermo-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cleishm-thermo-cpp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Type-safe temperature handling library modeled after std::chrono",
   "homepage": "https://github.com/cleishm/thermo-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1821,7 +1821,7 @@
       "port-version": 0
     },
     "cleishm-thermo-cpp": {
-      "baseline": "2.1.0",
+      "baseline": "2.1.1",
       "port-version": 0
     },
     "clfft": {

--- a/versions/c-/cleishm-thermo-cpp.json
+++ b/versions/c-/cleishm-thermo-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6cda068e0a50bbf9889691114121ca9b3aa792d7",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0b218a3b748228bbbe0804df6d692d134cfb4f0",
       "version": "2.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
