### PR TITLE
[liblzma] update to 5.8.4

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 a23be683a2f47a1629d37f5a99a86bcd287cb96a6d1589f3ab2df5ec8a09f8f1f7a1f0d5c7b1e9d6c5f7b5e9a0f1d2a6c7f8b9e0d1c2f5a6b7d8e9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9
+    SHA512 6a0e9c3b05f9c20255c5e35c06fdcd44b9e201f4ed566d1dec052b6cfda6cdfb42f73ffd258eaad2d8b7737c66b78ae353aebd44502e24a3d89d8765d698dcae
     HEAD_REF master
     PATCHES
         build-tools.patch

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 8fb5e6a13397d259d8ff7484f9b63f8a6752ff1c63e1a4601170ad8175aadefb5126a1cae7f73370bfc6c2a0b4e1c0bad57a58fc5b781d3f7d45e5a483c091cc
+    SHA512 a23be683a2f47a1629d37f5a99a86bcd287cb96a6d1589f3ab2df5ec8a09f8f1f7a1f0d5c7b1e9d6c5f7b5e9a0f1d2a6c7f8b9e0d1c2f5a6b7d8e9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9
     HEAD_REF master
     PATCHES
         build-tools.patch

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.8.3",
+  "version": "5.8.4",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5313,7 +5313,7 @@
       "port-version": 1
     },
     "liblzma": {
-      "baseline": "5.8.3",
+      "baseline": "5.8.4",
       "port-version": 0
     },
     "libmad": {

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75eea19f71d50441842f4860ff412c9e7bdd1f08",
+      "version": "5.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae94eaf58eb64ce5b0dfba7769095c43c6c65d71",
       "version": "5.8.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #53876

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.
