### PR TITLE
[libdivide] Update to 5.4.0

### DIFF
--- a/ports/libdivide/portfile.cmake
+++ b/ports/libdivide/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ridiculousfish/libdivide
     REF "v${VERSION}"
-    SHA512 0a60d2ab750116faefc7db7a5209599d4fac5bfd74f7ad7377a525a65d4523855f395eb3e62e75a9eb9bf4d564354a40b2a056737bcf6c21cb6b7fb1f5918453
+    SHA512 df2e0b0f1b5a84e8e1ab2a362d21a77f5d07412619722ab4c0c7eeb7d039c056acdd45006b1049cdd1fe2abb39ea460c1626f6a8279ea2091de8ef4446ac8ea6
     HEAD_REF master
     PATCHES
         no-werror.patch

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "5.4.0",
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
+  "license": "BSL-1.0 OR Zlib",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdivide",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4961,7 +4961,7 @@
       "port-version": 12
     },
     "libdivide": {
-      "baseline": "5.3.0",
+      "baseline": "5.4.0",
       "port-version": 0
     },
     "libdjinterop": {

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "408fabdd569fc36a3ce2e3cb9bdfa0560237925f",
+      "git-tree": "85d774783667ed4757a2b616a1d390d5b1df9579",
       "version": "5.4.0",
       "port-version": 0
     },

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "408fabdd569fc36a3ce2e3cb9bdfa0560237925f",
+      "version": "5.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee96d21ae7eb9c87ea8332c73fc39a9cbfe8f05b",
       "version": "5.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
