### PR TITLE
[plf-colony] Update to 7.7.11

### DIFF
--- a/ports/plf-colony/portfile.cmake
+++ b/ports/plf-colony/portfile.cmake
@@ -1,13 +1,16 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_colony
-    REF 9f3196a5d870907ace96f576e1f4ccb272efb281
-    SHA512 bcf2a5403df29be1f47c4ac01e6db1f4a115a86d63a8e3bc4f4aadf2f70e7f0c373630e8fb87f8c5ff09d87822cdd44aedbd157d45e56415762735a4b3d45138
+    REF 12455e05adb23fdb843f8b24da9afba5c5bd8505
+    SHA512 5530150802917f440b73558c3297519ef5eb653e00ae64e72e05e9a39e2f447254739e3c5d3b0d5dd40f617215d6f8a0cc5ce4e0600c2e056c1935a450865c38
     HEAD_REF master
 )
 
 file(COPY "${SOURCE_PATH}/plf_colony.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/plf-colony/vcpkg.json
+++ b/ports/plf-colony/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plf-colony",
-  "version": "7.6.10",
+  "version": "7.7.11",
   "description": "An unordered C++ data container providing fast iteration/insertion/erasure while maintaining pointer/iterator validity to non-erased elements regardless of insertions/erasures.",
-  "homepage": "https://plflib.org/colony.htm"
+  "homepage": "https://plflib.org/colony.htm",
+  "license": "Zlib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7893,7 +7893,7 @@
       "port-version": 0
     },
     "plf-colony": {
-      "baseline": "7.6.10",
+      "baseline": "7.7.11",
       "port-version": 0
     },
     "plf-hive": {

--- a/versions/p-/plf-colony.json
+++ b/versions/p-/plf-colony.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32d169747e62e12b79a35b0feafd7a6765f2ee84",
+      "version": "7.7.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "510bd2ea99e2234941e0dcae0888579edc3614d8",
       "version": "7.6.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
