### PR TITLE
[plf-stack] Updated to 2.0.21

### DIFF
--- a/ports/plf-stack/portfile.cmake
+++ b/ports/plf-stack/portfile.cmake
@@ -1,14 +1,22 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_stack
-    REF fd497417c17119dd73068d69749b67a6f9ff00b7 # 2.0.13
-    SHA512 77796cb7e9e008744f28f6de8ab72afa3366ea578be9aec36a4b5eb623cc1efaafb26ebf55456d311b9ce11e6e0e61ba9c030ecf0c7df63c185a13ff2fe2f39b
+    REF 36fba46175151a9f9ed237f26f407b5c4a4f06b2 # 2.0.21
+    SHA512 0f605d003abcf9b1d772a4615db68b1230fbea6ef841f2e03829d2c9c08cacbd8c48872abb0c532296ee880c89079b3d8c64663afb40cc010749c99e9f3b572f
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/plf_stack.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(
+    COPY
+        "${SOURCE_PATH}/plf_stack.h"
+        "${SOURCE_PATH}/plf_tools.h"
+        "${SOURCE_PATH}/plf_tools_undef.h"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
 
-# Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/plf-stack/vcpkg.json
+++ b/ports/plf-stack/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plf-stack",
-  "version": "2.0.13",
+  "version": "2.0.21",
   "description": "A C++ data container replicating std::stack functionality but with better performance",
-  "homepage": "https://www.plflib.org/"
+  "homepage": "https://www.plflib.org",
+  "license": "Zlib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7917,7 +7917,7 @@
       "port-version": 0
     },
     "plf-stack": {
-      "baseline": "2.0.13",
+      "baseline": "2.0.21",
       "port-version": 0
     },
     "plib": {

--- a/versions/p-/plf-stack.json
+++ b/versions/p-/plf-stack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89db33cc061870a0dc5347dfe416967f7d3547bd",
+      "version": "2.0.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "c06e4de984a2d6291d94ff1694783994600880c5",
       "version": "2.0.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
