### PR TITLE
[plf-nanotimer] Update to 1.0.10

### DIFF
--- a/ports/plf-nanotimer/portfile.cmake
+++ b/ports/plf-nanotimer/portfile.cmake
@@ -1,14 +1,16 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_nanotimer
-    REF 344c8e6f87e2ee924e4b0ae7ed71803a0ce75981 # v1.0.8
-    SHA512 11db9b5fb818ad639f6e9076aa29c322ae24d9b071e72df54086a30b77cca3c2020fcb5f120fa56ef7712a7e5ba1db63bc191648499bae87a1b662a076ca8d39
+    REF 84f93c76df71500689835897e8ad119c1aeb5e68
+    SHA512 34c8a194c32b3745591965da2fa5a49332b46eeb6ecc0e1de7f149a687bc21dede8b0c4bb502228fcb4299de1af0c8381c95809a0365a69a63fd8bb0c6604bd7
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/plf_nanotimer.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY "${SOURCE_PATH}/plf_nanotimer.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-# Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/plf-nanotimer/vcpkg.json
+++ b/ports/plf-nanotimer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plf-nanotimer",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "description": "A simple C++ 03/11/etc timer class for ~microsecond-precision cross-platform benchmarking",
-  "homepage": "https://www.plflib.org/"
+  "homepage": "https://www.plflib.org",
+  "license": "Zlib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7909,7 +7909,7 @@
       "port-version": 0
     },
     "plf-nanotimer": {
-      "baseline": "1.0.8",
+      "baseline": "1.0.10",
       "port-version": 0
     },
     "plf-queue": {

--- a/versions/p-/plf-nanotimer.json
+++ b/versions/p-/plf-nanotimer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e38a39df0acd567441478cab009b611e580b695",
+      "version": "1.0.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b29ec0bb467ac19fe6de501ee4ebd64f17280f1",
       "version": "1.0.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
