### PR TITLE
[open62541] Update to 1.4.20

### DIFF
--- a/ports/open62541/android.patch
+++ b/ports/open62541/android.patch
@@ -1,17 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index acbd6b4971..1ed8cb72ab 100644
+index 34b947883..4533874db 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -495,10 +495,10 @@ set(open62541_LIBRARIES "")
- set(open62541_PUBLIC_LIBRARIES "")
+@@ -496,11 +496,11 @@ set(pkgcfg_requiresprivate "")
  if("${UA_ARCHITECTURE}" STREQUAL "posix")
      list(APPEND open62541_LIBRARIES "m")
+     list(APPEND pkgcfg_libsprivate "-lm")
 -    if(UA_MULTITHREADING GREATER_EQUAL 100 OR UA_BUILD_UNIT_TESTS)
 +    if(UA_MULTITHREADING GREATER_EQUAL 100 OR UA_BUILD_UNIT_TESTS AND NOT ANDROID)
          list(APPEND open62541_PUBLIC_LIBRARIES "pthread")
+         list(APPEND pkgcfg_libsprivate "-lpthread")
      endif()
 -    if(NOT APPLE AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD"))
 +    if(NOT APPLE AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") AND NOT ANDROID)
          list(APPEND open62541_LIBRARIES "rt")
+         list(APPEND pkgcfg_libsprivate "-lrt")
      endif()
- elseif("${UA_ARCHITECTURE}" STREQUAL "win32")

--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open62541/open62541
-    REF v${VERSION}
-    SHA512 521e29921d7aed6ee9766a1781c28071447ec0046f02a23376798ac35c18feba37cc0f4c217df41abb1c4470b7bf7aae26cf88da0ec8136f64a969be9ff56426
+    REF "v${VERSION}"
+    SHA512 8471e97cbcdcddae7bac5350bec56527c35018a5cbe75474544edf212424529987dd5f74479d6274911db7aaeac355bcf911fe9fdd170b0cc54de70f8aa3549e
     HEAD_REF master
     PATCHES
       android.patch
@@ -66,8 +66,13 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/open62541")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/open62541/tools")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/open62541/tools"
+)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "open62541",
-  "version": "1.4.14",
+  "version": "1.4.20",
   "description": "open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.",
   "homepage": "https://open62541.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7417,7 +7417,7 @@
       "port-version": 0
     },
     "open62541": {
-      "baseline": "1.4.14",
+      "baseline": "1.4.20",
       "port-version": 0
     },
     "open62541pp": {

--- a/versions/o-/open62541.json
+++ b/versions/o-/open62541.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48e51bf51091deb4767ca38d250f8f16f5d5115e",
+      "version": "1.4.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "f50f1f5deb97ad70454ef0fdce0c0cfd9628430f",
       "version": "1.4.14",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

// Edit: `open62541pp` is not compatibel with 1.5.x, see: https://github.com/open62541pp/open62541pp/issues/695. Same for `qtopcua` => downgrading this PR to 1.4.20
