### PR TITLE
[slick-logger] Update to 1.3.0

### DIFF
--- a/ports/slick-logger/portfile.cmake
+++ b/ports/slick-logger/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-logger
     REF "v${VERSION}"
-    SHA512 48fcb8360e5bb663f207b633ec9c1fd378fa348106c7bc27cc8db5324ea005e3f789803a49db576c4d6f41c85b34437a4474f75f12fbdbca8605999eb3ea7771
+    SHA512 6d1ed7c46f7abbfd8173c79df40ac179da0cf47e9206dcc8db4da238ab2370671843ee56bd0c93e39ceb6c7dbf9c27124c6489cddcb5f5052e36dc26ba9c2fcc
     HEAD_REF main
     PATCHES
       slick-queue.patch

--- a/ports/slick-logger/slick-queue.patch
+++ b/ports/slick-logger/slick-queue.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c47da23..03e2f1e 100644
+index 49648a6..ee3b35e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -9,9 +9,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
  
  # 1.5.0 or newer is required: multi-process logging relies on the slick-shm based
  # shared-memory implementation introduced in slick-queue 1.3.0.
--find_package(slick-queue 1.5.0 CONFIG QUIET)
+-find_package(slick-queue 2.0.0 CONFIG QUIET)
 +find_package(slick-queue CONFIG REQUIRED)
  
 -if (NOT slick-queue_FOUND)
@@ -15,14 +15,14 @@ index c47da23..03e2f1e 100644
      include(FetchContent)
  
 diff --git a/cmake/slick-loggerConfig.cmake.in b/cmake/slick-loggerConfig.cmake.in
-index d7160a7..4c30d13 100644
+index 3528f3b..5754945 100644
 --- a/cmake/slick-loggerConfig.cmake.in
 +++ b/cmake/slick-loggerConfig.cmake.in
-@@ -3,7 +3,7 @@
+@@ -2,7 +2,7 @@
+ 
  include(CMakeFindDependencyMacro)
  
- # Find slick-queue dependency
--find_dependency(slick-queue 1.5.0 CONFIG)
+-find_dependency(slick-queue 2.0.0 CONFIG)
 +find_dependency(slick-queue CONFIG)
  
  include("${CMAKE_CURRENT_LIST_DIR}/slick-loggerTargets.cmake")

--- a/ports/slick-logger/vcpkg.json
+++ b/ports/slick-logger/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-logger",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A high-performance, cross-platform header-only logging library for C++20 using a multi-producer, multi-consumer ring buffer with multi-sink support and log rotation capabilities",
   "homepage": "https://github.com/SlickQuant/slick-logger",
   "license": "MIT",
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "slick-queue",
-      "version>=": "1.5.0"
+      "version>=": "2.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9461,7 +9461,7 @@
       "port-version": 0
     },
     "slick-logger": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "slick-net": {

--- a/versions/s-/slick-logger.json
+++ b/versions/s-/slick-logger.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2282b0c0d54acafb767e8d88ca3256cf6a8779c",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc4cbf51172d17c4606c5c6faaae179562027cc3",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
