### PR TITLE
[bzip3] Update to 1.5.4

### DIFF
--- a/ports/bzip3/portfile.cmake
+++ b/ports/bzip3/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO iczelia/bzip3
-    REF ${VERSION}
-    SHA512 4864db82af7bfb4b9753a4dfc6b966fb707607b5e5693134b6771a4c745a2cbe5767928c54f36ba89181d59dc2882d5630379c60655e23d0e7b2a0997d655aef
+    REF "${VERSION}"
+    SHA512 159144b14f1e118e736bbef21ccb3cbf350d863719508217878d22835885912e8cd898704ced76a3ac5cee91d90e75bc0a81d9e64bf7cd6f4e5330b5a3564e5e
     HEAD_REF master
     PATCHES
         disable-man.patch
@@ -23,8 +23,15 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/bzip3)
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig"
+)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/3rdparty/libsais-LICENSE"
+)

--- a/ports/bzip3/vcpkg.json
+++ b/ports/bzip3/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "bzip3",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A better and stronger spiritual successor to BZip2.",
   "homepage": "https://github.com/kspalaiologos/bzip3/",
-  "license": "LGPL-3.0-or-later",
+  "license": "LGPL-3.0-or-later AND Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/bzip3.json
+++ b/versions/b-/bzip3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d44e9787145b5c06a8c2aa180786ef12cb0b616c",
+      "version": "1.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "274144c8b721d4db5a1e15126c1cf9a159016166",
       "version": "1.5.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1565,7 +1565,7 @@
       "port-version": 6
     },
     "bzip3": {
-      "baseline": "1.5.3",
+      "baseline": "1.5.4",
       "port-version": 0
     },
     "c-ares": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
