### PR TITLE
[opencv4] Add nvcuvid feature for NVDEC video decoding

### DIFF
--- a/ports/opencv4/0029-nvidia-video-codec-sdk-dir.patch
+++ b/ports/opencv4/0029-nvidia-video-codec-sdk-dir.patch
@@ -1,0 +1,31 @@
+diff --git a/cmake/OpenCVDetectCUDA.cmake b/cmake/OpenCVDetectCUDA.cmake
+index c2179da..1023a44 100644
+--- a/cmake/OpenCVDetectCUDA.cmake
++++ b/cmake/OpenCVDetectCUDA.cmake
+@@ -67,6 +67,9 @@ include(cmake/OpenCVDetectCUDAUtils.cmake)
+ 
+ if(WITH_NVCUVID OR WITH_NVCUVENC)
+   set(cuda_toolkit_dirs "${CUDA_TOOLKIT_TARGET_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}")
++  if(NVIDIA_VIDEO_CODEC_SDK_DIR)
++    set(cuda_toolkit_dirs "${NVIDIA_VIDEO_CODEC_SDK_DIR}" ${cuda_toolkit_dirs})
++  endif()
+   ocv_check_for_nvidia_video_codec_sdk("${cuda_toolkit_dirs}")
+ endif()
+ 
+diff --git a/cmake/OpenCVDetectCUDALanguage.cmake b/cmake/OpenCVDetectCUDALanguage.cmake
+index bc40134..d691384 100644
+--- a/cmake/OpenCVDetectCUDALanguage.cmake
++++ b/cmake/OpenCVDetectCUDALanguage.cmake
+@@ -72,7 +72,11 @@ if(WITH_CUDNN)
+ endif()
+ 
+ if(WITH_NVCUVID OR WITH_NVCUVENC)
+-  ocv_check_for_nvidia_video_codec_sdk("${CUDAToolkit_LIBRARY_ROOT}")
++  set(cuda_toolkit_dirs "${CUDAToolkit_LIBRARY_ROOT}")
++  if(NVIDIA_VIDEO_CODEC_SDK_DIR)
++    set(cuda_toolkit_dirs "${NVIDIA_VIDEO_CODEC_SDK_DIR}" ${cuda_toolkit_dirs})
++  endif()
++  ocv_check_for_nvidia_video_codec_sdk("${cuda_toolkit_dirs}")
+ endif()
+ 
+ ocv_check_for_cmake_cuda_architectures()

--- a/ports/opencv4/0030-contrib-nvidia-video-codec-sdk-dir.patch
+++ b/ports/opencv4/0030-contrib-nvidia-video-codec-sdk-dir.patch
@@ -1,0 +1,17 @@
+diff --git a/modules/cudacodec/CMakeLists.txt b/modules/cudacodec/CMakeLists.txt
+index a2dd450..deddf32 100644
+--- a/modules/cudacodec/CMakeLists.txt
++++ b/modules/cudacodec/CMakeLists.txt
+@@ -17,7 +17,11 @@ endif()
+ 
+ ocv_add_module(cudacodec ${required_dependencies} OPTIONAL opencv_cudev WRAP python)
+ 
+-ocv_module_include_directories()
++if(NVIDIA_VIDEO_CODEC_SDK_DIR)
++  ocv_module_include_directories("${NVIDIA_VIDEO_CODEC_SDK_DIR}/include")
++else()
++  ocv_module_include_directories()
++endif()
+ ocv_glob_module_sources()
+ 
+ set(extra_libs "")

