### PR TITLE
[taglib] Updated to 2.3.2

### DIFF
--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -2,8 +2,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taglib/taglib
     REF "v${VERSION}"
-    SHA512 f3988a78692527af0cb006c2cf5767f2ca624a35eaf75a594ce29f26f8b8f233d9e79c7925305cb362fa600491a9b5f34a81b622b6456e62e32d94d769be3762
+    SHA512 800fe379d22d863111a22257a57d81b8e561722e8baf41dc06719913276c31f80f29dda8afd1b99f02c277d9f22e813c54c3329564bbf0ea3448c0bc6575862a
     HEAD_REF master
+    PATCHES
+        remove-bin-files.patch
+        taglib-config.patch
+        taglib-static.patch
 )
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
@@ -20,38 +24,14 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/taglib)
-
-set(pcfile "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/taglib.pc")
-if(EXISTS "${pcfile}")
-    vcpkg_replace_string("${pcfile}" "Requires: " "Requires: zlib" IGNORE_UNCHANGED)
-    vcpkg_replace_string("${pcfile}" " -lz" "")
-endif()
-set(pcfile "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/taglib.pc")
-if(EXISTS "${pcfile}")
-    vcpkg_replace_string("${pcfile}" "Requires: " "Requires: zlib" IGNORE_UNCHANGED)
-    vcpkg_replace_string("${pcfile}" " -lz" "")
-endif()
-
-# remove the debug/include files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/taglib-config.cmd" "${CURRENT_PACKAGES_DIR}/debug/bin/taglib-config.cmd") # Contains absolute paths
-
-# remove bin directory for static builds (taglib creates a cmake batch file there)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/taglib/taglib-config.cmake"
-[[include("${CMAKE_CURRENT_LIST_DIR}/taglib-targets.cmake")]]
-[[include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
-include("${CMAKE_CURRENT_LIST_DIR}/taglib-targets.cmake")]]
-    )
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/taglib/taglib_export.h" "defined(TAGLIB_STATIC)" "1")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/taglib/tag_c.h" "defined(TAGLIB_STATIC)" "1")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
-
 vcpkg_copy_pdbs()
 
-# copyright file
-file(COPY "${SOURCE_PATH}/COPYING.LGPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/taglib")
-file(COPY "${SOURCE_PATH}/COPYING.MPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/taglib")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/taglib/COPYING.LGPL" "${CURRENT_PACKAGES_DIR}/share/taglib/copyright")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/COPYING.LGPL"
+        "${SOURCE_PATH}/COPYING.MPL"
+)

--- a/ports/taglib/remove-bin-files.patch
+++ b/ports/taglib/remove-bin-files.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87b3c80e..051eeb2a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -123,18 +123,6 @@ if(WITH_ZLIB)
+   endif()
+ endif()
+ 
+-if(NOT WIN32)
+-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/taglib-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/taglib-config" @ONLY)
+-  install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/taglib-config" DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-          RENAME "taglib${TAGLIB_INSTALL_SUFFIX}-config")
+-endif()
+-
+-if(WIN32)
+-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/taglib-config.cmd.cmake" "${CMAKE_CURRENT_BINARY_DIR}/taglib-config.cmd")
+-  install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/taglib-config.cmd" DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-          RENAME "taglib${TAGLIB_INSTALL_SUFFIX}-config.cmd")
+-endif()
+-
+ if(NOT BUILD_FRAMEWORK)
+   if(IS_ABSOLUTE ${CMAKE_INSTALL_INCLUDEDIR})
+     set(CMAKE_PC_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})

--- a/ports/taglib/taglib-config.patch
+++ b/ports/taglib/taglib-config.patch
@@ -1,0 +1,15 @@
+diff --git a/taglib-config.cmake.in b/taglib-config.cmake.in
+index 691252f0..98db03d0 100644
+--- a/taglib-config.cmake.in
++++ b/taglib-config.cmake.in
+@@ -1,5 +1,10 @@
+ @PACKAGE_INIT@
+ 
++if(NOT @BUILD_SHARED_LIBS@)
++  include(CMakeFindDependencyMacro)
++  find_dependency(ZLIB)
++endif()
++
+ include("${CMAKE_CURRENT_LIST_DIR}/taglib-targets.cmake")
+ 
+ set(TAGLIB_FOUND ${TagLib_FOUND})

