### PR TITLE
[polyxml] Add port polyxml 0.1.0

### DIFF
--- a/ports/polyxml/portfile.cmake
+++ b/ports/polyxml/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nth-bailey/PolyXML
+    REF "v${VERSION}"
+    SHA512 7e30417433494e02d93df729adc5e27ee6a84d1ef682bf1dd101ece71b09256a8bd019bfa8cbabb48474a46d6ef49622232c75840f0d2747e8832592d7bfa495
+    HEAD_REF main
+)
+
+vcpkg_find_acquire_program(CARGO)
+
+message(STATUS "Building native Rust polyxml-c library...")
+vcpkg_execute_required_process(
+    COMMAND ${CARGO} build --release -p polyxml-c
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME "cargo-build-${TARGET_TRIPLE}"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/bindings/cpp"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME polyxml_cpp)
+
+file(INSTALL "${SOURCE_PATH}/crates/polyxml-c/include/polyxml.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL "${SOURCE_PATH}/target/release/polyxml.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin" OPTIONAL)
+    file(INSTALL "${SOURCE_PATH}/target/release/polyxml.dll.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib" OPTIONAL)
+elseif(VCPKG_TARGET_IS_OSX)
+    file(INSTALL "${SOURCE_PATH}/target/release/libpolyxml.dylib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib" OPTIONAL)
+else()
+    file(INSTALL "${SOURCE_PATH}/target/release/libpolyxml.so" DESTINATION "${CURRENT_PACKAGES_DIR}/lib" OPTIONAL)
+endif()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/polyxml/portfile.cmake
+++ b/ports/polyxml/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_find_acquire_program(CARGO)
+find_program(CARGO NAMES cargo cargo.exe HINTS "$ENV{CARGO_HOME}/bin" "$ENV{USERPROFILE}/.cargo/bin" "$ENV{HOME}/.cargo/bin" REQUIRED)
 
 message(STATUS "Building native Rust polyxml-c library...")
 vcpkg_execute_required_process(

--- a/ports/polyxml/vcpkg.json
+++ b/ports/polyxml/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "polyxml",
+  "version": "0.1.0",
+  "description": "High-performance, polyglot native XML data-binding engine built in Rust with C/C++ bindings",
+  "homepage": "https://github.com/nth-bailey/PolyXML",
+  "license": "MIT",
+  "supports": "(x64 | arm64) & (windows | linux | osx)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
﻿### Summary
Add new port `polyxml` version `0.1.0`.

PolyXML is a high-performance, polyglot native XML data-binding engine built in Rust with C/C++20 bindings.

#### Checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says (`0.1.0`).
- [x] The license declaration in `vcpkg.json` matches what upstream says (MIT).
- [x] The file installed as the "copyright" file matches what upstream says (LICENSE).
- [x] The source code of the component installed comes from an authoritative source (`https://github.com/nth-bailey/PolyXML`).