--- a/ports/opencv4/nvcuvid-shim.h
+++ b/ports/opencv4/nvcuvid-shim.h
@@ -1,0 +1,58 @@
+// Installed as <nvcuvid.h> for OpenCV's cudacodec module.
+//
+// The NVIDIA Video Codec SDK is not redistributable, but the NVDEC API it
+// describes is also published by NVIDIA under MIT in FFmpeg's nv-codec-headers
+// (the ffnvcodec port). Those headers declare each entry point as a function
+// *type* (tcuvidXxx) because FFmpeg resolves them with LoadLibrary at runtime.
+// OpenCV links them instead, so declare the corresponding functions here. The
+// import library is generated from nvcuvid.def; at run time the calls land in
+// the driver's nvcuvid.dll either way.
+
+#ifndef OPENCV_VCPKG_NVCUVID_H
+#define OPENCV_VCPKG_NVCUVID_H
+
+#include <cuda.h>
+
+#include <ffnvcodec/dynlink_nvcuvid.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern tcuvidCreateVideoSource cuvidCreateVideoSource;
+extern tcuvidCreateVideoSourceW cuvidCreateVideoSourceW;
+extern tcuvidDestroyVideoSource cuvidDestroyVideoSource;
+extern tcuvidSetVideoSourceState cuvidSetVideoSourceState;
+extern tcuvidGetVideoSourceState cuvidGetVideoSourceState;
+extern tcuvidGetSourceVideoFormat cuvidGetSourceVideoFormat;
+extern tcuvidGetSourceAudioFormat cuvidGetSourceAudioFormat;
+
+extern tcuvidCreateVideoParser cuvidCreateVideoParser;
+extern tcuvidParseVideoData cuvidParseVideoData;
+extern tcuvidDestroyVideoParser cuvidDestroyVideoParser;
+
+extern tcuvidGetDecoderCaps cuvidGetDecoderCaps;
+extern tcuvidCreateDecoder cuvidCreateDecoder;
+extern tcuvidDestroyDecoder cuvidDestroyDecoder;
+extern tcuvidDecodePicture cuvidDecodePicture;
+extern tcuvidGetDecodeStatus cuvidGetDecodeStatus;
+extern tcuvidReconfigureDecoder cuvidReconfigureDecoder;
+
+extern tcuvidMapVideoFrame64 cuvidMapVideoFrame64;
+extern tcuvidUnmapVideoFrame64 cuvidUnmapVideoFrame64;
+
+extern tcuvidCtxLockCreate cuvidCtxLockCreate;
+extern tcuvidCtxLockDestroy cuvidCtxLockDestroy;
+extern tcuvidCtxLock cuvidCtxLock;
+extern tcuvidCtxUnlock cuvidCtxUnlock;
+
+#ifdef __cplusplus
+}
+#endif
+
+// dynlink_cuviddec.h defines __CUVID_DEVPTR64 and aliases the typedef names;
+// the SDK header aliases the function names to match.
+#define cuvidMapVideoFrame cuvidMapVideoFrame64
+#define cuvidUnmapVideoFrame cuvidUnmapVideoFrame64
+
+#endif

--- a/ports/opencv4/nvcuvid.def
+++ b/ports/opencv4/nvcuvid.def
@@ -1,0 +1,30 @@
+; Import library definition for the NVDEC entry points of the NVIDIA display
+; driver's nvcuvid.dll. The names are those declared by the MIT-licensed
+; nv-codec-headers (ffnvcodec); no DLL or driver is needed to build the import
+; library from this file.
+LIBRARY nvcuvid.dll
+EXPORTS
+  cuvidCreateVideoSource
+  cuvidCreateVideoSourceW
+  cuvidDestroyVideoSource
+  cuvidSetVideoSourceState
+  cuvidGetVideoSourceState
+  cuvidGetSourceVideoFormat
+  cuvidGetSourceAudioFormat
+  cuvidCreateVideoParser
+  cuvidParseVideoData
+  cuvidDestroyVideoParser
+  cuvidGetDecoderCaps
+  cuvidCreateDecoder
+  cuvidDestroyDecoder
+  cuvidDecodePicture
+  cuvidGetDecodeStatus
+  cuvidReconfigureDecoder
+  cuvidMapVideoFrame
+  cuvidMapVideoFrame64
+  cuvidUnmapVideoFrame
+  cuvidUnmapVideoFrame64
+  cuvidCtxLockCreate
+  cuvidCtxLockDestroy
+  cuvidCtxLock
+  cuvidCtxUnlock

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -41,6 +41,7 @@ vcpkg_from_github(
       0025-fix-cuda-host-std-flag-forwarding.patch
       0026-cuda-msvc-preprocessor.patch
       0028-ffmpeg9-support.patch
+      0029-nvidia-video-codec-sdk-dir.patch
       "${PATCH1_FILE}"
       "${CUDA_13_SUPPORT_PATCH}"
 )
