### PR TITLE
[ball-lang] new port

### DIFF
--- a/ports/ball-lang/portfile.cmake
+++ b/ports/ball-lang/portfile.cmake
@@ -1,0 +1,146 @@
+# ball-lang: the unified `ball` CLI (issue #367/#368) for the Ball
+# programming language — compile / encode / run subcommands, plus the
+# self-hosted info/validate/tree/version verbs.
+#
+# This is a pure CLI application: no headers or libraries are installed, so
+# (like ports/vcpkg-tool-ninja, which packages the `ninja` build tool the
+# same way) we only need a release build.
+set(VCPKG_BUILD_TYPE release)
+
+# ...and, for the same reason, ${CURRENT_PACKAGES_DIR}/include stays empty.
+# Without this, vcpkg's post-build validation reports
+#   "The folder ${CURRENT_PACKAGES_DIR}/include is empty or not present ...
+#    If this is not a CMake helper port but this is otherwise intentional, add
+#    set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled) to suppress this message."
+#   "Found 1 post-build check problem(s) ... Please correct these before
+#    submitting this port to the curated registry."
+# — i.e. a submission blocker, surfaced by the ci.yml vcpkg smoke's own log.
+# NOT VCPKG_POLICY_CMAKE_HELPER_PORT (what ports/vcpkg-tool-ninja uses): that
+# one declares a port which ships only CMake scripts, which this is not.
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Ball-Lang/ball
+    REF "v${VERSION}"
+    # SHA512 of https://github.com/Ball-Lang/ball/archive/v1.64.0.tar.gz,
+    # obtained the way vcpkg's packaging tutorial prescribes: run the install
+    # once with `SHA512 0` and paste the hash from its "the expected SHA512 was
+    # all zeros, please change the expected SHA512 to: <hash>" error. Verified
+    # three ways (that message, `sha512sum` of vcpkg's own downloads/ copy, and
+    # `sha512sum` of an independent `curl` of the same URL).
+    # ON A VERSION BUMP this MUST be recomputed together with `version-semver`
+    # in vcpkg.json and the sidecar SHA512 below — all three name one tag.
+    SHA512 0622de99d53d923b5e41e091edca3bc7e24ab13ead3db1a557540f2cf70c75a415a3544c2dd44da5813a0540868c756dd604e46d68eb08353b5d9b16a63fca28
+    HEAD_REF main
+)
+
+# ── Self-hosted verbs: the pre-generated C++ sidecar (issues #368/#361) ──────
+# `ball compile` / `ball encode` / `ball version` only need the C++ compiler and
+# encoder libraries built here, so they are always real. `ball run` and the
+# self-hosted `info`/`validate`/`tree` verbs are the SELF-HOSTED half of the CLI
+# (issue #367): they are Ball programs compiled to C++ by Ball's own compiler
+# into dart/self_host/lib/{engine_rt.cpp,cli_rt.h}, which cpp/cli/CMakeLists.txt
+# EXISTS-gates at configure time. Producing them needs Dart plus a bootstrap
+# build of `ball_cpp_compile` — neither of which exists inside vcpkg's
+# sandboxed, network-isolated build.
+#
+# So the release workflow (.github/workflows/release-cpp.yml) runs that Dart
+# pipeline once per tag and publishes the two generated sources as a release
+# asset beside the `ball` binaries; this port downloads and unpacks that asset
+# into ${SOURCE_PATH}/dart/self_host/lib/ before configuring, and the same
+# EXISTS gates that give the Releases binaries every verb fire here too.
+#
+# It is a FEATURE, on by default, rather than an unconditional download:
+# vcpkg_download_distfile has no non-fatal mode, so gating it is the only way
+# vcpkg supports "this build does not need the sidecar". `vcpkg install
+# ball-lang[core]` therefore still yields exactly the compile/encode/version-only
+# `ball` this port shipped before — no download attempted, no hard failure —
+# while the default install gets every verb.
+#
+# FEATURE_OPTIONS is intentionally NOT forwarded to vcpkg_cmake_configure below:
+# the feature selects whether the two generated sources are *present*, and
+# cpp/cli/CMakeLists.txt keys off their existence, not off a -D flag. Passing an
+# unused -DBALL_WITH_SELFHOST would only earn a "manually-specified variables
+# were not used" warning from CMake.
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        selfhost BALL_WITH_SELFHOST
+)
+
+if(BALL_WITH_SELFHOST)
+    vcpkg_download_distfile(
+        BALL_SELFHOST_ARCHIVE
+        URLS "https://github.com/Ball-Lang/ball/releases/download/v${VERSION}/ball-selfhost-cpp-src-v${VERSION}.tar.gz"
+        FILENAME "ball-selfhost-cpp-src-v${VERSION}.tar.gz"
+        # SHA512 of the v1.64.0 release asset, cross-checked against the
+        # `ball-selfhost-cpp-src-v1.64.0.tar.gz.sha256` (and `SHA256SUMS.txt`)
+        # that release-cpp.yml publishes beside it. Recompute on a version bump.
+        SHA512 ee24364ebe55545b65384960e04ae5ebb7593133a4c6d65ba6fdccfc0c80e3ddee0ac776d00e7891cf499f26353fb670497e7e2e533fc17b56c188730c523f96
+    )
+    # NO_REMOVE_ONE_LEVEL: the asset is a flat archive of the two generated
+    # sources, deliberately with no wrapping directory, so the file names it
+    # unpacks are exactly the names cpp/cli/CMakeLists.txt gates on.
+    vcpkg_extract_source_archive(
+        BALL_SELFHOST_DIR
+        ARCHIVE "${BALL_SELFHOST_ARCHIVE}"
+        SOURCE_BASE "ball-selfhost-cpp-src"
+        NO_REMOVE_ONE_LEVEL
+    )
+    # Fail loud, not silently verbless: a sidecar that unpacked to something
+    # other than these two names would otherwise leave the EXISTS gates unmet
+    # and hand the user a stub `ball run` with a green install log.
+    foreach(_ball_selfhost_file IN ITEMS cli_rt.h engine_rt.cpp)
+        if(NOT EXISTS "${BALL_SELFHOST_DIR}/${_ball_selfhost_file}")
+            message(FATAL_ERROR
+                "ball-lang[selfhost]: ${_ball_selfhost_file} is missing from "
+                "ball-selfhost-cpp-src-v${VERSION}.tar.gz. Install "
+                "ball-lang[core] for the compile/encode/version-only build, or "
+                "report this against https://github.com/Ball-Lang/ball/issues.")
+        endif()
+    endforeach()
+    file(COPY
+        "${BALL_SELFHOST_DIR}/cli_rt.h"
+        "${BALL_SELFHOST_DIR}/engine_rt.cpp"
+        DESTINATION "${SOURCE_PATH}/dart/self_host/lib"
+    )
+    message(STATUS "ball-lang: self-hosted verbs ENABLED (run/info/validate/tree)")
+else()
+    message(STATUS "ball-lang: self-hosted verbs stubbed (feature 'selfhost' not selected) — compile/encode/version only")
+endif()
+
+# This configures the FULL cpp/ CMake project (shared + compiler + encoder +
+# cli + test) — there is no standalone `cpp/cli/CMakeLists.txt` entry point
+# today, matching how a human would build the repo locally (see the root
+# CLAUDE.md "Build & Test" section). Only the `ball` target and its link
+# dependencies are ever BUILT or INSTALLED though, via the target-scoped
+# `install(TARGETS ball ...)` rule in cpp/cli/CMakeLists.txt (issue #368) —
+# vcpkg_cmake_install()'s generated `install` target does not pull in
+# cpp/test/'s targets, which register no install() rules of their own.
+#
+# NOTE the `/cpp` suffix: SOURCE_PATH is the REPOSITORY root, which has no
+# CMakeLists.txt of its own (`cmake -S cpp -B cpp/build` is the documented
+# build). Configuring the bare SOURCE_PATH fails with "The source directory
+# ... does not appear to contain CMakeLists.txt" — which is exactly what the
+# ci.yml `vcpkg port smoke` job caught the first time this port was ever built
+# by any tool. vcpkg_install_copyright below still uses the bare SOURCE_PATH,
+# since LICENSE lives at the repository root.
+#
+# BALL_BUILD_PROTOBUF_RT / BALL_BUILD_UPSTREAM_CONFORMANCE both default OFF
+# upstream; passed explicitly so a future default flip in the Ball repo can't
+# silently start FetchContent'ing Google protobuf/abseil inside a vcpkg build.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/cpp"
+    OPTIONS
+        -DBALL_BUILD_PROTOBUF_RT=OFF
+        -DBALL_BUILD_UPSTREAM_CONFORMANCE=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_tools(
+    TOOL_NAMES ball
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
+    AUTO_CLEAN
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ball-lang/vcpkg.json
+++ b/ports/ball-lang/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "ball-lang",
+  "version-semver": "1.64.0",
+  "description": "ball — the unified CLI for the Ball programming language: compile, encode, and run programs where every program is a Protocol Buffer message.",
+  "homepage": "https://github.com/Ball-Lang/ball",
+  "documentation": "https://github.com/Ball-Lang/ball/blob/main/cpp/AGENTS.md",
+  "license": "MIT",
+  "supports": "!uwp & !android & !ios",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "selfhost"
+  ],
+  "features": {
+    "selfhost": {
+      "description": "The self-hosted verbs: `ball run`, `info`, `validate` and `tree`. Downloads the pre-generated C++ sources published with each release (Ball's own compiler emits them from Ball source, which needs a Dart toolchain vcpkg's sandbox does not have). Drop it with `ball-lang[core]` for a compile/encode/version-only build."
+    }
+  }
+}

