### PR TITLE
[decimal-for-cpp] Updated to 1.21

### DIFF
--- a/ports/decimal-for-cpp/portfile.cmake
+++ b/ports/decimal-for-cpp/portfile.cmake
@@ -1,11 +1,16 @@
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vpiotr/decimal_for_cpp
-    REF 98265a57385ec14ae84fc0b2b0f15c770b30f548
-    SHA512 b8779ffb81567309ab07fa17eb6d3eb8bb94f77f5a388fd395433a304923ccf75e753a5822f36e5ad9d8959ee1a92b660639367d3a443f353e3e22d36a056f4d
+    REF 599372ee214ab37b5c0fc68148352321978f20ed
+    SHA512 80c1e5068c1699ad819dfc4d47e316943b404ce8bc5fb0d8f8c48212ef79a2e41ca63e6846630993199b5ccda55c59cccc9206cf08d339070f9390782ca404d6
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/include/decimal.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/decimal-for-cpp)
-file(COPY ${SOURCE_PATH}/doc/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp/license.txt ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp/copyright)
+file(COPY "${SOURCE_PATH}/include/decimal.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/decimal-for-cpp")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/doc/license.txt"
+)

--- a/ports/decimal-for-cpp/vcpkg.json
+++ b/ports/decimal-for-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "decimal-for-cpp",
-  "version": "1.18",
-  "port-version": 1,
-  "description": "Decimal data type support, for COBOL-like fixed-point operations on currency values."
+  "version": "1.21",
+  "description": "Decimal data type support, for COBOL-like fixed-point operations on currency values.",
+  "license": "BSD-3-Clause"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2489,8 +2489,8 @@
       "port-version": 0
     },
     "decimal-for-cpp": {
-      "baseline": "1.18",
-      "port-version": 1
+      "baseline": "1.21",
+      "port-version": 0
     },
     "delaunator-cpp": {
       "baseline": "1.0.0",

--- a/versions/d-/decimal-for-cpp.json
+++ b/versions/d-/decimal-for-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "451174497c4e96e3301b3bd4949459dcbe2fc709",
+      "version": "1.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "a78e582f830db392c8d551f3008a5977dad45692",
       "version": "1.18",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
