### PR TITLE
[librdkafka] Update to 2.15.1

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO confluentinc/librdkafka
     REF "v${VERSION}"
-    SHA512 6da35f2d5b439451120a69e0aa41729ee9c7e5799a865b0354e980dc85e88b0d258b3e0e32231ac38a48bdb7a62620933a5d9651c94097a2f562415c12dafc90
+    SHA512 8d1cebb0dcefe3eb0905381e1a6bd1239b90e35be1924c9538d7ffcbba4a0a5b42febccc10465ea3a3fab15ecff2371c44a971cfe2835d8743c39e181fcd99e5
     HEAD_REF master
     PATCHES
         lz4.patch

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "librdkafka",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/confluentinc/librdkafka",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5609,7 +5609,7 @@
       "port-version": 0
     },
     "librdkafka": {
-      "baseline": "2.15.0",
+      "baseline": "2.15.1",
       "port-version": 0
     },
     "libredwg": {

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7575f720ccfe5d64e44d0542bdc8e2a9778593a2",
+      "version": "2.15.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "23491140627bc74410900d9c4cdd29f4778f20d1",
       "version": "2.15.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
