### PR TITLE
[arrow-adbc] Update to 24

### DIFF
--- a/ports/arrow-adbc/portfile.cmake
+++ b/ports/arrow-adbc/portfile.cmake
@@ -2,11 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/arrow-adbc
     REF apache-arrow-adbc-${VERSION}
-    SHA512 48f3e5663ae59d3910f0e545f0bad68778151017e7a67804143832a5812126ff5796db18e9584be75dcedae751f294f13457600964bb84c1038f65eb285c2d05
+    SHA512 2c325413c4af45642d956263f6a3e56012d7468cc3edf7a4dad325d85aab9469d066af42036983d770f2d8fc366841652455c63cb242ecc4b57b35481795c1cf
     HEAD_REF main
 )
-file(REMOVE_RECURSE "${SOURCE_PATH}/c/vendor/fmt")
-file(REMOVE_RECURSE "${SOURCE_PATH}/c/vendor/nanoarrow")
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/c/vendor/fmt"
+    "${SOURCE_PATH}/c/vendor/nanoarrow"
+)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -61,9 +63,11 @@ if("sqlite" IN_LIST FEATURES)
 endif()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib/cmake"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/arrow-adbc/vcpkg.json
+++ b/ports/arrow-adbc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow-adbc",
-  "version": "23",
+  "version": "24",
   "description": "Apache Arrow ADBC: Database Connectivity API for Arrow-based data systems",
   "homepage": "https://arrow.apache.org/adbc/",
   "license": "Apache-2.0",

--- a/versions/a-/arrow-adbc.json
+++ b/versions/a-/arrow-adbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9df8c8b9003dec044469fa2ce5a4378973968c77",
+      "version": "24",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa02a797ad44ad1d2630ab27ed8d5f664da6dff2",
       "version": "23",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -297,7 +297,7 @@
       "port-version": 0
     },
     "arrow-adbc": {
-      "baseline": "23",
+      "baseline": "24",
       "port-version": 0
     },
     "arsenalgear": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
