### PR TITLE
[keynub-licdongle] new port

### DIFF
--- a/ports/keynub-licdongle/portfile.cmake
+++ b/ports/keynub-licdongle/portfile.cmake
@@ -1,0 +1,60 @@
+# The library ships prebuilt; the port installs the files for the target platform
+# from the SDK repository and the CMake package config that goes with them.
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AB-KeyNub/KeyNub-SDK
+    REF v${VERSION}
+    SHA512 6c650b3ccbb70f7813d9df965c35be5cac953b7301504ac1dd43b9a31785be3e67201f87f45a30da52e76fe206a535b41550276cd097eb7edc18eb8ebffd6bae
+    HEAD_REF master
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(os "win")
+elseif(VCPKG_TARGET_IS_LINUX)
+    set(os "linux")
+elseif(VCPKG_TARGET_IS_OSX)
+    set(os "osx")
+else()
+    message(FATAL_ERROR "No prebuilt keynub_licdongle library for ${VCPKG_CMAKE_SYSTEM_NAME}")
+endif()
+set(natives "${SOURCE_PATH}/natives/${os}-${VCPKG_TARGET_ARCHITECTURE}")
+if(NOT IS_DIRECTORY "${natives}")
+    message(FATAL_ERROR "No prebuilt keynub_licdongle library for ${os}-${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+file(INSTALL
+    "${SOURCE_PATH}/include/licdongle.h"
+    "${SOURCE_PATH}/bindings/flat/licd_flat.h"
+    "${SOURCE_PATH}/bindings/labview/licd_labview.h"
+    "${SOURCE_PATH}/bindings/cpp/licdongle.hpp"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# One prebuilt set serves both configurations.
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(shared "${natives}/keynub_licdongle.dll" "${natives}/keynub_licdongle_flat.dll")
+    set(implib "${natives}/keynub_licdongle.lib" "${natives}/keynub_licdongle_flat.lib")
+    foreach(cfg "" "/debug")
+        file(INSTALL ${shared} DESTINATION "${CURRENT_PACKAGES_DIR}${cfg}/bin")
+        file(INSTALL ${implib} DESTINATION "${CURRENT_PACKAGES_DIR}${cfg}/lib")
+    endforeach()
+else()
+    file(GLOB shared "${natives}/libkeynub_licdongle.*" "${natives}/libkeynub_licdongle_flat.*")
+    list(FILTER shared EXCLUDE REGEX "_static\\.a$")
+    foreach(cfg "" "/debug")
+        file(INSTALL ${shared} DESTINATION "${CURRENT_PACKAGES_DIR}${cfg}/lib")
+    endforeach()
+endif()
+
+file(INSTALL
+    "${SOURCE_PATH}/keynub_licdongleConfig.cmake"
+    "${SOURCE_PATH}/keynub_licdongleConfigVersion.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/keynub_licdongle")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST
+    "${SOURCE_PATH}/LICENSE"
+    "${SOURCE_PATH}/BINARY-LICENSE.txt"
+    "${SOURCE_PATH}/NOTICE"
+    "${SOURCE_PATH}/THIRD-PARTY-NOTICES.txt")

--- a/ports/keynub-licdongle/usage
+++ b/ports/keynub-licdongle/usage
@@ -1,0 +1,9 @@
+keynub-licdongle provides CMake targets:
+
+    find_package(keynub_licdongle CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE keynub::licdongle)       # the C API
+    target_link_libraries(main PRIVATE keynub::licdongle_cpp)   # the header-only C++11 wrapper
+    target_link_libraries(main PRIVATE keynub::licdongle_flat)  # the flat companion API
+
+The library is loaded by name at start-up; keynub_copy_runtime(main) copies it
+next to the executable after each build.

--- a/ports/keynub-licdongle/vcpkg.json
+++ b/ports/keynub-licdongle/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "keynub-licdongle",
+  "version": "1.1.1",
+  "description": "Host SDK for the KeyNub USB-C license dongle: a prebuilt C library (verify authenticity, encrypted session, license records, counters, app-data encryption) with a header-only C++11 wrapper. Driverless on Windows, Linux and macOS.",
+  "homepage": "https://www.keynub.com/developers/c-cpp/",
+  "documentation": "https://github.com/AB-KeyNub/KeyNub-SDK/blob/master/NATIVES.md",
+  "license": null,
+  "supports": "!uwp & !xbox & !android & !emscripten & !(static & staticcrt) & (x64 | x86 | arm64) & (windows | linux | osx)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4388,6 +4388,10 @@
       "baseline": "2025.11.1",
       "port-version": 0
     },
+    "keynub-licdongle": {
+      "baseline": "1.1.1",
+      "port-version": 0
+    },
     "keystone": {
       "baseline": "0.9.2",
       "port-version": 4

--- a/versions/k-/keynub-licdongle.json
+++ b/versions/k-/keynub-licdongle.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "323a52e0390c6cd595aecc7c7b062ad9ce126272",
+      "version": "1.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
New port for the KeyNub License Dongle SDK (https://github.com/AB-KeyNub/KeyNub-SDK): the host library for a USB-C hardware license dongle, with a header-only C++11 wrapper.

The core library is **closed source and prebuilt**; the upstream repository ships the libraries for every supported platform under `natives/` together with the headers and a CMake package config. The port installs those files for the target triplet (dynamic linkage only) and the config, so `find_package(keynub_licdongle CONFIG)` provides `keynub::licdongle`, `keynub::licdongle_flat` and `keynub::licdongle_cpp`. `license` is `null` because the binaries are under the vendor's own terms (`BINARY-LICENSE.txt`, installed as part of the copyright file) alongside the Apache-2.0 headers.

Tested with `x64-windows`: installs, passes the post-build checks, and a consumer links and runs through the vcpkg toolchain.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.