### PR TITLE
[cpp-client-telemetry] Remove deprecated iOS option

### DIFF
--- a/ports/cpp-client-telemetry/portfile.cmake
+++ b/ports/cpp-client-telemetry/portfile.cmake
@@ -14,12 +14,6 @@ if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
   set(MATSDK_BUILD_APPLE_HTTP ON)
 endif()
 
-# iOS build options
-set(MATSDK_BUILD_IOS OFF)
-if(VCPKG_TARGET_IS_IOS)
-  set(MATSDK_BUILD_IOS ON)
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -42,7 +36,6 @@ vcpkg_cmake_configure(
         -DMATSDK_ZLIB_PROVIDER=SYSTEM
         -DBUILD_VERSION=${VERSION}
         -DMATSDK_BUILD_APPLE_HTTP=${MATSDK_BUILD_APPLE_HTTP}
-        -DBUILD_IOS=${MATSDK_BUILD_IOS}
 )
 
 vcpkg_cmake_install()

--- a/ports/cpp-client-telemetry/vcpkg.json
+++ b/ports/cpp-client-telemetry/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpp-client-telemetry",
   "version": "3.10.240.1",
+  "port-version": 1,
   "description": "Microsoft 1DS C/C++ Client Telemetry Library",
   "homepage": "https://github.com/microsoft/cpp_client_telemetry",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2042,7 +2042,7 @@
     },
     "cpp-client-telemetry": {
       "baseline": "3.10.240.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cpp-exiftool": {
       "baseline": "1.8.0",

--- a/versions/c-/cpp-client-telemetry.json
+++ b/versions/c-/cpp-client-telemetry.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bb09d6bba630af1bbe68c83f5283e1b7853c08c",
+      "version": "3.10.240.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "822b36ac2386737809f118d1dc4a92f4755eb76f",
       "version": "3.10.240.1",
       "port-version": 0


### PR DESCRIPTION
Fixes the follow-up noted in microsoft/vcpkg#53679.

The vcpkg toolchain already sets `CMAKE_SYSTEM_NAME=iOS`, which cpp-client-telemetry 3.10.240.1 uses for iOS targeting. Stop passing the deprecated `BUILD_IOS` compatibility option and increment the port revision.

The separate upstream SQLite target warning is addressed by microsoft/cpp_client_telemetry#1532 and will be included in a future source release.

Validation:
- `vcpkg format-manifest ports/cpp-client-telemetry/vcpkg.json`
- `vcpkg x-add-version cpp-client-telemetry --overwrite-version`
- the same option removal is covered by the iOS vcpkg and embedding jobs in microsoft/cpp_client_telemetry#1532