--- a/versions/b-/ball-lang.json
+++ b/versions/b-/ball-lang.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4b1e5f336fe91d20f98505a507e21f087d6eb8db",
+      "version-semver": "1.64.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -640,6 +640,10 @@
       "baseline": "2023-11-24",
       "port-version": 1
     },
+    "ball-lang": {
+      "baseline": "1.64.0",
+      "port-version": 0
+    },
     "baresip-libre": {
       "baseline": "4.10.0",
       "port-version": 0


### PR DESCRIPTION
Adds a new port: **`ball-lang`** — the `ball` CLI for the [Ball programming language](https://github.com/Ball-Lang/ball), a language in which every program is a Protocol Buffer message. Version **1.64.0**.

This is a **tool-only port**: it installs a single executable to `tools/ball-lang/` and no headers, libraries, or CMake config files, so nothing enters vcpkg's published link domain.

Opened as a **draft** per [Use GitHub draft PRs](https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#use-github-draft-prs). Two commits, per [Update the version files in `versions/`](https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#update-the-version-files-in-versions-of-any-modified-ports): the port, then the `x-add-version` output.

### License

`MIT`, declared in `vcpkg.json` as `"license": "MIT"`, matching the repository's [`LICENSE`](https://github.com/Ball-Lang/ball/blob/main/LICENSE) (`MIT License` / `Copyright (c) 2026 Ball Language Contributors`). That file is what `vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")` installs as `share/ball-lang/copyright`; I diffed the installed copy against upstream's.

### Features

- `core` — `ball compile`, `ball encode`, `ball version`. Built entirely from repository source.
- `selfhost` (**default**) — additionally enables `ball run`, `info`, `validate`, `tree`.

  These four verbs are themselves Ball programs, compiled to C++ by Ball's own compiler. Generating that C++ needs a Dart toolchain and a bootstrap compiler build, neither of which exists inside vcpkg's build environment, so upstream's release workflow emits the two generated **C++ source files** once per tag and publishes them as a release asset (`ball-selfhost-cpp-src-v1.64.0.tar.gz`, SHA512-pinned). The feature downloads that asset and **compiles those sources here**, like the rest of the port — no prebuilt binary is installed, so this is not a [prebuilt-binary port](https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#installing-prebuilt-binaries). `ball-lang[core]` skips the download entirely; it is modelled as a feature rather than an unconditional download because `vcpkg_download_distfile` has no non-fatal mode.

  Per [Default features must not add APIs](https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#default-features-must-not-add-apis): this default feature adds subcommands to the same single executable. It installs no additional binaries, headers, libraries, or APIs.

### Usage text

No `usage` file is added. The port installs no CMake config files and no headers, so vcpkg generates no usage text to correct — per [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md), "Don't add a usage file if the automatically generated usage is correct."

### Verification

`./vcpkg install ball-lang --triplet x64-linux` from this branch — real registry path, no overlay ports — on Debian/WSL2 x86_64, GCC 14.2.0:

```
-- ball-lang: self-hosted verbs ENABLED (run/info/validate/tree)
-- Configuring x64-linux
-- Building x64-linux-rel
-- Installing: .../packages/ball-lang_x64-linux/share/ball-lang/copyright
-- Adjusted RPATH of '.../packages/ball-lang_x64-linux/tools/ball-lang/ball'
-- Performing post-build validation
Elapsed time to handle ball-lang:x64-linux: 7.4 min
Total install time: 7.4 min
Packages installed in this vcpkg installation declare the following licenses:
MIT
All requested installations completed successfully in: 7.4 min
```

Post-build validation reported no problems. The installed tree is tool-only:

```console
$ find installed/x64-linux -ipath '*ball-lang*'
installed/x64-linux/share/ball-lang/copyright
installed/x64-linux/share/ball-lang/vcpkg_abi_info.txt
installed/x64-linux/share/ball-lang/vcpkg.spdx.json
installed/x64-linux/share/ball-lang/vcpkg-spdx-resources.json
installed/x64-linux/tools/ball-lang/ball

$ ./installed/x64-linux/tools/ball-lang/ball version
ball 0.3.0+6
```

`./vcpkg x-add-version ball-lang` is committed separately and is idempotent on re-run ("No files were updated").

### Notes for reviewers

- **Maturity — please read before reviewing.** I am deliberately *not* checking the maturity boxes below, because I do not think I can honestly check them, and I would rather you make the call than have me overstate the case. The facts: MIT-licensed, not archived, actively developed (commits daily through today), 100+ tagged releases with published binaries — but the first public commit is **2026-04-23** (~4.5 months of public development) and the oldest release is **2026-07-06** (~2 months old). That falls short of both bars in [Packaged projects should be mature](https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature). If you would rather this wait until the six-month mark (2026-10-23), I am happy to hold it or resubmit then.
- **`ball version` reports `0.3.0+6`, not `1.64.0`.** This is not a packaging mistake: `1.64.0` is the repository's release tag (what `vcpkg_from_github` fetches, and therefore the right port version), while `0.3.0+6` is the CLI subproject's own independently-numbered version, which is what upstream's `version` verb prints. I have reported the confusing mismatch upstream. Flagging it here so it does not look like the port pinned the wrong ref.
- **Port name.** `ball-lang` is the GitHub *organization* name (`Ball-Lang/ball`) lowercased, chosen over the bare repo name `ball` precisely because "ball" is a common word per [Use distinctive port names](https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#use-distinctive-port-names). It is not the strict `Owner-Project` form and the project is not yet in Repology, so I left that checklist item unchecked. Happy to rename to whatever you prefer.
- **Triplets.** `"supports": "!uwp & !android & !ios"`. I verified `x64-linux` by hand only and am relying on CI for the rest; I will fix whatever CI finds before marking this ready for review.
- `set(VCPKG_BUILD_TYPE release)` and `set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)` are both because this is an application port that installs no headers — the same shape as `ports/vcpkg-tool-ninja`.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
    - Every mechanical requirement I could verify is met: manifest formatted with `vcpkg format-manifest`, manifest file (not CONTROL), no deprecated helper functions, lowercase SHA512s, `copyright` installed, no patches, tests/examples not built, version files regenerated. Left unchecked only because of the maturity question above, which is yours to judge.
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
    - See "Maturity" above. ~4.5 months of public development, oldest release ~2 months old. I did not want to check a box I cannot back.
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/ball-lang/versions
    - [ ] The project is amongst the first web search results for "ball-lang" or "ball-lang C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
    - See "Port name" above — the name is the GitHub owner alone, not the strict `Owner-Project` form, so I left this for you to judge.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
    - `nlohmann-json` is the build's only external dependency and is declared unconditionally. Upstream's two `FetchContent` options (`BALL_BUILD_PROTOBUF_RT`, `BALL_BUILD_UPSTREAM_CONFORMANCE`) already default to `OFF`, and the portfile additionally passes `-D...=OFF` explicitly so a future upstream default flip cannot start fetching inside a vcpkg build.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
    - Upstream tags releases `vX.Y.Z`; the manifest uses `"version-semver": "1.64.0"` and the portfile fetches `REF "v${VERSION}"`. (See the `ball version` note above.)
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
    - `vcpkg_from_github(REPO Ball-Lang/ball)`, plus a release asset from that same repository's Releases for the `selfhost` feature.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RND3JhE2V1kSvDxtw4hj7f
