### PR TITLE
[efsw] Update to 1.7.2

### DIFF
--- a/ports/efsw/portfile.cmake
+++ b/ports/efsw/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SpartanJ/efsw
     REF "${VERSION}"
-    SHA512 d745f1c61ca80c69aff657a25f35e07bcae548bfe15fe36a8392e467b04d67b78a271e9bdd9b744c607c8fdf558c3046ad5986a20e9b4527078f4e36c60ad5c4
+    SHA512 6614314b96efe983647f3bd21870165e9c26ecf555bea0916f993f93221a491d997a16e847b34bc6db097599667917e71f570f591899e650a510a82297f7b6ad
     HEAD_REF master
 )
 
@@ -27,4 +27,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE"
+    "${SOURCE_PATH}/src/efsw/String.hpp"
+)

--- a/ports/efsw/vcpkg.json
+++ b/ports/efsw/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "efsw",
-  "version": "1.6.3",
+  "version": "1.7.2",
   "description": "efsw is a C++ cross-platform file system watcher and notifier.",
   "homepage": "https://github.com/SpartanJ/efsw",
-  "license": "MIT",
+  "license": "MIT AND Zlib",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2809,7 +2809,7 @@
       "port-version": 0
     },
     "efsw": {
-      "baseline": "1.6.3",
+      "baseline": "1.7.2",
       "port-version": 0
     },
     "egl": {

--- a/versions/e-/efsw.json
+++ b/versions/e-/efsw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "091c51cf228795d269c98dd51eacbbba875508fc",
+      "version": "1.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "34d2de87ccaa366967171601454bbf9379d7821b",
       "version": "1.6.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Closes #53631