### PR TITLE
[azure-messaging-eventhubs-cpp] Fix AMQP minimum version for beta.15

### DIFF
--- a/ports/azure-messaging-eventhubs-cpp/vcpkg.json
+++ b/ports/azure-messaging-eventhubs-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   ],
   "name": "azure-messaging-eventhubs-cpp",
   "version-semver": "1.0.0-beta.15",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Messaging Event Hubs SDK for C++",
     "This library provides Azure Messaging Event Hubs SDK."
@@ -15,7 +16,7 @@
     {
       "name": "azure-core-amqp-cpp",
       "default-features": false,
-      "version>=": "1.0.0-beta.12"
+      "version>=": "1.0.0-beta.13"
     },
     {
       "name": "azure-core-cpp",

--- a/versions/a-/azure-messaging-eventhubs-cpp.json
+++ b/versions/a-/azure-messaging-eventhubs-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18216b8b17e9e75facd7075b3c07256139ad9085",
+      "version-semver": "1.0.0-beta.15",
+      "port-version": 1
+    },
+    {
       "git-tree": "71cd240c581faf75ef36c15410442954b10f64b6",
       "version-semver": "1.0.0-beta.15",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -574,7 +574,7 @@
     },
     "azure-messaging-eventhubs-cpp": {
       "baseline": "1.0.0-beta.15",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-security-attestation-cpp": {
       "baseline": "1.1.0",


### PR DESCRIPTION
## Summary

Event Hubs `1.0.0-beta.15`, published in #53848, calls `MessageSender::IsLinkDetached()`. The port currently permits `azure-core-amqp-cpp` beta.12, which does not provide that API. An older consumer baseline can therefore select a dependency that fails to compile.

The upstream port template already requires beta.13 through Azure/azure-sdk-for-cpp#7400. This change applies that correction to the published vcpkg port as `1.0.0-beta.15#1`.

## Changes

- Raise the `azure-core-amqp-cpp` minimum from `1.0.0-beta.12` to `1.0.0-beta.13`.
- Set `port-version` to 1 and update the baseline and version database.
- Preserve all existing version entries and the beta.15 source archive and SHA512.

## Validation

- Reproduced dependency resolution with baseline `04a9d8e52`: beta.15 selects AMQP beta.12 and the `IsLinkDetached()` compile probe fails. Requesting beta.15#1 under the same baseline selects beta.13 and the probe passes.
- Built and installed the revised port from source on `arm64-osx` using `vcpkg install azure-messaging-eventhubs-cpp:arm64-osx --classic --editable --enforce-port-checks`. Debug, Release, and post-build validation pass. Dependencies were restored from the local binary cache.
- Configured, built, and ran a C++14 consumer through `find_package(azure-messaging-eventhubs-cpp CONFIG REQUIRED)` in Debug and Release. An `EventData` AMQP round trip passes in both configurations.
- Manifest formatting, LF checks, `vcpkg x-add-version --all`, `vcpkg x-ci-verify-versions`, and `git diff --check` pass. The new version tree matches the port contents, and all historical entries are preserved.

No download updates, port patches, platform support changes, or CI baseline changes are required.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
