### PR TITLE
[gtk] Update to 4.22.5

### DIFF
--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -85,7 +85,13 @@ vcpkg_copy_pdbs()
 
 vcpkg_fixup_pkgconfig()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/COPYING"
+        "${SOURCE_PATH}/gdk/COPYING"
+        "${SOURCE_PATH}/gtk/roaring/COPYING"
+        "${SOURCE_PATH}/gtk/timsort/COPYING"
+)
 
 set(TOOL_NAMES gtk4-builder-tool
                gtk4-encode-symbolic-svg

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 f474174c27fec97b26809ae28ded2923f37e82fd25783ce31bbee40a99a02e5f9ce517583f0e499d91289e6b0ebae8e2dc249cba721d827ee35c7b867378797d
+    SHA512 6c8970b8795df724c9e44e95a484278f9da7ddbc830f73d0c8678bce0752272af9f23d04e528bd51e9007db007150ec678072d4d76f89fd41dec579630758971
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "4.22.5",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
-  "license": "LGPL-2.0-only",
+  "license": "LGPL-2.1-or-later AND Apache-2.0",
   "supports": "!android & !xbox & !(arm64 & windows)",
   "dependencies": [
     {

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtk",
-  "version": "4.22.4",
+  "version": "4.22.5",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3649,7 +3649,7 @@
       "port-version": 0
     },
     "gtk": {
-      "baseline": "4.22.4",
+      "baseline": "4.22.5",
       "port-version": 0
     },
     "gtk3": {

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "155964418b1b7fcccd2d72823432d06448c9d4ab",
+      "git-tree": "2e67ae6a990c9097bea77c8a1d2fa5a5e4247da2",
       "version": "4.22.5",
       "port-version": 0
     },

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "155964418b1b7fcccd2d72823432d06448c9d4ab",
+      "version": "4.22.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b0088ae91301524f539cfb34f509a908134031f",
       "version": "4.22.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
