### PR TITLE
[rexo] Updated to 0.2.3

### DIFF
--- a/ports/rexo/portfile.cmake
+++ b/ports/rexo/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO "christophercrouzet/rexo"
-    REF "v0.2.2"
-    SHA512 "c7b093920bb23d1b8ecb905c8d3eb281e46607890c071c079df4c194215fc007d672ce3524848a1f0376188869f51fd9955e3fe027c10f3d286a003adfd78d09"
-    HEAD_REF "main"
+    REPO christophercrouzet/rexo
+    REF "v${VERSION}"
+    SHA512 fecb6b29a3396470c2f5174e74c6283b8c8b8b91294e4c0ed478ec4c896961bb3503a718d0e7fb5eec23aa0a2a80befa25e35b0d27eeab3708aa18d659968547
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
@@ -16,4 +16,5 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Rexo)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
-configure_file("${SOURCE_PATH}/UNLICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/UNLICENSE")

--- a/ports/rexo/vcpkg.json
+++ b/ports/rexo/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "rexo",
-  "version-semver": "0.2.2",
+  "version-semver": "0.2.3",
   "description": "Rexo is a neat single-file cross-platform unit testing framework for C/C++",
   "homepage": "https://github.com/christophercrouzet/rexo",
+  "license": "Unlicense",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8905,7 +8905,7 @@
       "port-version": 1
     },
     "rexo": {
-      "baseline": "0.2.2",
+      "baseline": "0.2.3",
       "port-version": 0
     },
     "rgfw": {

--- a/versions/r-/rexo.json
+++ b/versions/r-/rexo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8c2578af6567d0da3bd9c935965f9f22cb1e40e",
+      "version-semver": "0.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "baf2bfcbd402fbf0f66d810edfff4d7fbd7d1583",
       "version-semver": "0.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
