### PR TITLE
[wukong-easy-sdk] Add version 0.1.0

### DIFF
--- a/ports/wukong-easy-sdk/portfile.cmake
+++ b/ports/wukong-easy-sdk/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO WuKongIM/WuKongEasySDK-CPP
+    REF "v${VERSION}"
+    SHA512 b1e380e5bb67f34cf2f56d9b5c82b28f0d73167911edd9bfc77bbea6d4e29d62a8319a2f517110896c3ff457992897f7b4e6066469ed75716cd80750e2ae9939
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DWUKONG_BUILD_TESTS=OFF
+        -DWUKONG_BUILD_EXAMPLES=OFF
+        -DWUKONG_FETCH_JSON=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME WuKongEasySDK CONFIG_PATH lib/cmake/WuKongEasySDK)
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/wukong-easy-sdk/vcpkg.json
+++ b/ports/wukong-easy-sdk/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "wukong-easy-sdk",
+  "version-semver": "0.1.0",
+  "description": "C++17 WebSocket JSON-RPC client for WuKongIM",
+  "homepage": "https://github.com/WuKongIM/WuKongEasySDK-CPP",
+  "license": "MIT",
+  "supports": "!uwp & !android & !ios & !emscripten",
+  "dependencies": [
+    "boost-beast",
+    "nlohmann-json",
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11104,6 +11104,10 @@
       "baseline": "10.0.10320",
       "port-version": 5
     },
+    "wukong-easy-sdk": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "wxchartdir": {
       "baseline": "2.0.0",
       "port-version": 2

--- a/versions/w-/wukong-easy-sdk.json
+++ b/versions/w-/wukong-easy-sdk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "db2a4f3f497e202bfc92e78151d275091d85fefd",
+      "version-semver": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds `wukong-easy-sdk` 0.1.0, the official C++17 WebSocket JSON-RPC client for WuKongIM. The port builds the immutable [v0.1.0 release](https://github.com/WuKongIM/WuKongEasySDK-CPP/releases/tag/v0.1.0) from source, disables tests/examples/JSON fetching, resolves Boost.Beast, OpenSSL and nlohmann/json through vcpkg, and preserves the upstream `WuKongEasySDK::WuKongEasySDK` CMake target. No patches or bundled dependencies are used. The SDK is static; dependency/CRT linkage follows the selected triplet.

### Project readiness and naming

The C++ SDK itself is newly released; it does **not** claim six months of history. It is an official component maintained under [WuKongIM](https://github.com/WuKongIM), whose messaging server has public releases dating to [v1.0.0 on May 25, 2023](https://github.com/WuKongIM/WuKongIM/releases/tag/v1.0.0). The official [C++ integration documentation](https://docs.githubim.com/en/sdk/easy/cpp/getting-started) identifies this SDK. This submission relies on the maintainer guide's official-component maturity criterion; acceptance remains subject to maintainer review.

`wukong-easy-sdk` combines the WuKong project brand with the EasySDK component name (Owner-Project form). It also preserves the name already used by the project's [public Git registry](https://github.com/WuKongIM/WuKongEasySDK-CPP/blob/main/docs/VCPKG.md). `CPP` is the language-specific repository suffix. There is no existing curated port with this name.

### Validation

- Current vcpkg `master`: `04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4`.
- This exact port: `arm64-osx`, AppleClang 16, source download/SHA512 validation, Debug and Release installation, and `--enforce-port-checks` all passed.
- A separate consumer declaring only the exported SDK CMake target compiled, linked and ran SDK lifecycle/shutdown code in both Debug and Release. OpenSSL resolved inside the vcpkg installation in both configurations.
- Direct `clang++` compilation using only the installed root include directory and explicit SDK/OpenSSL libraries also linked and ran successfully in Debug and Release.
- A second independent manifest consumer resolved the remote fork as its default Git registry at `566a5e94185a8d54967d59b2783f75b9c22d2915`, with `reference: codex/wukong-easy-sdk` to select the unmerged version index. Installation and Debug/Release compile, link and lifecycle execution passed without overlay ports. This verifies the committed version tree as well as the port recipe.
- Automatically generated `vcpkg print-usage` correctly reports the upstream package and target, so no redundant usage file is added. The installed copyright matches the upstream MIT license.
- `vcpkg format-manifest`, `vcpkg x-add-version --all`, and `vcpkg x-ci-verify-versions` passed.
- Additional SDK evidence: [Linux/macOS/Windows source and custom-registry CI](https://github.com/WuKongIM/WuKongEasySDK-CPP/actions/runs/34193817776) and [independent release archive acceptance](https://github.com/WuKongIM/WuKongEasySDK-CPP/actions/runs/34193824542). These are supplemental evidence, not a claim that this new curated port has passed Microsoft's CI. The release and the previously validated registry source have identical `src/`, `include/`, `cmake/`, and `CMakeLists.txt` contents.

### New port checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [x] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<img width="1096" height="1147" alt="image" src="https://github.com/user-attachments/assets/a440ce2e-af2b-47b4-9c6f-bbb2ad161cd7" />
