### PR TITLE
[plf-hive] Update to 2026-09-06

### DIFF
--- a/ports/plf-hive/portfile.cmake
+++ b/ports/plf-hive/portfile.cmake
@@ -1,13 +1,16 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_hive
-    REF 5d4f13cafdc1bd5e23c4b5435e0f33f347d3b003
-    SHA512 9f32c8ad70851ba9e2db32c6d47999c2fe554f5e7fdab5803c3743c5df5ca881afacebeb37594dbb8a587df793eab9c7ccae05f20c48e7931cfbb30dd680f5ee
-    HEAD_REF master
+    REF aa47e3627a08251d6df2103ddc3be482eb9fa5b3 # commit date: 2026-09-06
+    SHA512 5e5660574575f7f0f5cae735e1b64922ada8f6cf9ae1cb5eb4f29039d4e0415a79241a0e00a63dd63cf654d55cba143fb370b2ec9d838428af25291794997d0d
+    HEAD_REF main
 )
 
 file(COPY "${SOURCE_PATH}/plf_hive.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/plf-hive/vcpkg.json
+++ b/ports/plf-hive/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plf-hive",
-  "version-date": "2025-12-22",
+  "version-date": "2026-09-06",
   "description": "plf::hive is a fork of plf::colony to match the current C++ standards proposal.",
-  "homepage": "https://plflib.org/colony.htm"
+  "homepage": "https://plflib.org/colony.htm",
+  "license": "Zlib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7897,7 +7897,7 @@
       "port-version": 0
     },
     "plf-hive": {
-      "baseline": "2025-12-22",
+      "baseline": "2026-09-06",
       "port-version": 0
     },
     "plf-indiesort": {

--- a/versions/p-/plf-hive.json
+++ b/versions/p-/plf-hive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d76bee54db3aa3801540e92abf44f80a9ac46d0",
+      "version-date": "2026-09-06",
+      "port-version": 0
+    },
+    {
       "git-tree": "61ec29501054eb034d51dc67343095d71772f3f9",
       "version-date": "2025-12-22",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
