### PR TITLE
[libpcap] Update to 1.10.7

### DIFF
--- a/ports/libpcap/portfile.cmake
+++ b/ports/libpcap/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO the-tcpdump-group/libpcap
     REF "libpcap-${VERSION}"
-    SHA512 eb0a627cabdc4fab8f56e81065469a6fad713681d06c43e7a3080896cad3925e8b22c6957fcc0439e9229b3ebf21af55d22cd89c8494342e4188bb0ac193c7ab
+    SHA512 58c50265ce10a0e30f5bbc372719ca6cac870db8909905db7cc68978b5ab3ca9c95c1b0b1a92cda6d21d2300f32e5e69b5b061d411ab50f76fcebb0bcc9d4dab
     HEAD_REF master
     PATCHES
         install.diff

--- a/ports/libpcap/vcpkg.json
+++ b/ports/libpcap/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "libpcap",
-  "version-semver": "1.10.6",
+  "version-semver": "1.10.7",
   "description": "A portable C/C++ library for network traffic capture",
-  "homepage": "https://www.tcpdump.org/",
+  "homepage": "https://www.tcpdump.org",
   "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5525,7 +5525,7 @@
       "port-version": 5
     },
     "libpcap": {
-      "baseline": "1.10.6",
+      "baseline": "1.10.7",
       "port-version": 0
     },
     "libpff": {

--- a/versions/l-/libpcap.json
+++ b/versions/l-/libpcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef4c4665d228d5deb78d874690b53454743ce24e",
+      "version-semver": "1.10.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ab17a2a48bbe68268a9b1e2b65796163ac4625f",
       "version-semver": "1.10.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
