### PR TITLE
[time-shield-cpp] Add new port

### DIFF
--- a/ports/time-shield-cpp/portfile.cmake
+++ b/ports/time-shield-cpp/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LimiNode/time-shield-cpp
+    REF "v${VERSION}"
+    SHA512 797db81c078e83313787cbc272756bf662fd42de9961dfb7427c39ee443c03c02f8c59cdfda53a08bd4378011488a9caae13632718f6f8f34d395eaf7543c75c
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTIME_SHIELD_CPP_BUILD_EXAMPLES=OFF
+        -DTIME_SHIELD_CPP_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME TimeShield
+    CONFIG_PATH lib/cmake/TimeShield
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/time-shield-cpp/vcpkg.json
+++ b/ports/time-shield-cpp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "time-shield-cpp",
+  "version": "2.0.0",
+  "description": "Header-only C++ library for time conversions, formatting, and utilities.",
+  "homepage": "https://github.com/LimiNode/time-shield-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10164,6 +10164,10 @@
       "baseline": "2.30.1",
       "port-version": 0
     },
+    "time-shield-cpp": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "tinkerforge": {
       "baseline": "2.1.25",
       "port-version": 3

--- a/versions/t-/time-shield-cpp.json
+++ b/versions/t-/time-shield-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f3e4554a6ac2317360fc3886d011dc4af52fb259",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds Time Shield v2.0.0, a header-only C++11 library for timestamp/calendar
conversions, parsing and formatting, time zones, timers, astronomy helpers,
and optional NTP support.

The project has demonstrated public development since June 2024 and published
v1.0.5 in December 2025. The port name exactly matches the authoritative
GitHub repository name, `time-shield-cpp`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project is [mature and ready for broad sharing with vcpkg users](https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#packaged-projects-should-be-mature)
    - [x] Has a release at least 6 months old or 6 months of demonstrated public development
    - [ ] Is an official component of something else meeting that criteria
    - [ ] Some other reason (please explain)
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/project/time-shield-cpp/versions
    - [x] The project is amongst the first web search results for "time-shield-cpp" or "time-shield-cpp C++". The exact-name search resolves to the authoritative `LimiNode/time-shield-cpp` repository.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. The only optional subsystem is part of the upstream source and introduces no package dependency.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Local validation on `x64-windows` completed without post-build warnings, and a
consumer using `find_package(TimeShield CONFIG REQUIRED)` built successfully.
