### PR TITLE
[plf-queue] Update to 2.0.21

### DIFF
--- a/ports/plf-queue/portfile.cmake
+++ b/ports/plf-queue/portfile.cmake
@@ -1,13 +1,16 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_queue
-    REF 1fb9d87a210f7813450ee54a469f9f79ea4ec872
-    SHA512 bca6662f5b0c4dfad4b9c1192aced83cf379ed2f115b498ad98003b7201fa80cf00ee697c7c8f9a8f9fe7c979207a8e99dd58549e124ea041af25c9217d7ae6f 
+    REF c00f1052ac78beb9ab8b3f3eef28b3da953f9bde
+    SHA512 10f5f1cf4d1d81bd0863df8b2cd9d4bd1b273b620b5c860c95284b26009248f2aef5cc6e766a810c30921431cb7fac3d4140911555143a7e07e48c145d466ce2
     HEAD_REF main
 )
 
 file(COPY "${SOURCE_PATH}/plf_queue.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/plf-queue/vcpkg.json
+++ b/ports/plf-queue/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plf-queue",
-  "version": "2.2",
+  "version": "2.0.21",
   "description": "A data container replicating std::queue functionality but with better performance than standard library containers in a queue context. C++98/03/11/14/etc-compatible.",
-  "homepage": "https://plflib.org/queue.htm"
+  "homepage": "https://plflib.org/queue.htm",
+  "license": "Zlib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7913,7 +7913,7 @@
       "port-version": 0
     },
     "plf-queue": {
-      "baseline": "2.2",
+      "baseline": "2.0.21",
       "port-version": 0
     },
     "plf-stack": {

--- a/versions/p-/plf-queue.json
+++ b/versions/p-/plf-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd9c19967b34e3a6a794ff31c0f68eb2bed7b38b",
+      "version": "2.0.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0c79130ac83677dbf3cab43a5a8f17b0e5b1307",
       "version": "2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
