### PR TITLE
[mercenary] Add new port version 1.0.0

### DIFF
--- a/ports/mercenary/portfile.cmake
+++ b/ports/mercenary/portfile.cmake
@@ -8,3 +8,5 @@ vcpkg_from_github(
 file(INSTALL "${SOURCE_PATH}/include/mercenary.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+ 

--- a/ports/mercenary/portfile.cmake
+++ b/ports/mercenary/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ChampionUgrax/mercenary
     REF v1.0.0
-    SHA512 "3eb477610dc850024976798a72887309007e5f17dcd8ab305e7e8b9195d8cd3f6a27bf79135767b93a0b12f7142d765ee4615a9e3a6c2f7b8f9a2f7c6e6b5d4c"
+    SHA512 "188b33c7e4d96bdb7ab1a58a44194a80145d59ae1d0bcd3375d4580165172c6923238f14dd40e7b4a0e97994d57eb53c846fcf3c996377b613cf5a134092ccc2"
 )
 #Move your header-only file directly into the system installation directory
 file(INSTALL "${SOURCE_PATH}/include/mercenary.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")

--- a/ports/mercenary/portfile.cmake
+++ b/ports/mercenary/portfile.cmake
@@ -1,0 +1,10 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ChampionUgrax/mercenary
+    REF v1.0.0
+    SHA512 ""
+)
+#Move your header-only file directly into the system installation directory
+file(INSTALL "${SOURCE_PATH}/include/mercenary.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mercenary/portfile.cmake
+++ b/ports/mercenary/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ChampionUgrax/mercenary
     REF v1.0.0
-    SHA512 ""
+    SHA512 "3eb477610dc850024976798a72887309007e5f17dcd8ab305e7e8b9195d8cd3f6a27bf79135767b93a0b12f7142d765ee4615a9e3a6c2f7b8f9a2f7c6e6b5d4c"
 )
 #Move your header-only file directly into the system installation directory
 file(INSTALL "${SOURCE_PATH}/include/mercenary.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")

--- a/ports/mercenary/vcpkg.json
+++ b/ports/mercenary/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "name": "mercenary",
+    "version": "1.0.0",
+    "description": "A lightning-fast, header-only C++17 library to cleanly format booleans(True/False, 1/0, true/false).",
+    "homepage": "https://github.com/ChampionUgrax/mercenary.git",
+    "license": "MIT"
+}

--- a/ports/mercenary/vcpkg.json
+++ b/ports/mercenary/vcpkg.json
@@ -1,7 +1,7 @@
 {
-    "name": "mercenary",
-    "version": "1.0.0",
-    "description": "A lightning-fast, header-only C++17 library to cleanly format booleans(True/False, 1/0, true/false).",
-    "homepage": "https://github.com/ChampionUgrax/mercenary.git",
-    "license": "MIT"
+  "name": "mercenary",
+  "version": "1.0.0",
+  "description": "A lightning-fast, header-only C++17 library to cleanly format booleans(True/False, 1/0, true/false).",
+  "homepage": "https://github.com/ChampionUgrax/mercenary.git",
+  "license": "MIT"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6588,6 +6588,10 @@
       "baseline": "5.1.2",
       "port-version": 0
     },
+    "mercenary": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "mesa": {
       "baseline": "24.0.7",
       "port-version": 3

--- a/versions/m-/mercenary.json
+++ b/versions/m-/mercenary.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b1ef5747c934c77bf3e50aa59581237655e704a0",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [ ] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
