### PR TITLE
[slick-stream-buffer-multiplexer] Update to 2.0.0

### DIFF
--- a/ports/slick-stream-buffer-multiplexer/portfile.cmake
+++ b/ports/slick-stream-buffer-multiplexer/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-stream-buffer-multiplexer
     REF "v${VERSION}"
-    SHA512 145ee9a3c7fff3c3ee34b6982ddbde5f4ba68d838830ebee8902ff17e80ba842a3ece9295cf7e6e7f3238a7d72c05449b02731f8f08340d72920d720a98689cb
+    SHA512 24389efa834a8578e0f4e103e37d0d79a7738f5f88ca70bd4369b99f9518059d6a41ec19971bb1b0fcb5272d2a3ff361507cfc9cee66a2b85dcff8c2565e02cb
     HEAD_REF main
     PATCHES
         slick-dependencies-fetching.patch

--- a/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
+++ b/ports/slick-stream-buffer-multiplexer/slick-dependencies-fetching.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c265436..14867ca 100644
+index 1caea39..6f86bc1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -10,9 +10,9 @@ set(CMAKE_CXX_STANDARD 20)
+@@ -10,9 +10,9 @@ project(slick-stream-buffer-multiplexer
  # Options:
  option(BUILD_SLICK_STREAM_BUFFER_MULTIPLEXER_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL})
  
--find_package(slick-stream-buffer 1.0.5 CONFIG QUIET)
+-find_package(slick-stream-buffer 2.0.0 CONFIG QUIET)
 +find_package(slick-stream-buffer CONFIG REQUIRED)
  
 -if (NOT slick-stream-buffer_FOUND)
@@ -15,10 +15,10 @@ index c265436..14867ca 100644
  
      # Disable slick-stream-buffer tests and examples, but allow installation
 @@ -27,9 +27,9 @@ else()
-     message(STATUS "slick-stream-buffer: ${slick-stream-buffer_VERSION}")
+     message(STATUS "Found slick-stream-buffer ${slick-stream-buffer_VERSION}: ${slick-stream-buffer_DIR}")
  endif()
  
--find_package(slick-queue 1.5.0 CONFIG QUIET)
+-find_package(slick-queue 2.0.0 CONFIG QUIET)
 +find_package(slick-queue CONFIG REQUIRED)
  
 -if (NOT slick-queue_FOUND)
@@ -27,28 +27,17 @@ index c265436..14867ca 100644
  
      # Disable slick-queue tests and examples, but allow installation
 diff --git a/cmake/slick-stream-buffer-multiplexerConfig.cmake.in b/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
-index b7f5032..96461bf 100644
+index cb98a71..abc7e79 100644
 --- a/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
 +++ b/cmake/slick-stream-buffer-multiplexerConfig.cmake.in
-@@ -3,8 +3,8 @@
- # Find dependencies
+@@ -8,8 +8,8 @@
+ # this package was built and installed against. A missing dependency is reported as a hard error
+ # instead. Mirrors what slick-stream-buffer and slick-queue do in their own config files.
  include(CMakeFindDependencyMacro)
- 
--find_dependency(slick-stream-buffer 1.0.5 CONFIG QUIET)
--if (NOT slick-stream-buffer_FOUND)
+-find_dependency(slick-stream-buffer 2.0.0 CONFIG)
+-find_dependency(slick-queue 2.0.0 CONFIG)
 +find_dependency(slick-stream-buffer CONFIG)
-+if (FALSE)
-     include(FetchContent)
- 
-     set(BUILD_SLICK_STREAM_BUFFER_TESTS OFF CACHE BOOL "" FORCE)
-@@ -16,8 +16,8 @@ if (NOT slick-stream-buffer_FOUND)
-     FetchContent_MakeAvailable(slick-stream-buffer)
- endif()
- 
--find_dependency(slick-queue 1.5.0 CONFIG QUIET)
--if (NOT slick-queue_FOUND)
 +find_dependency(slick-queue CONFIG)
-+if (FALSE)
-     include(FetchContent)
  
-     set(BUILD_SLICK_QUEUE_TESTS OFF CACHE BOOL "" FORCE)
+ include("${CMAKE_CURRENT_LIST_DIR}/slick-stream-buffer-multiplexerTargets.cmake")
+ 

--- a/ports/slick-stream-buffer-multiplexer/vcpkg.json
+++ b/ports/slick-stream-buffer-multiplexer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-stream-buffer-multiplexer",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A C++ lock-free MPMC byte stream buffer multiplexer",
   "homepage": "https://github.com/SlickQuant/slick-stream-buffer-multiplexer",
   "license": "MIT",
@@ -9,11 +9,11 @@
   "dependencies": [
     {
       "name": "slick-queue",
-      "version>=": "1.5.0"
+      "version>=": "2.0.0"
     },
     {
       "name": "slick-stream-buffer",
-      "version>=": "1.0.5"
+      "version>=": "2.0.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9473,7 +9473,7 @@
       "port-version": 0
     },
     "slick-stream-buffer-multiplexer": {
-      "baseline": "1.0.1",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "slickquant-hyperliquid-cpp": {

--- a/versions/s-/slick-stream-buffer-multiplexer.json
+++ b/versions/s-/slick-stream-buffer-multiplexer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a19155538733b9def2c828cad04637ed5045adf7",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "41a0d64bed8187df8b34f904c58598c072145b54",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
