### PR TITLE
[plf-indiesort] Update to 1.4.10

### DIFF
--- a/ports/plf-indiesort/portfile.cmake
+++ b/ports/plf-indiesort/portfile.cmake
@@ -1,14 +1,16 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_indiesort
-    REF fb28b3f24886253d4eaab5e05f23b8cf84238f1e
-    SHA512 1f8f7b8dbb698d22e02701d6991bf5525a825ac5404bdeba7b09bc7814175fedaeedebbd6aba4db587d5d93ab14d4f3e0dbe78a098b10e9c0d4efb1bc1456026
+    REF 23d3fb6e1f738d9ec6e05bd9e20a8d1f55df9eed
+    SHA512 42f468cbe948fee697f01e1547baed899cc55024ab28cc793dab0530c36faa08ca48011395c70d06e8d03c8e766dcaf87fee36cd2c611c8eb19f678cb917dd7b
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/plf_indiesort.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY "${SOURCE_PATH}/plf_indiesort.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-# Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/plf-indiesort/vcpkg.json
+++ b/ports/plf-indiesort/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plf-indiesort",
-  "version": "1.4.4",
+  "version": "1.4.10",
   "description": "A sort wrapper enabling both use of random-access sorting on non-random access containers, and increased performance for the sorting of large types.",
-  "homepage": "https://plflib.org/indiesort.htm"
+  "homepage": "https://plflib.org/indiesort.htm",
+  "license": "Zlib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7901,7 +7901,7 @@
       "port-version": 0
     },
     "plf-indiesort": {
-      "baseline": "1.4.4",
+      "baseline": "1.4.10",
       "port-version": 0
     },
     "plf-list": {

--- a/versions/p-/plf-indiesort.json
+++ b/versions/p-/plf-indiesort.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b258021895f1c28372d542729c261ec9deffccf8",
+      "version": "1.4.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "9906c63b4c60e46551fe19219cdd73b197e3bc73",
       "version": "1.4.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
