### PR TITLE
[slick-object-pool] Update to v0.2.0

### DIFF
--- a/ports/slick-object-pool/portfile.cmake
+++ b/ports/slick-object-pool/portfile.cmake
@@ -1,8 +1,10 @@
+set(VCPKG_BUILD_TYPE release) # header only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-object-pool
     REF "v${VERSION}"
-    SHA512 932eb5fe590c624b5dca477d874a1eb7822b2528bdb684f151d325b6808866baafa3010a3925ab0e2f4c7374f09163ac205065959a445dd5ef6f15546c433fb4
+    SHA512 d3fb8cbd3e0b05a4ba8658a3d10c474e1e111235741e6e0a426f770ccf4053f15c07ef22ba4f44ba4389bc5513448e9bd2dc33873f645a192ead49c81fda978b
     HEAD_REF main
 )
 
@@ -16,9 +18,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/slick-object-pool)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/slick-object-pool/usage
+++ b/ports/slick-object-pool/usage
@@ -1,4 +1,0 @@
-slick-object-pool is header-only and can be used from CMake via:
-
-    find_package(slick-object-pool CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE slick::object-pool)

--- a/ports/slick-object-pool/vcpkg.json
+++ b/ports/slick-object-pool/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-object-pool",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A high-performance, lock-free object pool for C++20 with multi-threading support",
   "homepage": "https://github.com/SlickQuant/slick-object-pool",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9469,7 +9469,7 @@
       "port-version": 0
     },
     "slick-object-pool": {
-      "baseline": "0.1.3",
+      "baseline": "0.2.0",
       "port-version": 0
     },
     "slick-queue": {

--- a/versions/s-/slick-object-pool.json
+++ b/versions/s-/slick-object-pool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "feee55426cedcf6c3eb05882dde2b81e5aa6f77a",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9daeba909b593f52c51a393b53ad95174c4a93f1",
       "version": "0.1.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
