### PR TITLE
[piex] Updated to 0.27

### DIFF
--- a/ports/piex/CMakeLists.txt
+++ b/ports/piex/CMakeLists.txt
@@ -1,45 +1,95 @@
-cmake_minimum_required(VERSION 3.8.0)
-project(piex)
+cmake_minimum_required(VERSION 3.16)
 
+project(piex LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# See https://github.com/google/piex/blob/master/piex.gyp
 if(MSVC)
-  add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
+    add_compile_options(/W3 /wd4005 /wd4996 /wd4018)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+else()
+    add_compile_options(-Wsign-compare -Wsign-conversion -Wunused-parameter)
 endif()
 
-include_directories(".")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_library(binary_parse
-  src/binary_parse/cached_paged_byte_array.cc
-  src/binary_parse/range_checked_byte_ptr.cc
+    src/binary_parse/cached_paged_byte_array.cc
+    src/binary_parse/cached_paged_byte_array.h
+    src/binary_parse/range_checked_byte_ptr.cc
+    src/binary_parse/range_checked_byte_ptr.h
 )
+target_compile_features(binary_parse PUBLIC cxx_std_20)
 
 add_library(image_type_recognition
-  src/image_type_recognition/image_type_recognition_lite.cc
+    src/image_type_recognition/image_type_recognition_lite.cc
 )
-
-target_link_libraries(image_type_recognition binary_parse)
-target_compile_features(image_type_recognition PUBLIC cxx_std_11)
+target_compile_features(image_type_recognition PUBLIC cxx_std_20)
+target_link_libraries(image_type_recognition PRIVATE
+    binary_parse
+)
 
 add_library(tiff_directory
-  src/tiff_directory/tiff_directory.cc
+    src/tiff_directory/tiff_directory.cc
+    src/tiff_directory/tiff_directory.h
 )
-
-target_link_libraries(tiff_directory binary_parse)
+target_compile_features(tiff_directory PUBLIC cxx_std_20)
+target_link_libraries(tiff_directory PRIVATE
+    binary_parse
+)
 
 add_library(piex
-  src/piex.cc
-  src/tiff_parser.cc
+    src/piex.cc
+    src/piex.h
+    src/piex_cr3.cc
+    src/piex_cr3.h
+    src/piex_types.h
+    src/tiff_parser.cc
+    src/tiff_parser.h
+)
+target_compile_features(piex PUBLIC cxx_std_20)
+target_link_libraries(piex PUBLIC
+    tiff_directory
+    image_type_recognition
+    binary_parse
 )
 
-target_link_libraries(piex tiff_directory image_type_recognition binary_parse)
-target_compile_features(piex PUBLIC cxx_std_11)
-
+include(GNUInstallDirs)
 install(
-  TARGETS piex
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+    TARGETS piex tiff_directory image_type_recognition binary_parse
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 if(NOT DISABLE_INSTALL_HEADERS)
-  install(FILES src/piex.h src/piex_types.h  DESTINATION include/src)
+    install(
+        FILES
+            src/piex.h
+            src/piex_types.h 
+            src/piex_cr3.h
+            src/tiff_parser.h
+        DESTINATION include/src
+    )
+
+    install(
+        FILES
+            src/binary_parse/cached_paged_byte_array.h
+            src/binary_parse/range_checked_byte_ptr.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/piex/binary_parse
+    )
+
+    install(
+        FILES
+            src/image_type_recognition/image_type_recognition_lite.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/piex/image_type_recognition
+    )
+
+    install(
+        FILES
+            src/tiff_directory/tiff_directory.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/piex/tiff_directory
+    )
 endif()

--- a/ports/piex/portfile.cmake
+++ b/ports/piex/portfile.cmake
@@ -1,11 +1,19 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+vcpkg_download_distfile(FIX_UPSTREAM_PR3
+    URLS https://github.com/google/piex/commit/4d59203c0aa957e9b80a7c7ca78f7af1771dc033.patch?full_index=1
+    SHA512 54eb8876204360be72e95d422ab147fd44cbb70749ccae8dd6167819b8f39ed522bc12b8273505a7da1c3a9c0eb85fd2ed98a10517f29ba9fc63de79aff62b53
+    FILENAME piex-pr-3.patch
+)
+
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO google/piex
-  REF 256bd102be288c19b4165e0ecc7097a18c004e92
-  SHA512 ae948588a99d586593788c995c3d65a488faaf99b2ab6c51ec39df7e11a42c89454dd505117e90b1f152f6abfc2e3e11f61b0af97e42ecdff0d978934e20f582
-  HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/piex
+    REF "v${VERSION}"
+    SHA512 4ab72ccce553e72b9a9b5bb164edb260e52caa527a8aa7b601906d7366a3c4b827845dd15fb319f130d677d417f20f1836b2faed56021b3a2be79e599abd6683
+    HEAD_REF master
+    PATCHES
+        "${FIX_UPSTREAM_PR3}"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -13,10 +21,13 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS_DEBUG
-      -DDISABLE_INSTALL_HEADERS=ON
+        -DDISABLE_INSTALL_HEADERS=ON
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/piex" RENAME copyright)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/piex/vcpkg.json
+++ b/ports/piex/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "piex",
-  "version-date": "2019-07-11",
-  "port-version": 2,
+  "version": "0.27",
   "description": "The Preview Image Extractor (PIEX) is designed to find and extract the largest",
   "homepage": "https://github.com/google/piex",
+  "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7861,8 +7861,8 @@
       "port-version": 0
     },
     "piex": {
-      "baseline": "2019-07-11",
-      "port-version": 2
+      "baseline": "0.27",
+      "port-version": 0
     },
     "pipewire": {
       "baseline": "1.6.7",

--- a/versions/p-/piex.json
+++ b/versions/p-/piex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef71237b1419909737628c92207fb22aee7a0c78",
+      "version": "0.27",
+      "port-version": 0
+    },
+    {
       "git-tree": "f9f7ad5427c18be18708d00150fe9ca33dc30a8a",
       "version-date": "2019-07-11",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: Switched to C++20, as they are using C++20 designated initializer.
