### PR TITLE
[daw-header-libraries] Update to 2.135.0

### DIFF
--- a/ports/daw-header-libraries/portfile.cmake
+++ b/ports/daw-header-libraries/portfile.cmake
@@ -1,9 +1,10 @@
-# Header-only library
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/header_libraries
     REF "v${VERSION}"
-    SHA512 0c75ae477c4e971d479ecdd9891028053e278211b75ce71ed808165e522520acfd863cc96c1bce5c5c0570766f760b7456c5840cd383bd12f16cffff2ed09de0
+    SHA512 eb09fb16f9b75335d36f4d58e0d10f34ce791e8136e1e7e9c79b2fbeb521eac0f145170e69d6f73f7d223bed4a4f887f67cbe686b3957006484dd99ed4bc4e0a
     HEAD_REF master
 )
 
@@ -12,7 +13,9 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-# remove empty lib and debug/lib directories (and duplicate files from debug/include)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.md"
+)

--- a/ports/daw-header-libraries/vcpkg.json
+++ b/ports/daw-header-libraries/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-header-libraries",
-  "version": "2.132.1",
+  "version": "2.135.0",
   "description": "Set of header-only algorithms used in daw-utf8-range and daw-json-link.",
   "homepage": "https://github.com/beached/header_libraries",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2433,7 +2433,7 @@
       "port-version": 0
     },
     "daw-header-libraries": {
-      "baseline": "2.132.1",
+      "baseline": "2.135.0",
       "port-version": 0
     },
     "daw-json-link": {

--- a/versions/d-/daw-header-libraries.json
+++ b/versions/d-/daw-header-libraries.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1fe714006c5cbb8ecf1cbe49373de831124e0961",
+      "version": "2.135.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cfe668913cf69e39fc65e3ea7398fe61803bd9e3",
       "version": "2.132.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
