### PR TITLE
[kuku] Update to 4.0.0

### DIFF
--- a/ports/kuku/portfile.cmake
+++ b/ports/kuku/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/Kuku
     REF "v${VERSION}"
-    SHA512 c5c79d0ca94e4a02786934ac419311ce2a46090b8846b885ec11f24205977a02270a14bbd7178b82eb9284e3345c89a421b710171bac5946491a61c9661775b8
+    SHA512 7d0e303d09e78db2886687d7785bff3efd32fcfb1e14d468264440b4e935722a187db9298471d0f5fbbc3c67a78a1cecc3ba4954c2c538fb249f730dcadd9fb9
     HEAD_REF main
 )
 
@@ -20,4 +20,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Kuku)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/NOTICE")

--- a/ports/kuku/vcpkg.json
+++ b/ports/kuku/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "kuku",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Kuku is a compact and convenient cuckoo hashing library written in C++.",
   "homepage": "https://github.com/microsoft/Kuku",
-  "license": "MIT",
+  "license": "MIT AND CC0-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4645,7 +4645,7 @@
       "port-version": 1
     },
     "kuku": {
-      "baseline": "3.0.0",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "kvasir-mpl": {

--- a/versions/k-/kuku.json
+++ b/versions/k-/kuku.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca91c7988243d3d4197572ed8743157f81435dec",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e3e5a5a120cae618458803ff7c6b4590bd2ea8ed",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

NOTE: Portfile shows all lines changed because I fixed line endings to LF form.