### PR TITLE
[glib] Update to 2.90.0

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_download_distfile(GLIB_ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "${PORT}-${VERSION}.tar.xz"
-    SHA512 9e2b4985d5e4e06c6897a33cf8c100b9303528ebd72152c10e4cb734fa62fc011c84b816b20f686a3b2aac9a4a5a46f33e7517b4c4c7f3c25c75ac3ddc11f844
+    SHA512 5ca18b4e89d0efef40d6921c33903cad242ac664e4125e8161fa7d0f0c9c65c9a7ff61d9e3ac3eb7b780b7e113392a87d12b402000f8af76b8050ddae26d0a01
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glib",
-  "version": "2.88.3",
+  "version": "2.90.0",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later AND (LGPL-2.1-only OR MPL-1.1)",

--- a/ports/glibmm/glib_2_90_compatibility.patch
+++ b/ports/glibmm/glib_2_90_compatibility.patch
@@ -1,0 +1,39 @@
+diff --git a/untracked/gio/giomm/dbusactiongroup.h b/untracked/gio/giomm/dbusactiongroup.h
+index 1434ea1..d577ba9 100644
+--- a/untracked/gio/giomm/dbusactiongroup.h
++++ b/untracked/gio/giomm/dbusactiongroup.h
+@@ -28,8 +28,15 @@
+ 
+ 
+ #ifndef DOXYGEN_SHOULD_SKIP_THIS
+-using GDBusActionGroup = struct _GDBusActionGroup;
+-using GDBusActionGroupClass = struct _GDBusActionGroupClass;
++// GDBusActionGroup was declared a final type between GLib 2.89.1 and 2.89.2.
++// Before that, GDBusActionGroupClass was not declared in GLib.
++// The preprocessor macro G_DBUS_ACTION_GROUP_CLASS was defined, though.
++#if !GLIB_CHECK_VERSION(2,89,1) || (!GLIB_CHECK_VERSION(2,89,2) && defined(G_DBUS_ACTION_GROUP_CLASS))
++  // glib < 2.89.1 or (glib == 2.89.1 and G_DBUS_ACTION_GROUP_CLASS is a preprocessor macro)
++  // GDBusActionGroup is not a final type,
++  // GDBusActionGroupClass is not declared in GLib.
++  using GDBusActionGroupClass = struct _GDBusActionGroupClass;
++#endif
+ #endif /* DOXYGEN_SHOULD_SKIP_THIS */
+ 
+ 
+diff --git a/untracked/gio/giomm/emblem.h b/untracked/gio/giomm/emblem.h
+index e2267b3..b3d5a42 100644
+--- a/untracked/gio/giomm/emblem.h
++++ b/untracked/gio/giomm/emblem.h
+@@ -24,11 +24,10 @@
+ 
+ #include <glibmm/object.h>
+ #include <giomm/icon.h>
++#include <gio/gio.h>
+ 
+ 
+ #ifndef DOXYGEN_SHOULD_SKIP_THIS
+-using GEmblem = struct _GEmblem;
+-using GEmblemClass = struct _GEmblemClass;
+ #endif /* DOXYGEN_SHOULD_SKIP_THIS */
+ 
+ 

--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_download_distfile(GLIBMM_ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${GLIBMM_ARCHIVE}"
+    PATCHES
+        glib_2_90_compatibility.patch # Backport from glibmm 2.89.0 (devel version)
 )
 
 vcpkg_configure_meson(
@@ -29,7 +31,7 @@ file(REMOVE_RECURSE
 
 vcpkg_fixup_pkgconfig()
 
-# Handle copyright and readmes
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME readme.txt)
-file(INSTALL "${SOURCE_PATH}/README.win32.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/COPYING"
+)

--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glibmm",
   "version": "2.88.1",
+  "port-version": 1,
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3493,7 +3493,7 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.88.3",
+      "baseline": "2.90.0",
       "port-version": 0
     },
     "glib-networking": {
@@ -3502,7 +3502,7 @@
     },
     "glibmm": {
       "baseline": "2.88.1",
-      "port-version": 0
+      "port-version": 1
     },
     "glm": {
       "baseline": "1.0.3",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "144da0263279413e074c3400744d51d5e1f2ba92",
+      "version": "2.90.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "55b8805164a1d87ad844e59e7f49221a7a97b6ba",
       "version": "2.88.3",
       "port-version": 0

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88e58241f3f547793c0208ebc607e4ca2bc588a5",
+      "version": "2.88.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d25f6508618942911a63de0976e9f0a8b0b02255",
       "version": "2.88.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Note: removed installed readmes from glibmm as I think no one reads them there and partially not interesting.