@@ -127,6 +128,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "jpegxl"     WITH_JPEGXL
  "msmf"       WITH_MSMF
  "nonfree"    OPENCV_ENABLE_NONFREE
+ "nvcuvid"    WITH_NVCUVID
  "thread"     OPENCV_ENABLE_THREAD_SUPPORT
  "opencl"     WITH_OPENCL
  "openvino"   WITH_OPENVINO
@@ -230,6 +232,7 @@ if("contrib" IN_LIST FEATURES)
       0018-contrib-fix-tesseract.patch
       0019-contrib-cout.diff
       0027-contrib-cuda-tuple.patch # https://github.com/opencv/opencv_contrib/commit/054007b78c8288ef2fd040e77dc0cf2e45f70c15
+      0030-contrib-nvidia-video-codec-sdk-dir.patch
       "${CONTRIB_CUDA_NAMESPACE_FIX}"
       "${CONTRIB_CUDA_NOT1_FIX}"
   )
@@ -433,6 +436,37 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
   endif()
 endif()
 
+if("nvcuvid" IN_LIST FEATURES)
+  # cudacodec links the NVDEC entry points of the display driver's nvcuvid.dll. Those are
+  # described by the NVIDIA Video Codec SDK, which is not redistributable, but the same API is
+  # published by NVIDIA under MIT in nv-codec-headers (the ffnvcodec port). Assemble the two
+  # pieces OpenCV looks for -- a <nvcuvid.h> with plain prototypes, and an import library -- and
+  # point OpenCV at them. No SDK download and no driver are needed to build.
+  vcpkg_cmake_get_vars(cmake_vars_file)
+  include("${cmake_vars_file}")
+
+  set(NVCODEC_SDK_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-nvcodec-sdk")
+  file(REMOVE_RECURSE "${NVCODEC_SDK_DIR}")
+  file(MAKE_DIRECTORY "${NVCODEC_SDK_DIR}/include" "${NVCODEC_SDK_DIR}/lib")
+  file(COPY "${CURRENT_INSTALLED_DIR}/include/ffnvcodec" DESTINATION "${NVCODEC_SDK_DIR}/include")
+  file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/nvcuvid-shim.h"
+       DESTINATION "${NVCODEC_SDK_DIR}/include" RENAME "nvcuvid.h")
+
+  vcpkg_execute_required_process(
+    COMMAND "${VCPKG_DETECTED_CMAKE_AR}"
+            "/def:${CMAKE_CURRENT_LIST_DIR}/nvcuvid.def"
+            "/machine:${VCPKG_TARGET_ARCHITECTURE}"
+            "/out:${NVCODEC_SDK_DIR}/lib/nvcuvid.lib"
+    WORKING_DIRECTORY "${NVCODEC_SDK_DIR}"
+    LOGNAME "nvcuvid-implib-${TARGET_TRIPLET}"
+  )
+
+  list(APPEND ADDITIONAL_BUILD_FLAGS
+    "-DNVIDIA_VIDEO_CODEC_SDK_DIR=${NVCODEC_SDK_DIR}"
+    "-DCUDA_nvcuvid_LIBRARY=${NVCODEC_SDK_DIR}/lib/nvcuvid.lib"
+  )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -514,7 +548,6 @@ vcpkg_cmake_configure(
         -DWITH_JASPER=OFF #Jasper is deprecated and will be removed in a future release, and is mutually exclusive with openjpeg that is preferred
         -DWITH_LAPACK=OFF
         -DWITH_MATLAB=OFF
-        -DWITH_NVCUVID=OFF
         -DWITH_NVCUVENC=OFF
         -DWITH_OBSENSOR=OFF
         -DWITH_OPENCL_D3D11_NV=OFF

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.12.0",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://opencv.org/",
   "documentation": "https://docs.opencv.org/4.12.0/",
@@ -299,6 +299,26 @@
     },
     "nonfree": {
       "description": "allow nonfree and unredistributable libraries"
+    },
+    "nvcuvid": {
+      "description": "NVIDIA NVDEC hardware video decoding (cudacodec::VideoReader)",
+      "supports": "windows & x64 & !uwp & !mingw",
+      "dependencies": [
+        "ffnvcodec",
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "contrib",
+            "cuda",
+            "ffmpeg"
+          ]
+        },
+        {
+          "name": "vcpkg-cmake-get-vars",
+          "host": true
+        }
+      ]
     },
     "opencl": {
       "description": "Enable opencl support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7474,7 +7474,7 @@
     },
     "opencv4": {
       "baseline": "4.12.0",
-      "port-version": 9
+      "port-version": 10
     },
     "openexr": {
       "baseline": "3.4.15",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb6d42c64ee177665d4ecf01f4692d77237e1f5d",
+      "version": "4.12.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "e2f8fa75770e53767d505264a9748abfc3fdf5db",
       "version": "4.12.0",
       "port-version": 9


### PR DESCRIPTION
Adds an `nvcuvid` feature so `cudacodec::VideoReader` can be used. The portfile currently
passes `-DWITH_NVCUVID=OFF` unconditionally, outside `${FEATURE_OPTIONS}`, so nvcuvid-accelerated decoding is not available. OpenCV's own default for the option is ON.

#13120 asked for this feature and was closed by #38928, which added the OFF line rather than the feature.

This PR was heavily generated with/by Claude Code, with me guiding and checking the work.

### Why this needs no Video Codec SDK

cudacodec calls the NVDEC entry points in the driver's `nvcuvid.dll`. The SDK that declares
them is not redistributable, but NVIDIA publishes the same API under MIT in nv-codec-headers,
which vcpkg already packages as `ffnvcodec`. The feature assembles the two things OpenCV looks
for, in the buildtree:

* `nvcuvid-shim.h`, installed as `<nvcuvid.h>`. nv-codec-headers declares each entry point as
a function type (`tcuvidXxx`) because FFmpeg resolves them with `LoadLibrary` at run time.
OpenCV links them instead, so the shim declares the matching functions and restores the x64
`cuvidMapVideoFrame`/`cuvidUnmapVideoFrame` aliases.
* `nvcuvid.def`, the exported symbol names, turned into an import library with `lib.exe /def:`.
An import library holds symbol names only, so this needs no DLL and no driver at build time.

Decode only; `WITH_NVCUVENC` stays off.

`ffmpeg[nvcodec]` is not required. cudacodec uses ffmpeg only to demux
(`CAP_PROP_FORMAT=-1`) and drives NVDEC itself.

### Patches

0029 and 0030 add `NVIDIA_VIDEO_CODEC_SDK_DIR` to OpenCV's SDK search. Upstream searches only
the CUDA toolkit directories, with `NO_DEFAULT_PATH`, and then discards the path it finds, so
an SDK installed anywhere else can neither be detected nor included. The CUDA Toolkit has not
shipped these files for many releases: I checked 11.7, 12.1, 12.3, 12.4, 12.5, 12.6, 12.8,
12.9 and 13.3, and none contains a cuvid header or import library. The patches are not
vcpkg-specific, and could/should be upstreamed. If this approach is acceptable to vcpkg maintainers, I'm happy to create the upstream PRs.

### Verification

Built `opencv4[core,nvcuvid]` on x64-windows with CUDA 13.3:

* `-- Verifying WITH_NVCUVID=ON => 'HAVE_NVCUVID'=TRUE`
* `NVIDIA CUDA: YES (ver 13.3.73, CUFFT CUBLAS NVCUVID)`
* `opencv_cudacodec4.dll` imports 18 cuvid symbols from `nvcuvid.dll`
* `cudacodec::VideoReader` decoded 60 frames of H.264 into a `GpuMat`

With the feature off, `vcpkg_check_features` still emits `-DWITH_NVCUVID=OFF`, so existing
builds are unchanged.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (no downloads were changed)
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature
baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed
to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.