### PR TITLE
[usd] Move schemaRegistry prim definition lookups out of line

### DIFF
--- a/ports/usd/011-move-prim-definition-lookups-out-of-line.patch
+++ b/ports/usd/011-move-prim-definition-lookups-out-of-line.patch
@@ -1,0 +1,91 @@
+--- a/pxr/usd/usd/schemaRegistry.h
++++ b/pxr/usd/usd/schemaRegistry.h
+@@ -495,37 +495,27 @@
+     /// Finds the prim definition for the given \p typeName token if 
+     /// \p typeName is a registered abstract typed schema type. Returns null if
+     /// it is not.
++    USD_API
+     const UsdPrimDefinition* FindAbstractPrimDefinition(
+-        const TfToken &typeName) const {
+-        const auto it = _abstractTypedPrimDefinitions.find(typeName);
+-        return it != _abstractTypedPrimDefinitions.end() ?
+-            it->second.get() : nullptr;
+-    }
++        const TfToken &typeName) const;
+ 
+     /// Finds the prim definition for the given \p typeName token if 
+     /// \p typeName is a registered concrete typed schema type. Returns null if
+     /// it is not.
++    USD_API
+     const UsdPrimDefinition* FindConcretePrimDefinition(
+-        const TfToken &typeName) const {
+-        const auto it = _concreteTypedPrimDefinitions.find(typeName);
+-        return it != _concreteTypedPrimDefinitions.end() ? 
+-            it->second.get() : nullptr;
+-    }
++        const TfToken &typeName) const;
+ 
+     /// Finds the prim definition for the given \p typeName token if 
+     /// \p typeName is a registered applied API schema type. Returns null if
+     /// it is not.
++    USD_API
+     const UsdPrimDefinition *FindAppliedAPIPrimDefinition(
+-        const TfToken &typeName) const {
+-        const auto it = _appliedAPIPrimDefinitions.find(typeName);
+-        return it != _appliedAPIPrimDefinitions.end() ?
+-            it->second.primDef.get() : nullptr;
+-    }
++        const TfToken &typeName) const;
+ 
+     /// Returns the empty prim definition.
+-    const UsdPrimDefinition *GetEmptyPrimDefinition() const {
+-        return _emptyPrimDefinition;
+-    }
++    USD_API
++    const UsdPrimDefinition *GetEmptyPrimDefinition() const;
+ 
+     /// Composes and returns a new UsdPrimDefinition from the given \p primType
+     /// and list of \p appliedSchemas. This prim definition will contain a union
+--- a/pxr/usd/usd/schemaRegistry.cpp
++++ b/pxr/usd/usd/schemaRegistry.cpp
+@@ -2166,5 +2166,40 @@
+     }
+ }
+ 
++// These lookups live in the implementation rather than in the class body:
++// their bodies instantiate map value types that own a unique_ptr to the
++// incomplete UsdPrimDefinition. When a C++20 translation unit parses the
++// header, libstdc++'s explicitly-defaulted pair constructor evaluates the
++// value types' destructibility, which requires a complete UsdPrimDefinition.
++const UsdPrimDefinition*
++UsdSchemaRegistry::FindAbstractPrimDefinition(const TfToken &typeName) const
++{
++    const auto it = _abstractTypedPrimDefinitions.find(typeName);
++    return it != _abstractTypedPrimDefinitions.end() ?
++        it->second.get() : nullptr;
++}
++
++const UsdPrimDefinition*
++UsdSchemaRegistry::FindConcretePrimDefinition(const TfToken &typeName) const
++{
++    const auto it = _concreteTypedPrimDefinitions.find(typeName);
++    return it != _concreteTypedPrimDefinitions.end() ?
++        it->second.get() : nullptr;
++}
++
++const UsdPrimDefinition *
++UsdSchemaRegistry::FindAppliedAPIPrimDefinition(const TfToken &typeName) const
++{
++    const auto it = _appliedAPIPrimDefinitions.find(typeName);
++    return it != _appliedAPIPrimDefinitions.end() ?
++        it->second.primDef.get() : nullptr;
++}
++
++const UsdPrimDefinition *
++UsdSchemaRegistry::GetEmptyPrimDefinition() const
++{
++    return _emptyPrimDefinition;
++}
++
+ PXR_NAMESPACE_CLOSE_SCOPE
+ 

--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -29,6 +29,7 @@ vcpkg_from_github(
         008-fix_clang8_compiler_error.patch
         009-vcpkg_install_folder_conventions.patch
         010-cmake_export_plugin_as_modules.patch
+        011-move-prim-definition-lookups-out-of-line.patch
 )
 
 # Changes accompanying 003-fix-dep.patch

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "usd",
   "version": "26.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenUSD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10542,7 +10542,7 @@
     },
     "usd": {
       "baseline": "26.8",
-      "port-version": 1
+      "port-version": 2
     },
     "usearch": {
       "baseline": "2.25.3",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a375ad07ecc5afb8992b623a25309e895529cb58",
+      "version": "26.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "6e450855d40c813b9e8e936f1ea3794ac419d744",
       "version": "26.8",
       "port-version": 1

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a375ad07ecc5afb8992b623a25309e895529cb58",
+      "git-tree": "e5a4d41622afddf400094099c9a53b410804cbcc",
       "version": "26.8",
       "port-version": 2
     },


### PR DESCRIPTION
## What does this PR fix?

pxr/usd/usd/schemaRegistry.h defines four lookup methods
(FindAbstractPrimDefinition, FindConcretePrimDefinition,
FindAppliedAPIPrimDefinition, GetEmptyPrimDefinition) inline in the
class body. Their bodies instantiate the map value types
pair<const TfToken, const _APISchemaDefinitionInfo>, whose member owns a
std::unique_ptr<UsdPrimDefinition>. UsdPrimDefinition is only
forward-declared in the header, and the inline member function bodies are
checked at class definition end.

With libstdc++ 13 compiled as C++20 or newer, the explicitly-defaulted
std::pair constructor evaluates __is_implicitly_default_constructible
of the value types, which instantiates the value types' destructors and
therefore requires a complete UsdPrimDefinition. Any C++20 translation
unit that includes this header then fails with:

`
/usr/include/c++/13/bits/unique_ptr.h:97:16: error: invalid application of 'sizeof' to an incomplete type 'pxrInternal_v0_26_8__pxrReserved__::UsdPrimDefinition'
`

(With C++17 the failing pair constructor overload does not exist, which is
why building the library itself does not hit this - only C++20 consumers do.)

This PR moves the four lookups into schemaRegistry.cpp (marked
USD_API), keeping the header parseable for C++20 consumers and leaving
behavior unchanged for the library itself.

## How was this tested?

- x64-linux-clang-20 (community triplet): full usd port build plus a
  C++23 consuming translation unit that previously failed with the error
  above - both pass with this patch applied.
- Verified the C++20/23 failure reproduces on the unpatched header and
  goes away with the patch (g++ -std=c++23 -fsyntax-only over the
  header chain).

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] Have you followed the guidelines in our [Contributing](https://github.com/microsoft/vcpkg/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/microsoft/vcpkg/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run cpkg x-add-version usd with your local changes?