### PR TITLE
[pdal-c] Update to 2.2.3

### DIFF
--- a/ports/pdal-c/portfile.cmake
+++ b/ports/pdal-c/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PDAL/CAPI
     REF "v${VERSION}"
-    SHA512 6fe2136831e37c2f87643b3c971a1397d8912c230e9bfde53a51ec1769bc5c2f08482395263906975c5d40dbabd32852a5a145a159cdcf2548390a0aff72a295
+    SHA512 19931945234341c18ff6264d65989e23fdc78e1072b1ebda8537aa677d93cd77689d809f7ceed8e815871c750fedf248be98c14cacc890626f5921f8854567b5
     HEAD_REF master
 )
 
@@ -21,8 +19,11 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-# Remove headers from debug
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Install copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+# Ignore license files related to unused tests
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+        "${SOURCE_PATH}/cmake/CodeCoverage.cmake"
+)

--- a/ports/pdal-c/vcpkg.json
+++ b/ports/pdal-c/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "pdal-c",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "description": "C API for the Point Data Abstraction Library (PDAL)",
-  "homepage": "https://github.com/PDAL/CAPI#readme",
+  "homepage": "https://github.com/PDAL/CAPI",
+  "license": "BSD-3-Clause",
   "supports": "!(windows & staticcrt)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7785,7 +7785,7 @@
       "port-version": 1
     },
     "pdal-c": {
-      "baseline": "2.2.0",
+      "baseline": "2.2.3",
       "port-version": 0
     },
     "pdal-dimbuilder": {

--- a/versions/p-/pdal-c.json
+++ b/versions/p-/pdal-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c299c56bd8a8b87dd01e6611035e9c95ea87a1d4",
+      "version": "2.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7916bf5653f1e62814a0a975e2af90d6862c881",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