--- a/ports/taglib/taglib-static.patch
+++ b/ports/taglib/taglib-static.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87b3c80e..a2606697 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -146,6 +146,10 @@ if(NOT BUILD_FRAMEWORK)
+   else()
+     set(CMAKE_PC_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+   endif()
++  set(TAGLIB_CFLAGS "")
++  if(NOT BUILD_SHARED_LIBS)
++    set(TAGLIB_CFLAGS "-DTAGLIB_STATIC")
++  endif()
+   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/taglib.pc.cmake" "${CMAKE_CURRENT_BINARY_DIR}/taglib.pc" @ONLY)
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/taglib.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+           RENAME "taglib${TAGLIB_INSTALL_SUFFIX}.pc")
+diff --git a/bindings/c/CMakeLists.txt b/bindings/c/CMakeLists.txt
+index d825fde8..85e51497 100644
+--- a/bindings/c/CMakeLists.txt
++++ b/bindings/c/CMakeLists.txt
+@@ -151,6 +151,10 @@ if(NOT BUILD_FRAMEWORK)
+   else()
+     set(CMAKE_PC_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+   endif()
++  set(TAGLIB_C_CFLAGS "")
++  if(NOT BUILD_SHARED_LIBS)
++    set(TAGLIB_C_CFLAGS "-DTAGLIB_STATIC")
++  endif()
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/taglib_c.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/taglib_c.pc @ONLY)
+   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/taglib_c.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+           RENAME taglib${TAGLIB_INSTALL_SUFFIX}_c.pc)
+diff --git a/bindings/c/taglib_c.pc.cmake b/bindings/c/taglib_c.pc.cmake
+index 86d4e27d..6cc8438a 100644
+--- a/bindings/c/taglib_c.pc.cmake
++++ b/bindings/c/taglib_c.pc.cmake
+@@ -8,4 +8,4 @@ Description: Audio meta-data library (C bindings)
+ Requires: taglib
+ Version: @TAGLIB_LIB_VERSION_STRING@
+ Libs: -L${libdir} -ltag_c@TAGLIB_INSTALL_SUFFIX@
+-Cflags: -I${includedir}/taglib@TAGLIB_INSTALL_SUFFIX@
++Cflags: -I${includedir}/taglib@TAGLIB_INSTALL_SUFFIX@ @TAGLIB_CFLAGS@
+diff --git a/taglib.pc.cmake b/taglib.pc.cmake
+index d20176f9..a1d43adf 100644
+--- a/taglib.pc.cmake
++++ b/taglib.pc.cmake
+@@ -9,4 +9,4 @@ Requires:
+ Requires.private: zlib
+ Version: @TAGLIB_LIB_VERSION_STRING@
+ Libs: -L${libdir} -ltag@TAGLIB_INSTALL_SUFFIX@
+-Cflags: -I${includedir} -I${includedir}/taglib@TAGLIB_INSTALL_SUFFIX@
++Cflags: -I${includedir} -I${includedir}/taglib@TAGLIB_INSTALL_SUFFIX@ @TAGLIB_CFLAGS@

--- a/ports/taglib/usage
+++ b/ports/taglib/usage
@@ -1,0 +1,17 @@
+taglib provides CMake targets:
+
+  # C++
+  find_package(taglib CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE TagLib::tag)
+
+  # C
+  find_package(taglib CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE TagLib::tag_c)
+
+taglib provides pkg-config modules:
+
+  # Audio meta-data library
+  taglib
+
+  # Audio meta-data library (C bindings)
+  taglib_c

--- a/ports/taglib/vcpkg.json
+++ b/ports/taglib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "taglib",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "TagLib Audio Meta-Data Library",
   "homepage": "https://taglib.org/",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/scripts/test_ports/vcpkg-ci-taglib/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-taglib/portfile.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-taglib/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-taglib/project/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+project(taglib-test LANGUAGES C CXX)
+
+# Verify CMake targets
+find_package(taglib CONFIG REQUIRED)
+
+add_executable(main_cmake_cpp main.cpp)
+target_link_libraries(main_cmake_cpp PRIVATE TagLib::tag)
+
+add_executable(main_cmake_c main.c)
+target_link_libraries(main_cmake_c PRIVATE TagLib::tag_c)
+
+# Verify PkgConfig targets
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(TagLib REQUIRED IMPORTED_TARGET taglib)
+pkg_check_modules(TagLibC REQUIRED IMPORTED_TARGET taglib_c)
+
+add_executable(main_pkg_cpp main.cpp)
+target_link_libraries(main_pkg_cpp PRIVATE PkgConfig::TagLib)
+
+add_executable(main_pkg_c main.c)
+target_link_libraries(main_pkg_c PRIVATE PkgConfig::TagLibC)
+set_target_properties(main_pkg_c PROPERTIES LINKER_LANGUAGE CXX)

--- a/scripts/test_ports/vcpkg-ci-taglib/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-taglib/project/main.c
@@ -1,0 +1,7 @@
+#include <tag_c.h>
+
+int main()
+{
+    taglib_file_new(NULL);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-taglib/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-taglib/project/main.cpp
@@ -1,0 +1,8 @@
+#include <taglib/fileref.h>
+
+int main()
+{
+	TagLib::File* tagFile = nullptr;
+    TagLib::FileRef fileRef(tagFile);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-taglib/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-taglib/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-taglib",
+  "version-string": "ci",
+  "description": "Validates taglib",
+  "dependencies": [
+    "taglib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10037,7 +10037,7 @@
       "port-version": 6
     },
     "taglib": {
-      "baseline": "2.3.1",
+      "baseline": "2.3.2",
       "port-version": 0
     },
     "talib": {

--- a/versions/t-/taglib.json
+++ b/versions/t-/taglib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d0974659d06c3aa3b69657815536f25dd89aedf",
+      "version": "2.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "83224e7f88cca8b768fd66f3f99b040867f7dad4",
       "version": "2.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: Changed from `vcpkg_replace_string` to explicit patch, so we can submit it as PR upstream, if here is anything okay